### PR TITLE
Revert "[doc] schedule main coroutine in actor scheduler (#101)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ so you'll see namespaces like `stdexec` and `exec` instead of `std::execution` i
 #include <cassert>
 #include "ex_actor/api.h"
 
-ex_actor::ActorRegistry registry(/*thread_pool_size=*/1);
-
 struct Counter {
   int Add(int x) { return count += x; }
   int count = 0;
 };
 
 exec::task<void> MainCoroutine() {
+  ex_actor::ActorRegistry registry(/*thread_pool_size=*/1);
+
   // 1. Create the actor.
   ex_actor::ActorRef actor = co_await registry.CreateActor<Counter>();
 
@@ -57,11 +57,7 @@ exec::task<void> MainCoroutine() {
   assert(res == 1);
 }
 
-int main() {
-  // use the thread pool inside ActorRegistry to execute the main coroutine.
-  // main thread blocks in `sync_wait` until the coroutine finishes.
-  stdexec::sync_wait(stdexec::starts_on(registry.GetScheduler(), MainCoroutine()));
-}
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
@@ -109,11 +105,7 @@ exec::task<void> MainCoroutine() {
   assert(res == "Where is my child? Dad, I'm here!");
 }
 
-int main() {
-  // use the thread pool inside ActorRegistry to execute the main coroutine.
-  // main thread blocks in `sync_wait` until the coroutine finishes.
-  stdexec::sync_wait(stdexec::starts_on(registry.GetScheduler(), MainCoroutine()));
-}
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 

--- a/docs/contents/schedulers.md
+++ b/docs/contents/schedulers.md
@@ -52,22 +52,19 @@ Use it when you know what you are doing.
 ```cpp
 #include "ex_actor/api.h"
 
-ex_actor::PriorityThreadPool thread_pool(1);
-ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
-
 struct TestActor {
   void Foo() {}
 };
 
 exec::task<void> MainCoroutine() {
+  ex_actor::PriorityThreadPool thread_pool(1);
+  ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
   auto actor = co_await registry.CreateActor<TestActor>(ex_actor::ActorConfig {
     .priority = 1 // smaller number means higher priority
   });
 }
 
-int main() {
-  stdexec::sync_wait(stdexec::starts_on(registry.GetScheduler(), MainCoroutine()));
-}
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
@@ -87,22 +84,21 @@ If you do have some very high-priority actors, consider using the [`SchedulerUni
 #include "ex_actor/api.h"
 #include <cassert>
 
-// 1. create two thread pools
-ex_actor::WorkSharingThreadPool thread_pool1(1);
-ex_actor::WorkSharingThreadPool thread_pool2(1);
-// 2. create a scheduler union, union two schedulers into one.
-ex_actor::SchedulerUnion scheduler_union(std::vector<ex_actor::WorkSharingThreadPool::Scheduler> {
-  thread_pool1.GetScheduler(), thread_pool2.GetScheduler()
-});
-auto scheduler = scheduler_union.GetScheduler();
-// 3. create a registry with the scheduler union
-ex_actor::ActorRegistry registry(scheduler);
-
 struct TestActor {
   uint64_t GetThreadId() { return std::hash<std::thread::id>{}(std::this_thread::get_id()); }
 };
 
 exec::task<void> MainCoroutine() {
+  // 1. create two thread pools
+  ex_actor::WorkSharingThreadPool thread_pool1(1);
+  ex_actor::WorkSharingThreadPool thread_pool2(1);
+  // 2. create a scheduler union, union two schedulers into one.
+  ex_actor::SchedulerUnion scheduler_union(std::vector<ex_actor::WorkSharingThreadPool::Scheduler> {
+    thread_pool1.GetScheduler(), thread_pool2.GetScheduler()
+  });
+  auto scheduler = scheduler_union.GetScheduler();
+  // 3. create a registry with the scheduler union
+  ex_actor::ActorRegistry registry(scheduler);
   // 4. create two actors, specify the scheduler index in ActorConfig.
   auto actor1 = co_await registry.CreateActor<TestActor>(ex_actor::ActorConfig {.scheduler_index = 0});
   auto actor2 = co_await registry.CreateActor<TestActor>(ex_actor::ActorConfig {.scheduler_index = 1});
@@ -113,9 +109,7 @@ exec::task<void> MainCoroutine() {
   assert(thread_id1 != thread_id2);
 }
 
-int main() {
-  stdexec::sync_wait(stdexec::starts_on(registry.GetScheduler(), MainCoroutine()));
-}
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 #include <gmock/gmock-matchers.h>
@@ -61,8 +62,8 @@ TEST(BasicApiTest, ActorRegistryCreationWithDefaultScheduler) {
 }
 
 TEST(BasicApiTest, ShouldWorkWithAsyncSpawn) {
-  ex_actor::ActorRegistry registry(/*thread_pool_size=*/1);
-  auto coroutine = [&registry]() -> exec::task<void> {
+  auto coroutine = []() -> exec::task<void> {
+    ex_actor::ActorRegistry registry(/*thread_pool_size=*/1);
     auto counter = co_await registry.CreateActor<Counter>();
     exec::async_scope scope;
     scope.spawn(counter.SendLocal<&Counter::Add>(1));
@@ -71,22 +72,24 @@ TEST(BasicApiTest, ShouldWorkWithAsyncSpawn) {
     EXPECT_EQ(res, 1);
     co_return;
   };
-  ex::sync_wait(stdexec::starts_on(registry.GetScheduler(), coroutine()));
+  ex::sync_wait(coroutine());
 }
 
 TEST(BasicApiTest, ExceptionInActorMethodShouldBePropagatedToCaller) {
-  ex_actor::ActorRegistry registry(/*thread_pool_size=*/10);
-  auto coroutine = [&registry]() -> exec::task<void> {
+  auto coroutine = []() -> exec::task<void> {
+    ex_actor::WorkSharingThreadPool thread_pool(10);
+    ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     auto counter = co_await registry.CreateActor<Counter>();
     co_await counter.Send<&Counter::Error>();
   };
-  ASSERT_THAT([&]() { ex::sync_wait(stdexec::starts_on(registry.GetScheduler(), coroutine())); },
+  ASSERT_THAT([&coroutine] { ex::sync_wait(coroutine()); },
               Throws<std::exception>(Property(&std::exception::what, HasSubstr("error0"))));
 }
 
 TEST(BasicApiTest, NestActorRefCase) {
-  ex_actor::ActorRegistry registry(/*thread_pool_size=*/10);
-  auto coroutine = [&registry]() -> exec::task<void> {
+  auto coroutine = []() -> exec::task<void> {
+    ex_actor::WorkSharingThreadPool thread_pool(10);
+    ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     ex_actor::ActorRef counter = co_await registry.CreateActor<Counter>();
     exec::async_scope scope;
     for (int i = 0; i < 100; ++i) {
@@ -102,12 +105,13 @@ TEST(BasicApiTest, NestActorRefCase) {
     EXPECT_EQ(res3, 100);
     co_return;
   };
-  ex::sync_wait(stdexec::starts_on(registry.GetScheduler(), coroutine()));
+  ex::sync_wait(coroutine());
 }
 
 TEST(BasicApiTest, CreateActorWithFullConfig) {
-  ex_actor::ActorRegistry registry(/*thread_pool_size=*/10);
-  auto coroutine = [&registry]() -> exec::task<void> {
+  auto coroutine = []() -> exec::task<void> {
+    ex_actor::WorkSharingThreadPool thread_pool(10);
+    ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     auto counter = co_await registry.CreateActor<Counter>(
         ex_actor::ActorConfig {.max_message_executed_per_activation = 10, .actor_name = "counter1"});
     co_await registry.CreateActor<Counter>(ex_actor::ActorConfig {.actor_name = "counter2"});
@@ -120,7 +124,7 @@ TEST(BasicApiTest, CreateActorWithFullConfig) {
     co_await registry.CreateActor<Proxy>(config, counter);
     co_await registry.DestroyActor(counter);
   };
-  ex::sync_wait(stdexec::starts_on(registry.GetScheduler(), coroutine()));
+  ex::sync_wait(coroutine());
 }
 
 static ex_actor::ActorRegistry g_registry(/*thread_pool_size=*/1);
@@ -145,5 +149,5 @@ TEST(BasicApiTest, LookUpNamedActor) {
     auto getvalue_reply = co_await std::move(getvalue_sender);
     EXPECT_EQ(getvalue_reply, 0);
   };
-  ex::sync_wait(stdexec::starts_on(g_registry.GetScheduler(), coroutine()));
+  ex::sync_wait(coroutine());
 }


### PR DESCRIPTION
This reverts commit dd14ddd6bce3a291ef6844ff7dfcfb181bd91e49. but keeps some useful change.

The GetScheduler() API conflicts with some design in the future, remove it from doc first, so user won't use it.