### PR TITLE
[perf] only sleep when send queues are empty

### DIFF
--- a/include/ex_actor/internal/util.h
+++ b/include/ex_actor/internal/util.h
@@ -126,6 +126,11 @@ struct LinearizableUnboundedQueue {
     return value;
   }
 
+  bool Empty() {
+    std::lock_guard lock(mutex_);
+    return queue_.empty();
+  }
+
  private:
   std::queue<T> queue_;
   mutable std::mutex mutex_;

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -168,7 +168,9 @@ void MessageBroker::SendProcessLoop(const std::stop_token& stop_token) {
       EXA_THROW_CHECK(multi.send(send_socket));
     }
     SendHeartbeat();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    if (pending_send_operations_.Empty() && pending_reply_operations_.Empty()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
   }
 }
 


### PR DESCRIPTION
I think checking if the queues are empty is simpler than adding a flag.