### PR TITLE
[feat] Allow user to configure log level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bazel-*
 docs/contents/assets
 docs/contents/index.md
 Testing/
+core.*
+*.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,6 +86,7 @@
         "distributed_test",
         "network_test",
         "skynet_test",
+        "logging_test",
       ]
     }
   ]

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,10 +9,7 @@ filegroup(
 
 cc_library(
     name = "ex_actor",
-    srcs = [
-        "src/ex_actor/internal/actor_registry.cc",
-        "src/ex_actor/internal/network.cc",
-    ],
+    srcs = glob(["src/**/*.cc"]),
     hdrs = glob(["include/**/*.h"]),
     includes = ["include"],
     deps = [

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(
   STATIC
   src/ex_actor/internal/network.cc
   src/ex_actor/internal/actor_registry.cc
+  src/ex_actor/internal/logging.cc
 )
 target_include_directories(ex_actor PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -29,8 +29,6 @@
 
 #include "ex_actor/internal/constants.h"
 #include "ex_actor/internal/util.h"
-#include "spdlog/sinks/stdout_sinks.h"
-#include "spdlog/spdlog.h"
 
 namespace ex_actor {
 struct NodeInfo {
@@ -87,7 +85,7 @@ class MessageBroker {
       bool expected = false;
       bool changed = started.compare_exchange_strong(expected, true);
       if (!changed) [[unlikely]] {
-        spdlog::critical("MessageBroker Operation already started");
+        logging::Critical("MessageBroker Operation already started");
         std::terminate();
       }
       message_broker->PushOperation(this);
@@ -127,8 +125,6 @@ class MessageBroker {
     Identifier identifier;
     ByteBufferType data;
   };
-
-  std::unique_ptr<spdlog::logger> logger_ = logging::CreateLogger("MessageBroker");
 
   std::vector<NodeInfo> node_list_;
   uint32_t this_node_id_;

--- a/src/ex_actor/internal/logging.cc
+++ b/src/ex_actor/internal/logging.cc
@@ -1,0 +1,62 @@
+#include "ex_actor/internal/logging.h"
+
+#include <spdlog/spdlog.h>
+
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+namespace ex_actor::internal::logging {
+using ex_actor::logging::LogLevel;
+
+spdlog::level::level_enum ToSpdlogLevel(LogLevel level) {
+  switch (level) {
+    case LogLevel::kDebug:
+      return spdlog::level::debug;
+    case LogLevel::kInfo:
+      return spdlog::level::info;
+    case LogLevel::kWarn:
+      return spdlog::level::warn;
+    case LogLevel::kError:
+      return spdlog::level::err;
+    case LogLevel::kFatal:
+      return spdlog::level::critical;
+  }
+  EXA_THROW << "Invalid log level: " << level;
+}
+
+std::unique_ptr<spdlog::logger> CreateLoggerUsingConfig(const ex_actor::logging::LogConfig& config) {
+  constexpr char kLoggerName[] = "ex_actor";
+  std::unique_ptr<spdlog::logger> logger;
+  if (config.log_file_path.empty()) {
+    logger = std::make_unique<spdlog::logger>(kLoggerName, std::make_unique<spdlog::sinks::stdout_color_sink_mt>());
+  } else {
+    logger = std::make_unique<spdlog::logger>(
+        kLoggerName, std::make_unique<spdlog::sinks::basic_file_sink_mt>(config.log_file_path));
+  }
+  logger->set_level(ToSpdlogLevel(config.level));
+  logger->set_pattern(kDefaultLoggerPattern);
+  return logger;
+}
+
+std::unique_ptr<spdlog::logger>& GlobalLogger() {
+  static std::unique_ptr<spdlog::logger> global_logger = CreateLoggerUsingConfig({});
+  return global_logger;
+}
+
+void InstallFallbackExceptionHandler() {
+  std::set_terminate([] {
+    if (auto ex = std::current_exception()) {
+      try {
+        std::rethrow_exception(ex);
+      } catch (const std::exception& e) {
+        logging::Critical("terminate called with an active exception, type: {}, what: {}", typeid(e).name(), e.what());
+      } catch (...) {
+        logging::Critical("terminate called with an unknown exception");
+      }
+    } else {
+      logging::Critical("terminate called without an active exception");
+    }
+    std::abort();
+  });
+};
+}  // namespace ex_actor::internal::logging

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,7 @@ ex_actor_test(complex_api_test)
 ex_actor_test(distributed_test)
 ex_actor_test(network_test)
 ex_actor_test(skynet_test TIMEOUT 10)
+ex_actor_test(logging_test)
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 # multi-process test

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -69,6 +69,8 @@ TEST(BasicApiTest, ShouldWorkWithAsyncSpawn) {
     auto future = scope.spawn_future(counter.SendLocal<&Counter::GetValue>());
     auto res = co_await std::move(future);
     EXPECT_EQ(res, 1);
+    // Wait for all spawned work to complete before destroying the scope
+    co_await scope.on_empty();
     co_return;
   };
   ex_actor::Init(/*thread_pool_size=*/10);

--- a/test/logging_test.cc
+++ b/test/logging_test.cc
@@ -1,0 +1,146 @@
+#include "ex_actor/internal/logging.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "ex_actor/api.h"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Helper function to read file contents
+std::string ReadFile(const std::string& path) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    return "";
+  }
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+// Helper function to check if string contains substring
+bool Contains(const std::string& str, const std::string& substring) { return str.find(substring) != std::string::npos; }
+
+// Helper function to clean up log file (resets logger to close file handle on Windows)
+void CleanupLogFile(const std::string& log_file) {
+  if (fs::exists(log_file)) {
+    // Reset logger to close file handle before cleanup (required on Windows)
+    ex_actor::ConfigureLogging({});
+    fs::remove(log_file);
+  }
+}
+
+}  // namespace
+
+// Test 1: Init() and Shutdown() without configure logging, should see all logs
+TEST(LoggingTest, InitShutdownWithoutConfigureLogging) {
+  std::string log_file = "test_log_1.txt";
+
+  // Clean up any existing log file
+  CleanupLogFile(log_file);
+
+  // Configure logging to file with default Info level
+  ex_actor::ConfigureLogging({
+      .log_file_path = log_file,
+  });
+
+  // Init and Shutdown
+  ex_actor::Init(4);
+  ex_actor::Shutdown();
+
+  // flush log
+  ex_actor::internal::logging::GlobalLogger()->flush();
+
+  // Read log file and verify both Init and Shutdown logs are present
+  std::string log_contents = ReadFile(log_file);
+  EXPECT_FALSE(log_contents.empty()) << "Log file should not be empty";
+  EXPECT_TRUE(Contains(log_contents, "Initializing ex_actor")) << "Should see Init log. Log contents:\n"
+                                                               << log_contents;
+  EXPECT_TRUE(Contains(log_contents, "Shutting down ex_actor")) << "Should see Shutdown log. Log contents:\n"
+                                                                << log_contents;
+
+  // Clean up
+  CleanupLogFile(log_file);
+}
+
+// Test 2: ConfigureLogging() with error level, should see no info log
+TEST(LoggingTest, ConfigureLoggingWithErrorLevel) {
+  std::string log_file = "test_log_2.txt";
+
+  // Clean up any existing log file
+  CleanupLogFile(log_file);
+
+  // Configure logging to file with Error level (should filter out Info logs)
+  ex_actor::ConfigureLogging({
+      .level = ex_actor::logging::LogLevel::kError,
+      .log_file_path = log_file,
+  });
+
+  // Init and Shutdown - these produce Info level logs
+  ex_actor::Init(4);
+  ex_actor::Shutdown();
+
+  // flush log
+  ex_actor::internal::logging::GlobalLogger()->flush();
+
+  // Read log file - should be empty or not contain Info logs
+  std::string log_contents = ReadFile(log_file);
+  EXPECT_FALSE(Contains(log_contents, "Initializing ex_actor"))
+      << "Should NOT see Init log at Error level. Log contents:\n"
+      << log_contents;
+  EXPECT_FALSE(Contains(log_contents, "Shutting down ex_actor"))
+      << "Should NOT see Shutdown log at Error level. Log contents:\n"
+      << log_contents;
+
+  // Clean up
+  CleanupLogFile(log_file);
+}
+
+// Test 3: Init() first with Info level, then ConfigureLogging() with Error level in the middle,
+// and Shutdown(). Should only see Init log, not Shutdown log
+TEST(LoggingTest, ConfigureLoggingInMiddle) {
+  std::string log_file = "test_log_3.txt";
+
+  // Clean up any existing log file
+  CleanupLogFile(log_file);
+
+  // Configure logging to file with Info level initially
+  ex_actor::ConfigureLogging({
+      .level = ex_actor::logging::LogLevel::kInfo,
+      .log_file_path = log_file,
+  });
+
+  // Init - should be logged
+  ex_actor::Init(4);
+
+  // Change log level to Error in the middle
+  ex_actor::ConfigureLogging({
+      .level = ex_actor::logging::LogLevel::kError,
+      .log_file_path = log_file,
+  });
+
+  // Shutdown - should NOT be logged because level is now Error
+  ex_actor::Shutdown();
+
+  // flush log
+  ex_actor::internal::logging::GlobalLogger()->flush();
+
+  // Read log file
+  std::string log_contents = ReadFile(log_file);
+  EXPECT_FALSE(log_contents.empty()) << "Log file should not be empty";
+  EXPECT_TRUE(Contains(log_contents, "Initializing ex_actor"))
+      << "Should see Init log (before level change). Log contents:\n"
+      << log_contents;
+  EXPECT_FALSE(Contains(log_contents, "Shutting down ex_actor"))
+      << "Should NOT see Shutdown log (after level change to Error). Log contents:\n"
+      << log_contents;
+
+  // Clean up
+  CleanupLogFile(log_file);
+}

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -3,6 +3,8 @@
 
 #include "ex_actor/api.h"
 
+namespace logging = ex_actor::internal::logging;
+
 class PingWorker {
  public:
   explicit PingWorker(std::string name) : name_(std::move(name)) {}
@@ -41,5 +43,5 @@ int main(int /*argc*/, char** argv) {
   ex_actor::Init(shared_pool->GetScheduler(), this_node_id, cluster_node_info, shared_pool, dummy_resource,
                  dummy_resource, dummy_resource, dummy_resource);
   stdexec::sync_wait(MainCoroutine(this_node_id, cluster_node_info.size()));
-  spdlog::info("main exit, node id: {}", this_node_id);
+  logging::Info("main exit, node id: {}", this_node_id);
 }

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -8,6 +8,7 @@
 #include "ex_actor/api.h"
 
 using ex_actor::internal::network::ByteBufferType;
+namespace logging = ex_actor::internal::logging;
 
 TEST(NetworkTest, MessageBrokerTest) {
   auto test_once = []() {
@@ -28,7 +29,7 @@ TEST(NetworkTest, MessageBrokerTest) {
         scope.spawn(message_broker.SendRequest(to_node_id, ByteBufferType(std::to_string(node_id))) |
                     stdexec::then([node_id](ByteBufferType data) {
                       std::string data_str(static_cast<char*>(data.data()), data.size());
-                      spdlog::info("got response data, node id: {}, data: {}", node_id, data_str);
+                      logging::Info("got response data, node id: {}, data: {}", node_id, data_str);
                       ASSERT_EQ(data_str, std::to_string(node_id));
                     }));
       }
@@ -40,7 +41,7 @@ TEST(NetworkTest, MessageBrokerTest) {
   };
 
   for (int i = 0; i < 10; ++i) {
-    spdlog::info("test once, {}", i);
+    logging::Info("test once, {}", i);
     test_once();
   }
 }


### PR DESCRIPTION
Add `ex_actor::ConfigureLogging` interface

Also removed the individual logggers inside ActorRigistry and MessageBroker. Instead, using a global logger instance.

From now on we should use `logging::Info`, `logging::Error`... to print log. Do not use `spdlog::info` anymore.