### PR TITLE
[API] add HoldResource() interface

### DIFF
--- a/docs/contents/schedulers.md
+++ b/docs/contents/schedulers.md
@@ -27,15 +27,17 @@ int main() {
 ```
 <!-- doc test end -->
 
-Another way is to make your execution resource a `shared_ptr`, and pass it in the end of the `ex_actor::Init` function. So we can hold a reference to it. Then you don't need to call `ex_actor::Shutdown` explicitly.
+Another way is to make your execution resource an `unique_ptr` or `shared_ptr`, and use `ex_actor::HoldResource` to hold it, then we're able to control its lifecycle, and you don't need to call `ex_actor::Shutdown` explicitly anymore.
 
 <!-- doc test start -->
 ```cpp
 #include "ex_actor/api.h"
 
 int main() {
-  auto thread_pool_shared_ptr = std::make_shared<ex_actor::WorkSharingThreadPool>(/*thread_count=*/10);
-  ex_actor::Init(thread_pool_shared_ptr->GetScheduler(), thread_pool_shared_ptr);
+  // can also be a `shared_ptr` if you want to use it elsewhere.
+  auto thread_pool = std::make_unique<ex_actor::WorkSharingThreadPool>(/*thread_count=*/10);
+  ex_actor::Init(thread_pool->GetScheduler());
+  ex_actor::HoldResource(std::move(thread_pool));
 }
 ```
 <!-- doc test end -->

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -252,8 +252,6 @@ void AssignGlobalDefaultRegistry(std::unique_ptr<ex_actor::ActorRegistry> regist
 
 bool IsGlobalDefaultRegistryInitialized() { return global_default_registry != nullptr; }
 
-void AddResourceToHolder(std::shared_ptr<void> resource) { resource_holder.push_back(std::move(resource)); }
-
 static void RegisterAtExitCleanup() {
   static bool at_exit_cleanup_registered = false;
 
@@ -303,6 +301,8 @@ void Init(uint32_t thread_pool_size, uint32_t this_node_id, const std::vector<No
   internal::SetupGlobalHandlers();
   global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size, this_node_id, cluster_node_info);
 }
+
+void HoldResource(std::shared_ptr<void> resource) { resource_holder.push_back(std::move(resource)); }
 
 void Shutdown() {
   internal::logging::Info("Shutting down ex_actor.");

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -36,12 +36,11 @@ exec::task<void> MainCoroutine(uint32_t this_node_id, size_t total_nodes) {
 
 int main(int /*argc*/, char** argv) {
   auto shared_pool = std::make_shared<ex_actor::WorkSharingThreadPool>(4);
-  auto dummy_resource = std::make_shared<int>(0);
   uint32_t this_node_id = std::atoi(argv[1]);
   std::vector<ex_actor::NodeInfo> cluster_node_info = {{.node_id = 0, .address = "tcp://127.0.0.1:5301"},
                                                        {.node_id = 1, .address = "tcp://127.0.0.1:5302"}};
-  ex_actor::Init(shared_pool->GetScheduler(), this_node_id, cluster_node_info, shared_pool, dummy_resource,
-                 dummy_resource, dummy_resource, dummy_resource);
+  ex_actor::Init(shared_pool->GetScheduler(), this_node_id, cluster_node_info);
+  ex_actor::HoldResource(shared_pool);
   stdexec::sync_wait(MainCoroutine(this_node_id, cluster_node_info.size()));
   logging::Info("main exit, node id: {}", this_node_id);
 }


### PR DESCRIPTION
Make resource holding an separate API. So we don't need to put `resources...` to every `Init()` overload. This will cause big trouble in the future when there are more and more `Init()` overloads. So I want to change it before too many people use it.

This is a breaking change. Users should move resources from `Init()` function to `ec_actor::HoldResource()`. See changes in `test/scheduler_test.cc` for example.