### PR TITLE
refactor: use async_scope to send quit messsage

### DIFF
--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -131,7 +131,7 @@ class MessageBroker {
 
   std::jthread send_thread_;
   std::jthread recv_thread_;
-  bool stopped_ = false;
+  std::atomic_bool stopped_ = false;
   std::latch quit_latch_;
   exec::async_scope async_scope_;
 


### PR DESCRIPTION
@lixin-wei  The true reason is that spawn does not accept a sender that returns a value. We can use spawn_future to spawn the sender or use ex::then to consume the result, because for the quit and heartbeat messages, the reply is just an empty buffer.