### PR TITLE
feat: propagate exceptions in distributed mode

### DIFF
--- a/include/ex_actor/internal/serialization.h
+++ b/include/ex_actor/internal/serialization.h
@@ -32,6 +32,8 @@ T Deserialize(const uint8_t* data, size_t size) {
 enum class NetworkRequestType : uint8_t {
   kActorCreationRequest = 0,
   kActorMethodCallRequest,
+  kActorMethodCallReturn,
+  kActorMethodCallError,
 };
 
 template <class Tuple>

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -73,8 +73,8 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
     // TODO: test error propagation
     auto error = ping_worker.Send<&PingWorker::Error>();
 
-    // ASSERT_THAT([&error] { stdexec::sync_wait(std::move(error)); },
-    //             Throws<std::exception>(Property(&std::exception::what, HasSubstr("error"))));
+    ASSERT_THAT([&error] { stdexec::sync_wait(std::move(error)); },
+                Throws<std::exception>(Property(&std::exception::what, HasSubstr("error"))));
   };
 
   std::jthread node_0(node_main, 0);


### PR DESCRIPTION
- Catch exceptions in actor methods using ex::upon_error()
- Add   kActorMethodCallReturn and  kActorMethodCallError to NetworkRequestType
- On exception, serialize the what() message and reply with a kActorMethodCallError header.  Deserialize and rethrow exception on client side
- Enable and pass the test for exception propagation

Fixes #35