### PR TITLE
Destroy processor_actor in `~ActorRegistry()`

### DIFF
--- a/include/ex_actor/internal/actor_creation.h
+++ b/include/ex_actor/internal/actor_creation.h
@@ -384,6 +384,8 @@ class ActorRegistry {
       message_broker_->ClusterAlignedStop();
     }
     ex::sync_wait(processor_actor_.CallActorMethod<&ActorRegistryRequestProcessor::AsyncDestroyAllActors>());
+    ex::sync_wait(processor_actor_.AsyncDestroy());
+    ex::sync_wait(async_scope_.on_empty());
     spdlog::info("Actor registry shutdown completed");
   }
 


### PR DESCRIPTION
Or there might be a corner case when ActorRegistry destroyed but processor_actor still has tasks.