### PR TITLE
[doc] Update link for Talk at PureCpp 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See ⚙️[Installation](https://ex-actor.github.io/ex-actor/installation/) page
 
  - [Actor Model Explained (Video, English)](https://www.youtube.com/watch?v=ELwEdb_pD0k)
  - [Wikipedia - Actor Model](https://en.wikipedia.org/wiki/Actor_model)
- - [Talk at PureCpp 2025 (Video, Chinese)](https://www.bilibili.com/video/BV1Ddq6BoEJM)
+ - [Talk at PureCpp 2025 (Video, Chinese)](https://www.bilibili.com/video/BV1LYB7BMEeQ/)
 
 # FAQs
 


### PR DESCRIPTION
Deleted the viedo by mistake. Re-uploaded, the url changed