### PR TITLE
[API] remove ActoryRegistry::GetScheudler() interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TARGET_COMPILE_PDB.pdb
 bazel-*
 docs/contents/assets
 docs/contents/index.md
+Testing/

--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -53,7 +53,7 @@ class PingWorker {
 // 1. Register the class & methods using EXA_REMOTE
 EXA_REMOTE(&PingWorker::FactoryCreate, &PingWorker::Ping);
 
-std::unique_ptr<ex_actor::ActorRegistry<>> registry;
+std::unique_ptr<ex_actor::ActorRegistry> registry;
 
 exec::task<void> MainCoroutine(uint32_t this_node_id, size_t total_nodes) {
   uint32_t remote_node_id = (this_node_id + 1) % total_nodes;
@@ -69,10 +69,8 @@ int main(int argc, char** argv) {
   uint32_t this_node_id = std::atoi(argv[1]);
   std::vector<ex_actor::NodeInfo> cluster_node_info = {{.node_id = 0, .address = "tcp://127.0.0.1:5301"},
                                                        {.node_id = 1, .address = "tcp://127.0.0.1:5302"}};
-  registry = std::make_unique<ex_actor::ActorRegistry<>>(/*thread_pool_size=*/4, this_node_id, cluster_node_info);
-  auto main_coroutine =
-      stdexec::starts_on(registry->GetScheduler(), MainCoroutine(this_node_id, cluster_node_info.size()));
-  stdexec::sync_wait(std::move(main_coroutine));
+  registry = std::make_unique<ex_actor::ActorRegistry>(/*thread_pool_size=*/4, this_node_id, cluster_node_info);
+  stdexec::sync_wait(MainCoroutine(this_node_id, cluster_node_info.size()));
 }
 ```
 <!-- doc test end -->

--- a/docs/contents/tutorial.md
+++ b/docs/contents/tutorial.md
@@ -207,8 +207,8 @@ exec::task<void> MainCoroutine() {
   // `when_all` example, handy for small number of tasks.
   auto [res1, res2, res3] = co_await stdexec::when_all(
     counters[0].Send<&Counter::AddAndGet>(1),
-    counters[1].Send<&Counter::AddAndGet>(2),
-    counters[2].Send<&Counter::AddAndGet>(3)
+    counters[1].Send<&Counter::AddAndGet>(1),
+    counters[2].Send<&Counter::AddAndGet>(1)
   );
   assert(res1 == 1);
   assert(res2 == 1);

--- a/include/ex_actor/api.h
+++ b/include/ex_actor/api.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "ex_actor/internal/actor_creation.h"  // IWYU pragma: export
+#include "ex_actor/internal/actor_registry.h"  // IWYU pragma: export
 #include "ex_actor/internal/reflect.h"         // IWYU pragma: export
 #include "ex_actor/internal/scheduler.h"       // IWYU pragma: export
 #include "ex_actor/internal/util.h"            // IWYU pragma: export

--- a/include/ex_actor/internal/actor_config.h
+++ b/include/ex_actor/internal/actor_config.h
@@ -46,16 +46,18 @@ struct get_priority_t {
       return UINT32_MAX;
     }
   }
+  constexpr auto query(stdexec::forwarding_query_t) const noexcept -> bool { return true; }
 };
 
 struct get_scheduler_index_t {
-  constexpr uint32_t operator()(const auto& prop) const noexcept {
+  constexpr size_t operator()(const auto& prop) const noexcept {
     if constexpr (requires { prop.query(get_scheduler_index_t {}); }) {
       return prop.query(get_scheduler_index_t {});
     } else {
       return 0;
     }
   }
+  constexpr auto query(stdexec::forwarding_query_t) const noexcept -> bool { return true; }
 };
 
 constexpr inline get_priority_t get_priority {};

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -348,7 +348,6 @@ class ActorRegistryRequestProcessor {
   }
 };
 
-template <ex::scheduler Scheduler = WorkSharingThreadPool::Scheduler>
 class ActorRegistry {
  public:
   /**
@@ -361,6 +360,7 @@ class ActorRegistry {
   /**
    * @brief Construct in single-node mode, use specified scheduler.
    */
+  template <ex::scheduler Scheduler>
   explicit ActorRegistry(Scheduler scheduler)
       : ActorRegistry(/*thread_pool_size=*/0, std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler),
                       /*this_node_id=*/0, /*cluster_node_info=*/ {}, /*heartbeat_config=*/ {}) {}
@@ -375,6 +375,7 @@ class ActorRegistry {
   /**
    * @brief Construct in distributed mode, use specified scheduler.
    */
+  template <ex::scheduler Scheduler>
   explicit ActorRegistry(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info,
                          network::HeartbeatConfig heartbeat_config = {})
       : ActorRegistry(/*thread_pool_size=*/0, std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler), this_node_id,
@@ -445,10 +446,6 @@ class ActorRegistry {
         &ActorRegistryRequestProcessor::GetActorRefByName<UserClass>;
 
     return util::WrapSenderWithInlineScheduler(processor_actor_ref_.SendLocal<kProcessFn>(node_id, name));
-  }
-
-  Scheduler GetScheduler() const {
-    return *reinterpret_cast<const Scheduler*>(scheduler_->GetUnderlyingSchedulerPtr());
   }
 
  private:

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -229,7 +229,8 @@ void MessageBroker::CheckHeartbeat() {
     if (node.node_id != this_node_id_ &&
         std::chrono::steady_clock::now() - last_seen_[node.node_id] >= heartbeat_.heartbeat_timeout) {
       logger_->error("Node {} detect that node {} is dead, try to exit", this_node_id_, node.node_id);
-      std::exit(1);
+      // don't call static variables' destructors, or the program will hang in MessageBroker's destructor
+      std::quick_exit(1);
     }
   }
 }

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -7,7 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "ex_actor/api.h"
-#include "ex_actor/internal/actor_creation.h"
+#include "ex_actor/internal/actor_registry.h"
 #include "rfl/internal/has_reflector.hpp"
 
 namespace ex = stdexec;
@@ -58,7 +58,7 @@ TEST(BasicApiTest, ActorRegistryCreationWithDefaultScheduler) {
     EXPECT_EQ(getvalue_reply, 0);
     co_return;
   };
-  ex::sync_wait(stdexec::starts_on(registry.GetScheduler(), coroutine()));
+  ex::sync_wait(coroutine());
 }
 
 TEST(BasicApiTest, ShouldWorkWithAsyncSpawn) {

--- a/test/doc_test.py
+++ b/test/doc_test.py
@@ -168,13 +168,13 @@ def build_and_test(temp_dir: Path, verbose: bool = False):
     
     print("\n=== Building ===")
     build_cmd = [
-        "cmake", "--build", str(build_dir), "--config", "Release"
+        "cmake", "--build", str(build_dir), "--config", "Debug"
     ]
     subprocess.run(build_cmd, check=True)
     
     print("\n=== Running Tests ===")
     test_cmd = [
-        "ctest", "-C", "Release", "--output-on-failure"
+        "ctest", "-C", "Debug", "--output-on-failure"
     ]
     if verbose:
         test_cmd.append("-V")

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -19,7 +19,7 @@ class PingWorker {
 EXA_REMOTE(&PingWorker::FactoryCreate, &PingWorker::Ping);
 
 namespace {
-std::unique_ptr<ex_actor::ActorRegistry<>> registry;
+std::unique_ptr<ex_actor::ActorRegistry> registry;
 
 exec::task<void> MainCoroutine(uint32_t this_node_id, size_t total_nodes) {
   uint32_t remote_node_id = (this_node_id + 1) % total_nodes;
@@ -37,9 +37,7 @@ int main(int /*argc*/, char** argv) {
   uint32_t this_node_id = std::atoi(argv[1]);
   std::vector<ex_actor::NodeInfo> cluster_node_info = {{.node_id = 0, .address = "tcp://127.0.0.1:5301"},
                                                        {.node_id = 1, .address = "tcp://127.0.0.1:5302"}};
-  registry = std::make_unique<ex_actor::ActorRegistry<>>(/*thread_pool_size=*/4, this_node_id, cluster_node_info);
-  auto main_coroutine =
-      stdexec::starts_on(registry->GetScheduler(), MainCoroutine(this_node_id, cluster_node_info.size()));
-  stdexec::sync_wait(std::move(main_coroutine));
+  registry = std::make_unique<ex_actor::ActorRegistry>(/*thread_pool_size=*/4, this_node_id, cluster_node_info);
+  stdexec::sync_wait(MainCoroutine(this_node_id, cluster_node_info.size()));
   spdlog::info("main exit, node id: {}", this_node_id);
 }


### PR DESCRIPTION
Remove it temporarily, to make ActoryRegistry a non-template class. So we can do https://github.com/ex-actor/ex-actor/issues/106

Will make a type-erased scheduler in the future.

Fixed some errors in doc BTW.