### PR TITLE
Simplify distributed mode API

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -9,59 +9,65 @@ Distributed mode enables you to create actors at remote nodes. When calling a re
 serialized and send to the remote node through network, after execution the return value will be deserialized and send
 back to the caller.
 
-Due to the lack of reflection before C++26, some boilerplate is needed.
+To make your actor class be able to be created remotely, you need to use `EXA_REMOTE` macro to register the class, e.g.:
 
-1. Add a static `Create` method to you class: `static YourClass Create(...)`.
-2. Add a `constexpr static std::tuple kActorMethods` to you class, which contains all methods you want to call remotely.
-The name can be adjusted by defining `EXA_ACTOR_METHODS_KEYWORD`.
-3. List all actor classes in a `ex_actor::ActorRoster<A, B, C...>` and pass it to `ex_actor::ActorRegistry`.
+```cpp
+class YourClass  {
+ public:
+  void Method1() {};
+  void Method2() {};
+};
 
-They are used to create a fixed ID for class and its constructor&methods, so that we know how to serialize/deserialize.
+YourClass FactoryCreate() { return YourClass(); }
+EXA_REMOTE(&YourClass::FactoryCreate, &YourClass::Method1, &YourClass::Method2);
+```
 
-**✨ All these boilerplate can be eliminated in C++26 using reflection, I'll implement it when C++26 is released, stay tuned!**
+In the `EX_REMOTE` macro, the first argument is a factory function to create your class, and the rest are the methods you want to call remotely.
+
+This is used to generate a serialization schema for network communication.
+
+Then instead of calling `registry.CreateActor<YourClass>()`, you need to call `registry.CreateActor<YourClass, &FactoryCreate>()`. Or an exception will be thrown.
+
+✨ **BTW, this can be simplified in C++26 using reflection, I'll implement it when C++26 is released, stay tuned!** ✨
 
 ## Example
 
 <!-- doc test start, wrapper_script: test/multi_process_test.sh -->
 ```cpp
 #include <cassert>
-
 #include "ex_actor/api.h"
 
 class PingWorker {
  public:
   explicit PingWorker(std::string name) : name_(std::move(name)) {}
 
-  // Boilerplate 1, the Create method
-  static PingWorker Create(std::string name) { return PingWorker(std::move(name)); }
+  // You can also put this outside the class if you don't want to modify your class
+  static PingWorker FactoryCreate(std::string name) { return PingWorker(std::move(name)); }
 
   std::string Ping(const std::string& message) { return "ack from " + name_ + ", msg got: " + message; }
-
-  // Boilerplate 2, the kActorMethods tuple.
-  // The name can be adjusted by defining `EXA_ACTOR_METHODS_KEYWORD`
-  static constexpr std::tuple kActorMethods = {&PingWorker::Ping};
 
  private:
   std::string name_;
 };
 
+// 1. Register the class & methods using EXA_REMOTE
+EXA_REMOTE(&PingWorker::FactoryCreate, &PingWorker::Ping);
+
 int main(int argc, char** argv) {
   uint32_t this_node_id = std::atoi(argv[1]);
   ex_actor::WorkSharingThreadPool thread_pool(4);
 
-  // Boilerplate 3, the actor roster(a name list of all actors)
-  // split by comma, e.g. ActorRoster<A, B, C...>
-  ex_actor::ActorRoster<PingWorker> roster;
-
   std::vector<ex_actor::NodeInfo> cluster_node_info = {{.node_id = 0, .address = "tcp://127.0.0.1:5301"},
                                                        {.node_id = 1, .address = "tcp://127.0.0.1:5302"}};
   ex_actor::ActorRegistry registry(thread_pool.GetScheduler(),
-                                   /*this_node_id=*/this_node_id, cluster_node_info, roster);
+                                   /*this_node_id=*/this_node_id, cluster_node_info);
 
   uint32_t remote_node_id = (this_node_id + 1) % cluster_node_info.size();
-  auto ping_worker =
-      registry.CreateActorUseStaticCreateFn<PingWorker>(ex_actor::ActorConfig {.node_id = remote_node_id},
-                                                        /*name=*/"Alice");
+
+  // 2. Specify the factory function in registry.CreateActor
+  auto ping_worker = registry.CreateActor<PingWorker, &PingWorker::FactoryCreate>(
+      ex_actor::ActorConfig {.node_id = remote_node_id}, /*name=*/"Alice"
+  );
   auto ping = ping_worker.Send<&PingWorker::Ping>("hello");
   auto [ping_res] = stdexec::sync_wait(std::move(ping)).value();
   assert(ping_res == "ack from Alice, msg got: hello");

--- a/include/ex_actor/internal/actor_creation.h
+++ b/include/ex_actor/internal/actor_creation.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <memory>
@@ -31,15 +30,13 @@
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/network.h"
 #include "ex_actor/internal/reflect.h"
+#include "ex_actor/internal/remote_handler_registry.h"
 #include "ex_actor/internal/serialization.h"
 #include "ex_actor/internal/util.h"
 
 namespace ex_actor::internal {
 
-template <class... Classes>
-struct ActorRoster {};
-
-template <ex::scheduler Scheduler, class... ActorClasses>
+template <ex::scheduler Scheduler>
 class ActorRegistry {
  public:
   /**
@@ -54,7 +51,6 @@ class ActorRegistry {
    * @brief Constructor for distributed mode.
    */
   explicit ActorRegistry(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info,
-                         ActorRoster<ActorClasses...> /*actor_roster*/,
                          network::HeartbeatConfig heartbeat_config =
                              {
                                  .heartbeat_timeout = kDefaultHeartbeatTimeout,
@@ -65,8 +61,8 @@ class ActorRegistry {
         this_node_id_(this_node_id),
         message_broker_(std::make_unique<network::MessageBroker>(
             cluster_node_info, this_node_id,
-            [this](uint64_t receive_request_id, network::ByteBufferType data) {
-              HandleNetworkRequest(receive_request_id, std::move(data));
+            [this](uint64_t received_request_id, network::ByteBufferType data) {
+              HandleNetworkRequest(received_request_id, std::move(data));
             },
             heartbeat_config)) {
     logging::SetupProcessWideLoggingConfig();
@@ -99,30 +95,6 @@ class ActorRegistry {
   }
 
   /**
-   * @brief Create an actor with a manually specified config.
-   */
-  template <class UserClass, class... Args>
-  ActorRef<UserClass> CreateActor(ActorConfig config, Args&&... args) {
-    EXA_THROW_CHECK_EQ(config.node_id, this_node_id_)
-        << "`CreateActor` can only be used to create actor at current node, to create actor at remote node, use "
-           "`CreateActorUseStaticCreateFn`, because we need a unique construction signature.";
-    auto actor_id = GenerateRandomActorId();
-    auto actor_name = config.actor_name;
-    auto actor =
-        std::make_unique<Actor<UserClass, Scheduler>>(scheduler_, std::move(config), std::forward<Args>(args)...);
-    auto handle = ActorRef<UserClass>(this_node_id_, config.node_id, actor_id,
-                                      GetActorClassIndexInRoster<UserClass>().value_or(UINT64_MAX), actor.get(),
-                                      message_broker_.get());
-    actor_id_to_actor_.Insert(actor_id, std::move(actor));
-    if (actor_name) {
-      const auto& name = *actor_name;
-      EXA_THROW_CHECK(!actor_name_to_id_.contains(name)) << "An actor with the same name already exists.";
-      actor_name_to_id_.emplace(name, actor_id);
-    }
-    return handle;
-  }
-
-  /**
    * @brief Create actor at current node using default config.
    */
   template <class UserClass, class... Args>
@@ -131,13 +103,14 @@ class ActorRegistry {
   }
 
   /**
-   * @brief Create an actor using UserClass::Create() static method. This is for distributed mode, where the class
-   * construction signature must be unique, or we don't know how to deserialize the args at the remote node.
+   * @brief Create an actor with a manually specified config.
    */
-  template <class UserClass, class... Args>
-  ActorRef<UserClass> CreateActorUseStaticCreateFn(ActorConfig config, Args&&... args) {
-    static_assert(std::is_invocable_v<decltype(&UserClass::Create), Args...>,
-                  "Class can't be created by given args using UserClass::Create() static method");
+  template <class UserClass, auto kCreateFn = nullptr, class... Args>
+  ActorRef<UserClass> CreateActor(ActorConfig config, Args&&... args) {
+    if constexpr (kCreateFn != nullptr) {
+      static_assert(std::is_invocable_v<decltype(kCreateFn), Args...>,
+                    "Class can't be created by given args and create function");
+    }
     if (is_distributed_mode_) {
       EXA_THROW_CHECK(node_id_to_address_.contains(config.node_id)) << "Invalid node id: " << config.node_id;
     }
@@ -145,56 +118,61 @@ class ActorRegistry {
     // local actor, create directly
     if (config.node_id == this_node_id_) {
       auto actor_id = GenerateRandomActorId();
-      auto actor = std::make_unique<Actor<UserClass, Scheduler, /*kUseStaticCreateFn=*/true>>(
-          scheduler_, std::move(config), std::forward<Args>(args)...);
-      auto handle = ActorRef<UserClass>(this_node_id_, config.node_id, actor_id,
-                                        GetActorClassIndexInRoster<UserClass>().value_or(UINT64_MAX), actor.get(),
-                                        message_broker_.get());
-      actor_id_to_actor_.Insert(actor_id, std::move(actor));
+      auto actor = std::make_unique<Actor<UserClass, kCreateFn>>(
+          std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler_), config, std::forward<Args>(args)...);
+      auto handle = ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, actor.get(), message_broker_.get());
       if (config.actor_name.has_value()) {
         std::string& name = *config.actor_name;
-        EXA_THROW_CHECK(!actor_name_to_id_.contains(name)) << "An actor with the same name already exists.";
-        actor_name_to_id_.emplace(name, actor_id);
+        EXA_THROW_CHECK(!actor_name_to_id_.Contains(name))
+            << "An actor with the same name already exists, name=" << name;
+        actor_name_to_id_.Insert(name, actor_id);
       }
+      actor_id_to_actor_.Insert(actor_id, std::move(actor));
       return handle;
     }
 
-    auto create_fn = &UserClass::Create;
-    using CreateFnSig = reflect::Signature<decltype(create_fn)>;
+    if constexpr (kCreateFn == nullptr) {
+      EXA_THROW << "CreateActor<UserClass> can only be used to create local actor, to create remote actor, use "
+                   "CreateActor<UserClass, kCreateFn> to provide a fixed signature for remote actor creation. node_id="
+                << config.node_id << ", this_node_id=" << this_node_id_ << ", actor_type=" << typeid(UserClass).name();
+    }
 
-    // remote actor, serialize args and send to remote
-    uint64_t class_index_in_roster = GetActorClassIndexInRoster<UserClass>().value();
+    if constexpr (kCreateFn != nullptr) {
+      using CreateFnSig = reflect::Signature<decltype(kCreateFn)>;
 
-    // protocol: [message_type][class_index_in_roster][ActorCreationArgs]
-    typename CreateFnSig::DecayedArgsTupleType args_tuple {std::forward<Args>(args)...};
-    serde::ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config,
-                                                                                              std::move(args_tuple)};
-    std::vector<char> serialized = serde::Serialize(actor_creation_args);
+      // protocol: [message_type][handler_key_len][handler_key][ActorCreationArgs]
+      typename CreateFnSig::DecayedArgsTupleType args_tuple {std::forward<Args>(args)...};
+      serde::ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config,
+                                                                                                std::move(args_tuple)};
+      std::vector<char> serialized = serde::Serialize(actor_creation_args);
+      std::string handler_key = reflect::GetUniqueNameForFunction<kCreateFn>();
+      serde::BufferWriter buffer_writer(network::ByteBufferType {
+          serialized.size() + sizeof(uint64_t) + handler_key.size() + sizeof(serde::NetworkRequestType)});
+      buffer_writer.WritePrimitive(serde::NetworkRequestType::kActorCreationRequest);
+      buffer_writer.WritePrimitive(handler_key.size());
+      // TODO optimize the copy here
+      buffer_writer.CopyFrom(handler_key.data(), handler_key.size());
+      buffer_writer.CopyFrom(serialized.data(), serialized.size());
+      EXA_THROW_CHECK(buffer_writer.EndReached()) << "Buffer writer not ended";
 
-    serde::BufferWriter buffer_writer(network::ByteBufferType {serialized.size() + sizeof(class_index_in_roster) +
-                                                               sizeof(serde::NetworkRequestType)});
-
-    buffer_writer.WritePrimitive(serde::NetworkRequestType::kActorCreationRequest);
-    buffer_writer.WritePrimitive(class_index_in_roster);
-    buffer_writer.CopyFrom(serialized.data(), serialized.size());  // TODO optimize the copy here
-    EXA_THROW_CHECK(buffer_writer.EndReached()) << "Buffer writer not ended";
-
-    // send to remote
-    auto sender =
-        message_broker_->SendRequest(config.node_id, std::move(buffer_writer).MoveBufferOut()) |
-        ex::then([](network::ByteBufferType response_buffer) {
-          serde::BufferReader reader(std::move(response_buffer));
-          auto type = reader.template NextPrimitive<serde::NetworkReplyType>();
-          if (type == serde::NetworkReplyType::kActorCreationError) {
-            EXA_THROW << serde::Deserialize<serde::ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
-          }
-          auto actor_id = reader.template NextPrimitive<uint64_t>();
-          return actor_id;
-        });
-    // sync wait and create handle
-    auto [actor_id] = stdexec::sync_wait(std::move(sender)).value();
-    return ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, GetActorClassIndexInRoster<UserClass>().value(),
-                               nullptr, message_broker_.get());
+      // send to remote
+      auto sender =
+          message_broker_->SendRequest(config.node_id, std::move(buffer_writer).MoveBufferOut()) |
+          ex::then([](network::ByteBufferType response_buffer) {
+            serde::BufferReader reader(std::move(response_buffer));
+            auto type = reader.template NextPrimitive<serde::NetworkReplyType>();
+            if (type == serde::NetworkReplyType::kActorCreationError) {
+              EXA_THROW
+                  << "Got actor creation error from remote node:"
+                  << serde::Deserialize<serde::ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
+            }
+            auto actor_id = reader.template NextPrimitive<uint64_t>();
+            return actor_id;
+          });
+      // sync wait and create handle
+      auto [actor_id] = stdexec::sync_wait(std::move(sender)).value();
+      return ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, nullptr, message_broker_.get());
+    }
   }
 
   template <class UserClass>
@@ -202,18 +180,19 @@ class ActorRegistry {
     auto actor_id = actor_ref.GetActorId();
     EXA_THROW_CHECK(actor_id_to_actor_.Contains(actor_id)) << "Actor with id " << actor_id << " not found";
     auto& actor = actor_id_to_actor_.At(actor_id);
+    auto actor_name = actor->GetActorConfig().actor_name;
     actor_id_to_actor_.Erase(actor_id);
-    std::erase_if(actor_name_to_id_, [actor_id](const auto& pair) { return pair.second == actor_id; });
+    if (actor_name.has_value()) {
+      actor_name_to_id_.Erase(actor_name.value());
+    }
   }
 
   template <class UserClass>
   std::optional<ActorRef<UserClass>> GetActorRefByName(const std::string& name) const {
-    if (actor_name_to_id_.contains(name)) {
-      const auto actor_id = actor_name_to_id_.at(name);
+    if (actor_name_to_id_.Contains(name)) {
+      const auto actor_id = actor_name_to_id_.At(name);
       const auto& actor = actor_id_to_actor_.At(actor_id);
-      return ActorRef<UserClass>(this_node_id_, this_node_id_, actor_id,
-                                 GetActorClassIndexInRoster<UserClass>().value_or(UINT64_MAX), actor.get(),
-                                 message_broker_.get());
+      return ActorRef<UserClass>(this_node_id_, this_node_id_, actor_id, actor.get(), message_broker_.get());
     }
 
     return std::nullopt;
@@ -243,8 +222,7 @@ class ActorRegistry {
 
     auto [actor_id] = ex::sync_wait(std::move(sender)).value();
     if (actor_id.has_value()) {
-      return ActorRef<UserClass>(this_node_id_, node_id, actor_id.value(),
-                                 GetActorClassIndexInRoster<UserClass>().value(), nullptr, message_broker_.get());
+      return ActorRef<UserClass>(this_node_id_, node_id, actor_id.value(), nullptr, message_broker_.get());
     }
 
     return std::nullopt;
@@ -259,17 +237,7 @@ class ActorRegistry {
   util::LockGuardedMap<uint64_t, std::unique_ptr<TypeErasedActor>> actor_id_to_actor_;
   std::unique_ptr<network::MessageBroker> message_broker_;
   exec::async_scope async_scope_;
-  std::unordered_map<std::string, std::uint64_t> actor_name_to_id_;
-
-  template <class UserClass>
-  std::optional<uint64_t> GetActorClassIndexInRoster() const {
-    constexpr auto kActorClassIndex = reflect::GetIndexInParamPack<UserClass, ActorClasses...>();
-    if (is_distributed_mode_ && !kActorClassIndex.has_value()) {
-      EXA_THROW_CHECK(kActorClassIndex.has_value())
-          << "Can't find actor class in roster, class=" << typeid(UserClass).name();
-    }
-    return kActorClassIndex;
-  }
+  util::LockGuardedMap<std::string, std::uint64_t> actor_name_to_id_;
 
   void InitRandomNumGenerator() {
     std::random_device rd;
@@ -290,37 +258,38 @@ class ActorRegistry {
     return static_cast<serde::NetworkRequestType>(*static_cast<const uint8_t*>(buffer.data()));
   }
 
-  void HandleNetworkRequest(uint64_t receive_request_id, network::ByteBufferType request_buffer) {
+  void ReplyError(uint64_t received_request_id, serde::NetworkReplyType reply_type, std::string error_msg) {
+    std::vector<char> serialized = serde::Serialize(serde::ActorMethodReturnValue {std::move(error_msg)});
+    serde::BufferWriter writer(network::ByteBufferType(sizeof(serde::NetworkRequestType) + serialized.size()));
+    writer.WritePrimitive(reply_type);
+    writer.CopyFrom(serialized.data(), serialized.size());
+    message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
+  }
+
+  void SetupActorRefSerializationContext() {
+    auto& info = ActorRefDeserializationContext::GetThreadLocalInstance();
+    info.this_node_id = this_node_id_;
+    info.message_broker = message_broker_.get();
+    info.actor_look_up_fn = [this](uint64_t actor_id) -> TypeErasedActor* {
+      if (actor_id_to_actor_.Contains(actor_id)) {
+        return actor_id_to_actor_.At(actor_id).get();
+      }
+      return nullptr;
+    };
+  }
+
+  void HandleNetworkRequest(uint64_t received_request_id, network::ByteBufferType request_buffer) {
+    SetupActorRefSerializationContext();
     serde::BufferReader<network::ByteBufferType> reader(std::move(request_buffer));
     auto message_type = reader.NextPrimitive<serde::NetworkRequestType>();
 
     if (message_type == serde::NetworkRequestType::kActorCreationRequest) {
-      auto actor_cls_index = reader.NextPrimitive<uint64_t>();
-      try {
-        uint64_t actor_id = FindClassAndCreateActor(actor_cls_index, reader.Current(), reader.RemainingSize());
-        serde::BufferWriter<network::ByteBufferType> writer(
-            network::ByteBufferType(sizeof(serde::NetworkReplyType) + sizeof(actor_id)));
-        writer.WritePrimitive(serde::NetworkReplyType::kActorCreationReturn);
-        writer.WritePrimitive(actor_id);
-        message_broker_->ReplyRequest(receive_request_id, std::move(writer).MoveBufferOut());
-      } catch (std::exception& error) {
-        auto error_msg = std::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-        std::vector<char> serialized = serde::Serialize(serde::ActorMethodReturnValue {std::move(error_msg)});
-        serde::BufferWriter<network::ByteBufferType> writer(
-            network::ByteBufferType(sizeof(serde::NetworkReplyType) + serialized.size()));
-        writer.WritePrimitive(serde::NetworkReplyType::kActorCreationError);
-        writer.CopyFrom(serialized.data(), serialized.size());
-        message_broker_->ReplyRequest(receive_request_id, std::move(writer).MoveBufferOut());
-      }
+      HandleActorCreationRequest(received_request_id, std::move(reader));
       return;
     }
 
     if (message_type == serde::NetworkRequestType::kActorMethodCallRequest) {
-      auto class_index_in_roster = reader.NextPrimitive<uint64_t>();
-      auto method_index = reader.NextPrimitive<uint64_t>();
-      auto actor_id = reader.NextPrimitive<uint64_t>();
-      FindClassAndCallMethod(class_index_in_roster, method_index, actor_id, receive_request_id, reader.Current(),
-                             reader.RemainingSize());
+      HandleActorMethodCallRequest(received_request_id, std::move(reader));
       return;
     }
 
@@ -328,17 +297,17 @@ class ActorRegistry {
       auto actor_name =
           serde::Deserialize<serde::ActorLookUpRequest>(reader.Current(), reader.RemainingSize()).actor_name;
 
-      if (actor_name_to_id_.contains(actor_name)) {
+      if (actor_name_to_id_.Contains(actor_name)) {
         serde::BufferWriter<network::ByteBufferType> writer(
             network::ByteBufferType(sizeof(serde::NetworkRequestType) + sizeof(uint64_t)));
-        auto actor_id = actor_name_to_id_.at(actor_name);
+        auto actor_id = actor_name_to_id_.At(actor_name);
         writer.WritePrimitive(serde::NetworkReplyType::kActorLookUpReturn);
         writer.WritePrimitive(actor_id);
-        message_broker_->ReplyRequest(receive_request_id, std::move(writer).MoveBufferOut());
+        message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
       } else {
         serde::BufferWriter writer(network::ByteBufferType(sizeof(serde::NetworkRequestType)));
         writer.WritePrimitive(serde::NetworkReplyType::kActorLookUpError);
-        message_broker_->ReplyRequest(receive_request_id, std::move(writer).MoveBufferOut());
+        message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
       }
 
       return;
@@ -346,107 +315,77 @@ class ActorRegistry {
     EXA_THROW << "Invalid message type: " << static_cast<int>(message_type);
   }
 
-  template <size_t kClassIndex = 0>
-  uint64_t FindClassAndCreateActor(uint64_t actor_cls_index, const uint8_t* data, size_t size) {
-    if (kClassIndex == actor_cls_index) {
-      using ActorClass = reflect::ParamPackElement<kClassIndex, ActorClasses...>;
-      constexpr auto kFactoryCreateFn = &ActorClass::Create;
-      serde::ActorCreationArgs creation_args = serde::DeserializeFnArgs<kFactoryCreateFn>(data, size);
-      auto actor_id = GenerateRandomActorId();
-      auto& actor_name = creation_args.actor_config.actor_name;
-      if (actor_name.has_value()) {
-        EXA_THROW_CHECK(!actor_name_to_id_.contains(actor_name.value()))
-            << "An actor with the same name already exists.";
-        actor_name_to_id_.emplace(actor_name.value(), actor_id);
+  void HandleActorCreationRequest(uint64_t received_request_id, serde::BufferReader<network::ByteBufferType> reader) {
+    auto handler_key_len = reader.NextPrimitive<uint64_t>();
+    auto handler_key = reader.PullString(handler_key_len);
+    try {
+      auto handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorCreationHandler(handler_key);
+      auto result = handler(RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext {
+          .request_buffer = std::move(reader),
+          .scheduler = std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler_),
+      });
+      uint64_t actor_id = GenerateRandomActorId();
+      if (result.actor_name.has_value()) {
+        EXA_THROW_CHECK(!actor_name_to_id_.Contains(result.actor_name.value()))
+            << "An actor with the same name already exists, name=" << result.actor_name.value();
+        actor_name_to_id_.Insert(result.actor_name.value(), actor_id);
       }
-      std::unique_ptr<TypeErasedActor> actor = Actor<ActorClass, Scheduler>::CreateUseArgTuple(
-          scheduler_, std::move(creation_args.actor_config), std::move(creation_args.args_tuple));
-      actor_id_to_actor_.Insert(actor_id, std::move(actor));
-      return actor_id;
+      actor_id_to_actor_.Insert(actor_id, std::move(result.actor));
+      serde::BufferWriter<network::ByteBufferType> writer(
+          network::ByteBufferType(sizeof(serde::NetworkReplyType) + sizeof(actor_id)));
+      writer.WritePrimitive(serde::NetworkReplyType::kActorCreationReturn);
+      writer.WritePrimitive(actor_id);
+      message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
+    } catch (std::exception& error) {
+      auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
+      ReplyError(received_request_id, serde::NetworkReplyType::kActorCreationError, std::move(error_msg));
     }
-    if constexpr (kClassIndex + 1 < sizeof...(ActorClasses)) {
-      return FindClassAndCreateActor<kClassIndex + 1>(actor_cls_index, data, size);
-    }
-    EXA_THROW << "Can't find actor class in roster, actor_cls_index=" << actor_cls_index;
   }
 
-  template <class ActorClass, size_t kMethodIndex = 0>
-  void FindMethodAndCallIt(uint64_t method_index, uint64_t actor_id, uint64_t receive_request_id, const uint8_t* data,
-                           size_t size) {
-    constexpr auto kActorMethodsTuple = reflect::GetActorMethodsTuple<ActorClass>();
-    if constexpr (std::tuple_size_v<decltype(kActorMethodsTuple)> > 0) {
-      if (kMethodIndex == method_index) {
-        std::unique_ptr<TypeErasedActor>& actor = actor_id_to_actor_.At(actor_id);
-        constexpr auto kMethodPtr = std::get<kMethodIndex>(kActorMethodsTuple);
-        using Sig = reflect::Signature<decltype(kMethodPtr)>;
+  void HandleActorMethodCallRequest(uint64_t received_request_id, serde::BufferReader<network::ByteBufferType> reader) {
+    auto handler_key_len = reader.NextPrimitive<uint64_t>();
+    auto handler_key = reader.PullString(handler_key_len);
+    auto actor_id = reader.NextPrimitive<uint64_t>();
+    if (!actor_id_to_actor_.Contains(actor_id)) {
+      ReplyError(
+          received_request_id, serde::NetworkReplyType::kActorMethodCallError,
+          fmt_lib::format("Can't find actor at remote node, actor_id={}, node_id={}, maybe it's already destroyed.",
+                          actor_id, this_node_id_));
+      return;
+    }
 
-        auto& info = ActorRefDeserializationInfo::GetThreadLocalInstance();
-        info.this_node_id = this_node_id_;
-        info.message_broker = message_broker_.get();
-        info.look_up = [this](uint64_t actor_id) -> TypeErasedActor* {
-          if (actor_id_to_actor_.Contains(actor_id)) {
-            return actor_id_to_actor_.At(actor_id).get();
+    RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandler handler = nullptr;
+    try {
+      handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorMethodCallHandler(handler_key);
+    } catch (std::exception& error) {
+      auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
+      ReplyError(received_request_id, serde::NetworkReplyType::kActorMethodCallError, std::move(error_msg));
+      return;
+    }
+
+    EXA_THROW_CHECK(handler != nullptr);
+    auto do_call =
+        handler(RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext {
+            .actor = actor_id_to_actor_.At(actor_id).get(),
+            .request_buffer = std::move(reader),
+        }) |
+        ex::then([this, received_request_id](network::ByteBufferType buffer) {
+          message_broker_->ReplyRequest(received_request_id, std::move(buffer));
+        }) |
+        ex::upon_error([this, received_request_id](auto error) {
+          try {
+            EXA_THROW_CHECK(error) << "Error should not be null";
+            std::rethrow_exception(error);
+          } catch (std::exception& error) {
+            auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
+            ReplyError(received_request_id, serde::NetworkReplyType::kActorMethodCallError, std::move(error_msg));
           }
-          return nullptr;
-        };
-
-        serde::ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> call_args =
-            serde::DeserializeFnArgs<kMethodPtr>(data, size);
-
-        auto sender =
-            actor->template CallActorMethodUseTuple<kMethodPtr>(std::move(call_args.args_tuple)) |
-            ex::then([this, receive_request_id](auto return_value) {
-              std::vector<char> serialized = serde::Serialize(serde::ActorMethodReturnValue {std::move(return_value)});
-              serde::BufferWriter writer(
-                  network::ByteBufferType {sizeof(serde::NetworkRequestType) + serialized.size()});
-              // TODO optimize the copy here
-              writer.WritePrimitive(serde::NetworkReplyType::kActorMethodCallReturn);
-              writer.CopyFrom(serialized.data(), serialized.size());
-              message_broker_->ReplyRequest(receive_request_id, std::move(writer).MoveBufferOut());
-            }) |
-            ex::upon_error([this, receive_request_id](auto error) {
-              try {
-                if (error) {
-                  std::rethrow_exception(error);
-                }
-              } catch (std::exception& error) {
-                auto error_msg = std::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-                std::vector<char> serialized = serde::Serialize(serde::ActorMethodReturnValue {std::move(error_msg)});
-                serde::BufferWriter writer(
-                    network::ByteBufferType(sizeof(serde::NetworkRequestType) + serialized.size()));
-                writer.WritePrimitive(serde::NetworkReplyType::kActorMethodCallError);
-                writer.CopyFrom(serialized.data(), serialized.size());
-                message_broker_->ReplyRequest(receive_request_id, std::move(writer).MoveBufferOut());
-              }
-            });
-        async_scope_.spawn(std::move(sender));
-        return;
-      }
-    }
-    if constexpr (kMethodIndex + 1 < std::tuple_size_v<decltype(kActorMethodsTuple)>) {
-      return FindMethodAndCallIt<ActorClass, kMethodIndex + 1>(method_index, actor_id, receive_request_id, data, size);
-    }
-    EXA_THROW << "Can't find method in actor class, method_index=" << method_index
-              << ", class=" << typeid(ActorClass).name();
-  }
-
-  template <size_t kClassIndex = 0>
-  void FindClassAndCallMethod(uint64_t actor_cls_index, uint64_t method_index, uint64_t actor_id,
-                              uint64_t receive_request_id, const uint8_t* data, size_t size) {
-    if (kClassIndex == actor_cls_index) {
-      using ActorClass = reflect::ParamPackElement<kClassIndex, ActorClasses...>;
-      return FindMethodAndCallIt<ActorClass>(method_index, actor_id, receive_request_id, data, size);
-    }
-    if constexpr (kClassIndex + 1 < sizeof...(ActorClasses)) {
-      return FindClassAndCallMethod<kClassIndex + 1>(actor_cls_index, method_index, actor_id, receive_request_id, data,
-                                                     size);
-    }
-    EXA_THROW << "Can't find actor class in roster, actor_cls_index=" << actor_cls_index;
+        });
+    async_scope_.spawn(std::move(do_call));
   }
 };
 }  // namespace ex_actor::internal
 
 namespace ex_actor {
 using ex_actor::internal::ActorRegistry;
-using ex_actor::internal::ActorRoster;
 }  // namespace ex_actor

--- a/include/ex_actor/internal/alias.h
+++ b/include/ex_actor/internal/alias.h
@@ -14,9 +14,12 @@
 
 #pragma once
 
+#include <spdlog/spdlog.h>
 #include <stdexec/execution.hpp>
 
 namespace ex_actor {
 // NOLINTNEXTLINE(misc-unused-alias-decls)
 namespace ex = stdexec;
+// NOLINTNEXTLINE(misc-unused-alias-decls)
+namespace fmt_lib = spdlog::fmt_lib;
 }  // namespace ex_actor

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -57,7 +57,7 @@ struct HeartbeatConfig {
 class MessageBroker {
  public:
   explicit MessageBroker(std::vector<NodeInfo> node_list, uint32_t this_node_id,
-                         std::function<void(uint64_t receive_request_id, ByteBufferType data)> request_handler,
+                         std::function<void(uint64_t received_request_id, ByteBufferType data)> request_handler,
                          HeartbeatConfig heartbeat_config = {.heartbeat_timeout = kDefaultHeartbeatTimeout,
                                                              .heartbeat_interval = kDefaultHeartbeatInterval});
   ~MessageBroker();
@@ -111,7 +111,7 @@ class MessageBroker {
    */
   SendRequestSender SendRequest(uint32_t to_node_id, ByteBufferType data, MessageFlag flag = MessageFlag::kNormal);
 
-  void ReplyRequest(uint64_t receive_request_id, ByteBufferType data);
+  void ReplyRequest(uint64_t received_request_id, ByteBufferType data);
 
  private:
   void EstablishConnections();
@@ -129,7 +129,7 @@ class MessageBroker {
 
   std::vector<NodeInfo> node_list_;
   uint32_t this_node_id_;
-  std::function<void(uint64_t receive_request_id, ByteBufferType data)> request_handler_;
+  std::function<void(uint64_t received_request_id, ByteBufferType data)> request_handler_;
   HeartbeatConfig heartbeat_;
   std::atomic_uint64_t send_request_id_counter_ = 0;
   std::atomic_uint64_t received_request_id_counter_ = 0;

--- a/include/ex_actor/internal/reflect.h
+++ b/include/ex_actor/internal/reflect.h
@@ -160,6 +160,13 @@ constexpr auto UnwrapReturnSenderIfNested() {
     return std::type_identity<ReturnType> {};
   }
 }
+
+template <auto kFunc>
+std::string GetUniqueNameForFunction() {
+  // TODO: according to the standard, typeid().name() is not guaranteed to be unique, but in modern gcc&clang,
+  // it's an unique mangled name. So it works now, maybe replace it with a more robust way in the future.
+  return typeid(kFunc).name();
+}
 }  // namespace ex_actor::internal::reflect
 
 namespace ex_actor::reflect {

--- a/include/ex_actor/internal/remote_handler_registry.h
+++ b/include/ex_actor/internal/remote_handler_registry.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include "ex_actor/internal/actor.h"
+#include "ex_actor/internal/network.h"
+#include "ex_actor/internal/reflect.h"
+#include "ex_actor/internal/serialization.h"
+
+namespace ex_actor::internal {
+
+class RemoteActorRequestHandlerRegistry {
+ public:
+  static RemoteActorRequestHandlerRegistry& GetInstance() {
+    static RemoteActorRequestHandlerRegistry instance;
+    return instance;
+  }
+
+  struct RemoteActorMethodCallHandlerContext {
+    TypeErasedActor* actor;
+    serde::BufferReader<network::ByteBufferType> request_buffer;
+  };
+  struct RemoteActorCreationHandlerContext {
+    serde::BufferReader<network::ByteBufferType> request_buffer;
+    std::unique_ptr<TypeErasedActorScheduler> scheduler;
+  };
+  struct CreateActorResult {
+    std::unique_ptr<TypeErasedActor> actor;
+    std::optional<std::string> actor_name;
+  };
+
+  using RemoteActorMethodCallHandler =
+      std::function<exec::task<network::ByteBufferType>(RemoteActorMethodCallHandlerContext context)>;
+  using RemoteActorCreationHandler = std::function<CreateActorResult(RemoteActorCreationHandlerContext context)>;
+
+  void RegisterRemoteActorMethodCallHandler(const std::string& key, RemoteActorMethodCallHandler func) {
+    EXA_THROW_CHECK(!remote_actor_method_call_handler_.contains(key))
+        << "Duplicate remote actor method call handler: " << key
+        << ", maybe you have duplicated functions in EXA_REMOTE.";
+    remote_actor_method_call_handler_[key] = std::move(func);
+  }
+  RemoteActorMethodCallHandler GetRemoteActorMethodCallHandler(const std::string& key) const {
+    EXA_THROW_CHECK(remote_actor_method_call_handler_.contains(key))
+        << "Remote actor method call handler not found: " << key
+        << ", maybe you forgot to register it with EXA_REMOTE.";
+    return remote_actor_method_call_handler_.at(key);
+  }
+  void RegisterRemoteActorCreationHandler(const std::string& key, RemoteActorCreationHandler func) {
+    EXA_THROW_CHECK(!remote_actor_creation_handler_.contains(key))
+        << "Duplicate remote actor creation handler: " << key << ", maybe you have duplicated functions in EXA_REMOTE.";
+    remote_actor_creation_handler_[key] = std::move(func);
+  }
+  RemoteActorCreationHandler GetRemoteActorCreationHandler(const std::string& key) const {
+    EXA_THROW_CHECK(remote_actor_creation_handler_.contains(key))
+        << "Remote actor creation handler not found: " << key << ", maybe you forgot to register it with EXA_REMOTE.";
+    return remote_actor_creation_handler_.at(key);
+  }
+
+ private:
+  std::unordered_map<std::string, RemoteActorCreationHandler> remote_actor_creation_handler_;
+  std::unordered_map<std::string, RemoteActorMethodCallHandler> remote_actor_method_call_handler_;
+};
+
+template <auto kActorCreateFn, auto... kActorMethods>
+class RemoteFuncHandlerRegistrar {
+ public:
+  explicit RemoteFuncHandlerRegistrar() {
+    static_assert(!std::is_member_function_pointer_v<decltype(kActorCreateFn)>,
+                  "kActorCreateFn must be a non-member function pointer");
+    using CreateFnSig = reflect::Signature<decltype(kActorCreateFn)>;
+    static_assert(!std::is_void_v<std::decay_t<typename CreateFnSig::ReturnType>>,
+                  "kActorCreateFn must return a non-void value");
+    static_assert(!std::is_fundamental_v<typename CreateFnSig::ReturnType>,
+                  "kActorCreateFn must return a non-fundamental value");
+    auto check_fn_class = []<class C, auto kMemberFn>() {
+      using MemberFnSig = reflect::Signature<decltype(kMemberFn)>;
+      static_assert(std::is_same_v<C, typename MemberFnSig::ClassType>,
+                    "Actor methods' class does not match the create function's class");
+    };
+    (check_fn_class.template operator()<typename CreateFnSig::ReturnType, kActorMethods>(), ...);
+    auto register_handler = [this]<auto kFuncPtr>() {
+      std::string func_name = reflect::GetUniqueNameForFunction<kFuncPtr>();
+      if constexpr (std::is_member_function_pointer_v<decltype(kFuncPtr)>) {
+        RemoteActorRequestHandlerRegistry::GetInstance().RegisterRemoteActorMethodCallHandler(
+            func_name, [this](RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext context) {
+              return DeserializeAndInvokeActorMethod<kFuncPtr>(std::move(context));
+            });
+      } else {
+        RemoteActorRequestHandlerRegistry::GetInstance().RegisterRemoteActorCreationHandler(
+            func_name, [this](RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext context) {
+              return DeserializeAndCreateActor<kFuncPtr>(std::move(context));
+            });
+      }
+    };
+    register_handler.template operator()<kActorCreateFn>();
+    (register_handler.template operator()<kActorMethods>(), ...);
+  }
+
+ private:
+  template <auto kCreateFn>
+  RemoteActorRequestHandlerRegistry::CreateActorResult DeserializeAndCreateActor(
+      RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext context) {
+    using ActorClass = reflect::Signature<decltype(kCreateFn)>::ReturnType;
+    serde::ActorCreationArgs creation_args =
+        serde::DeserializeFnArgs<kCreateFn>(context.request_buffer.Current(), context.request_buffer.RemainingSize());
+    std::unique_ptr<TypeErasedActor> actor = Actor<ActorClass, kCreateFn>::CreateUseArgTuple(
+        std::move(context.scheduler), std::move(creation_args.actor_config), std::move(creation_args.args_tuple));
+    auto actor_name = actor->GetActorConfig().actor_name;
+    return {
+        .actor = std::move(actor),
+        .actor_name = std::move(actor_name),
+    };
+  }
+
+  /**
+   * @returns A coroutine carrying the serialized result of the actor method call.
+   */
+  template <auto kMethod>
+  exec::task<network::ByteBufferType> DeserializeAndInvokeActorMethod(
+      RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext context) {
+    EXA_THROW_CHECK(context.actor != nullptr);
+    using Sig = reflect::Signature<decltype(kMethod)>;
+
+    serde::ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> call_args =
+        serde::DeserializeFnArgs<kMethod>(context.request_buffer.Current(), context.request_buffer.RemainingSize());
+
+    auto return_value =
+        co_await context.actor->template CallActorMethodUseTuple<kMethod>(std::move(call_args.args_tuple));
+    std::vector<char> serialized = serde::Serialize(serde::ActorMethodReturnValue {std::move(return_value)});
+    serde::BufferWriter writer(network::ByteBufferType {sizeof(serde::NetworkRequestType) + serialized.size()});
+    // TODO optimize the copy here
+    writer.WritePrimitive(serde::NetworkReplyType::kActorMethodCallReturn);
+    writer.CopyFrom(serialized.data(), serialized.size());
+    co_return std::move(writer).MoveBufferOut();
+  };
+};
+
+#define EXA_CONCATENATE_DIRECT(s1, s2, s3, s4) s1##s2##s3##s4
+#define EXA_CONCATENATE(s1, s2, s3, s4) EXA_CONCATENATE_DIRECT(s1, s2, s3, s4)
+#define EXA_ANONYMOUS_VARIABLE(str) EXA_CONCATENATE(str, __LINE__, _, __COUNTER__)
+}  // namespace ex_actor::internal
+
+namespace ex_actor {
+#define EXA_REMOTE(...)                                                                        \
+  /* NOLINTNEXTLINE(misc-use-internal-linkage) */                                              \
+  inline ::ex_actor::internal::RemoteFuncHandlerRegistrar<__VA_ARGS__> EXA_ANONYMOUS_VARIABLE( \
+      exa_remote_func_registrar_);
+};  // namespace ex_actor

--- a/include/ex_actor/internal/serialization.h
+++ b/include/ex_actor/internal/serialization.h
@@ -122,6 +122,13 @@ class BufferReader {
     return value;
   }
 
+  std::string PullString(size_t length) {
+    EXA_THROW_CHECK_LE(offset_ + length, size_) << "Buffer overflow, offset: " << offset_ << ", size: " << size_;
+    std::string value(reinterpret_cast<const char*>(Current()), length);
+    offset_ += length;
+    return value;
+  }
+
   const uint8_t* Current() const { return start_ + offset_; }
 
   size_t RemainingSize() const { return size_ - offset_; }

--- a/include/ex_actor/internal/util.h
+++ b/include/ex_actor/internal/util.h
@@ -207,7 +207,7 @@ class LockGuardedMap {
     map_.erase(key);
   }
 
-  bool Contains(const K& key) {
+  bool Contains(const K& key) const {
     std::lock_guard lock(mutex_);
     return map_.contains(key);
   }

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -29,7 +29,7 @@
 namespace ex_actor::internal::network {
 
 MessageBroker::MessageBroker(std::vector<ex_actor::NodeInfo> node_list, uint32_t this_node_id,
-                             std::function<void(uint64_t receive_request_id, ByteBufferType data)> request_handler,
+                             std::function<void(uint64_t received_request_id, ByteBufferType data)> request_handler,
                              HeartbeatConfig heartbeat_config)
     : node_list_(std::move(node_list)),
       this_node_id_(this_node_id),
@@ -126,9 +126,9 @@ MessageBroker::SendRequestSender MessageBroker::SendRequest(uint32_t to_node_id,
   };
 }
 
-void MessageBroker::ReplyRequest(uint64_t receive_request_id, ByteBufferType data) {
-  auto identifier = received_request_id_to_identifier_.At(receive_request_id);
-  received_request_id_to_identifier_.Erase(receive_request_id);
+void MessageBroker::ReplyRequest(uint64_t received_request_id, ByteBufferType data) {
+  auto identifier = received_request_id_to_identifier_.At(received_request_id);
+  received_request_id_to_identifier_.Erase(received_request_id);
 
   pending_reply_operations_.Push(ReplyOperation {
       .identifier = identifier,
@@ -216,9 +216,9 @@ void MessageBroker::HandleReceivedMessage(zmq::multipart_t multi) {
     operation->Complete(std::move(data_bytes));
   } else if (identifier.response_node_id == this_node_id_) {
     // Request from remote node - pass to handler, which will send response back
-    auto receive_request_id = received_request_id_counter_.fetch_add(1);
-    received_request_id_to_identifier_.Insert(receive_request_id, identifier);
-    request_handler_(receive_request_id, std::move(data_bytes));
+    auto received_request_id = received_request_id_counter_.fetch_add(1);
+    received_request_id_to_identifier_.Insert(received_request_id, identifier);
+    request_handler_(received_request_id, std::move(data_bytes));
   } else {
     EXA_THROW << "Invalid identifier, " << EXA_DUMP_VARS(identifier);
   }

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -6,36 +6,28 @@ class PingWorker {
  public:
   explicit PingWorker(std::string name) : name_(std::move(name)) {}
 
-  // Boilerplate 1, the Create method
   static PingWorker Create(std::string name) { return PingWorker(std::move(name)); }
 
   std::string Ping(const std::string& message) { return "ack from " + name_ + ", msg got: " + message; }
-
-  // Boilerplate 2, the kActorMethods tuple.
-  // The name can be adjusted by defining `EXA_ACTOR_METHODS_KEYWORD`
-  static constexpr std::tuple kActorMethods = {&PingWorker::Ping};
 
  private:
   std::string name_;
 };
 
+EXA_REMOTE(&PingWorker::Create, &PingWorker::Ping);
+
 int main(int /*argc*/, char** argv) {
   uint32_t this_node_id = std::atoi(argv[1]);
   ex_actor::WorkSharingThreadPool thread_pool(4);
 
-  // Boilerplate 3, the actor roster(a name list of all actors)
-  // split by comma, e.g. ActorRoster<A, B, C...>
-  ex_actor::ActorRoster<PingWorker> roster;
-
   std::vector<ex_actor::NodeInfo> cluster_node_info = {{.node_id = 0, .address = "tcp://127.0.0.1:5301"},
                                                        {.node_id = 1, .address = "tcp://127.0.0.1:5302"}};
   ex_actor::ActorRegistry registry(thread_pool.GetScheduler(),
-                                   /*this_node_id=*/this_node_id, cluster_node_info, roster);
+                                   /*this_node_id=*/this_node_id, cluster_node_info);
 
   uint32_t remote_node_id = (this_node_id + 1) % cluster_node_info.size();
-  auto ping_worker =
-      registry.CreateActorUseStaticCreateFn<PingWorker>(ex_actor::ActorConfig {.node_id = remote_node_id},
-                                                        /*name=*/"Alice");
+  auto ping_worker = registry.CreateActor<PingWorker, &PingWorker::Create>(
+      ex_actor::ActorConfig {.node_id = remote_node_id}, /*name=*/"Alice");
   auto ping = ping_worker.Send<&PingWorker::Ping>("hello");
   auto [ping_res] = stdexec::sync_wait(std::move(ping)).value();
   assert(ping_res == "ack from Alice, msg got: hello");

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -19,8 +19,8 @@ TEST(NetworkTest, MessageBrokerTest) {
       ex_actor::internal::util::SetThreadName("node_" + std::to_string(node_id));
       ex_actor::internal::network::MessageBroker message_broker(
           node_list,
-          /*this_node_id=*/node_id, [&message_broker](uint64_t receive_request_id, ByteBufferType data) {
-            message_broker.ReplyRequest(receive_request_id, std::move(data));
+          /*this_node_id=*/node_id, [&message_broker](uint64_t received_request_id, ByteBufferType data) {
+            message_broker.ReplyRequest(received_request_id, std::move(data));
           });
       uint32_t to_node_id = (node_id + 1) % node_list.size();
       exec::async_scope scope;


### PR DESCRIPTION
closes https://github.com/ex-actor/ex-actor/issues/70

Use a runtime static map for function registeration, instead of using compile-time type list.

Now the API looks like this:

```cpp
class YourClass  {
 public:
  void Method1() {};
  void Method2() {};
};

YourClass FactoryCreate() { return YourClass(); }
EXA_REMOTE(&YourClass::FactoryCreate, &YourClass::Method1, &YourClass::Method2);
```

see `docs/contents/distributed_mode.md` for more detail.