### PR TITLE
[bug fix] Fix static fiasco with spdlog

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ Language: Cpp
 BasedOnStyle: Google
 DerivePointerAlignment: false
 # "Regroup" automatically regroups includes. This assumes that all test files
-# end with `_test.cc`. Otherwise, the main header file for a unit test may not
+# end with `_test.cc`. Otherwise, the main header file for an unit test may not
 # be recognized correctly.
 IncludeBlocks: Regroup
 IncludeCategories:

--- a/docs/contents/tutorial.md
+++ b/docs/contents/tutorial.md
@@ -29,7 +29,7 @@ struct Counter {
 };
 
 /*
-1. First, create a ex_actor::ActorRegistry, usually as a global variable.
+1. First, create an ex_actor::ActorRegistry, usually as a global variable.
    All methods of ActorRegistry are thread-safe.
 */
 ex_actor::ActorRegistry registry(/*thread_pool_size=*/1);

--- a/include/ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h
+++ b/include/ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h
@@ -133,7 +133,7 @@ static_assert(sizeof(std::thread::id) == 4 || sizeof(std::thread::id) == 8,
 typedef std::thread::id thread_id_t;
 static const thread_id_t invalid_thread_id;  // Default ctor creates invalid ID
 
-// Note we don't define a invalid_thread_id2 since std::thread::id doesn't have one; it's
+// Note we don't define an invalid_thread_id2 since std::thread::id doesn't have one; it's
 // only used if MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED is defined anyway, which it won't
 // be.
 static inline thread_id_t thread_id() { return std::this_thread::get_id(); }
@@ -3595,7 +3595,7 @@ class ConcurrentQueue {
           auto reusable = details::invalid_thread_id2;
           if (mainHash->entries[index].key.compare_exchange_strong(reusable, id, std::memory_order_seq_cst,
                                                                    std::memory_order_relaxed)) {
-            implicitProducerHashCount.fetch_sub(1, std::memory_order_relaxed);  // already counted as a used slot
+            implicitProducerHashCount.fetch_sub(1, std::memory_order_relaxed);  // already counted as an used slot
             mainHash->entries[index].value = producer;
             break;
           }

--- a/include/ex_actor/internal/logging.h
+++ b/include/ex_actor/internal/logging.h
@@ -20,11 +20,28 @@
 #include <rfl/to_view.hpp>
 #include <spdlog/spdlog.h>
 
+#ifdef _WIN32
+#include <spdlog/sinks/wincolor_sink.h>
+#else
+#include <spdlog/sinks/ansicolor_sink.h>
+#endif
+
 #if __cpp_lib_stacktrace >= 202011L
 #include <stacktrace>
 #endif
 
 namespace ex_actor::internal::logging {
+
+inline std::shared_ptr<spdlog::logger> CreateLogger(const std::string& name) {
+#ifdef _WIN32
+  auto color_sink = std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>();
+#else
+  auto color_sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
+#endif
+  auto logger = std::make_shared<spdlog::logger>(name, std::move(color_sink));
+  logger->set_pattern("[%Y-%m-%d %T.%e%z] [%^%L%$] [%t] %v");
+  return logger;
+}
 
 inline void InstallFallbackExceptionHandler() {
   std::set_terminate([] {

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -29,6 +29,8 @@
 
 #include "ex_actor/internal/constants.h"
 #include "ex_actor/internal/util.h"
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
 
 namespace ex_actor {
 struct NodeInfo {
@@ -125,6 +127,8 @@ class MessageBroker {
     Identifier identifier;
     ByteBufferType data;
   };
+
+  std::shared_ptr<spdlog::logger> logger_ = logging::CreateLogger("MessageBroker");
 
   std::vector<NodeInfo> node_list_;
   uint32_t this_node_id_;

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -59,7 +59,7 @@ MessageBroker::~MessageBroker() {
 
 void MessageBroker::ClusterAlignedStop() {
   // tell all other nodes: I'm going to quit
-  spdlog::info("[Cluster Aligned Stop] Node {} sending quit message to all other nodes", this_node_id_);
+  logger_->info("[Cluster Aligned Stop] Node {} sending quit message to all other nodes", this_node_id_);
   for (const auto& node : node_list_) {
     if (node.node_id != this_node_id_) {
       auto sender = SendRequest(node.node_id, ByteBufferType {}, MessageFlag::kQuit) | ex::then([](auto empty) {});
@@ -72,13 +72,13 @@ void MessageBroker::ClusterAlignedStop() {
   quit_latch_.wait();
   stopped_.store(true);
   ex::sync_wait(async_scope_.on_empty());
-  spdlog::info("[Cluster Aligned Stop] All nodes are going to quit, stopping node {}'s io threads.", this_node_id_);
+  logger_->info("[Cluster Aligned Stop] All nodes are going to quit, stopping node {}'s io threads.", this_node_id_);
   // stop io threads first
   send_thread_.request_stop();
   recv_thread_.request_stop();
   send_thread_.join();
   recv_thread_.join();
-  spdlog::info("[Cluster Aligned Stop] Node {}'s io threads stopped, cluster aligned stop completed", this_node_id_);
+  logger_->info("[Cluster Aligned Stop] Node {}'s io threads stopped, cluster aligned stop completed", this_node_id_);
 }
 
 void MessageBroker::EstablishConnections() {
@@ -89,7 +89,7 @@ void MessageBroker::EstablishConnections() {
       recv_socket_.bind(node.address);
       recv_socket_.set(zmq::sockopt::linger, 0);
       found_local_address = true;
-      spdlog::info("Node {}'s recv socket bound to {}", this_node_id_, node.address);
+      logger_->info("Node {}'s recv socket bound to {}", this_node_id_, node.address);
       break;
     }
   }
@@ -104,8 +104,8 @@ void MessageBroker::EstablishConnections() {
       auto& send_socket = node_id_to_send_socket_.At(node.node_id);
       send_socket.set(zmq::sockopt::linger, 0);
       send_socket.connect(node.address);
-      spdlog::info("Node {} added a send socket, connected to node {} at {}", this_node_id_, node.node_id,
-                   node.address);
+      logger_->info("Node {} added a send socket, connected to node {} at {}", this_node_id_, node.node_id,
+                    node.address);
     }
   }
 }
@@ -198,7 +198,7 @@ void MessageBroker::HandleReceivedMessage(zmq::multipart_t multi) {
   auto identifier = internal::serde::Deserialize<Identifier>(identifier_bytes.data<uint8_t>(), identifier_bytes.size());
   if (identifier.flag == MessageFlag::kQuit) {
     EXA_THROW_CHECK_EQ(data_bytes.size(), 0) << "Quit message should not have data";
-    spdlog::info("[Cluster Aligned Stop] Node {} is going to quit", identifier.request_node_id);
+    logger_->info("[Cluster Aligned Stop] Node {} is going to quit", identifier.request_node_id);
     quit_latch_.count_down();
     return;
   }
@@ -228,7 +228,7 @@ void MessageBroker::CheckHeartbeat() {
   for (const auto& node : node_list_) {
     if (node.node_id != this_node_id_ &&
         std::chrono::steady_clock::now() - last_seen_[node.node_id] >= heartbeat_.heartbeat_timeout) {
-      spdlog::error("Node {} detect that node {} is dead, try to exit", this_node_id_, node.node_id);
+      logger_->error("Node {} detect that node {} is dead, try to exit", this_node_id_, node.node_id);
       std::exit(1);
     }
   }

--- a/test/shuffle_merge_test.cc
+++ b/test/shuffle_merge_test.cc
@@ -115,7 +115,7 @@ class Coordinator {
     exec::async_scope scope;
 
     // Launch all data sources in parallel with deterministic sequential data
-    // Each source gets a unique range of sequential numbers
+    // Each source gets an unique range of sequential numbers
     for (size_t i = 0; i < sources_.size(); ++i) {
       int start_value = static_cast<int>((i * data_size_per_source) + 1);
       scope.spawn(


### PR DESCRIPTION
Create its own logger in ActorRegistry and MessageBroker. Instead of using global defualt logger. Which will cause static fiasco when using ActorRegistry as a global variable.