### PR TITLE
[chore] add some comments on LinearizableUnboundedQueue

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -2,7 +2,7 @@
 
 !!! Note
 
-    This feature is currently in alpha stage. While it's fully functional and ready for use, it's not massively tested in production yet. Bugs and API changes should be expected. Welcome to have a try and build together with us!
+    This feature is currently in alpha stage. While it's fully functional and ready for use, it's not massively tested in production yet. Bugs, performance issues and API changes should be expected. Welcome to have a try and build together with us!
 
 
 Distributed mode enables you to create actors at remote nodes. When calling a remote actor, all arguments will be

--- a/include/ex_actor/internal/util.h
+++ b/include/ex_actor/internal/util.h
@@ -108,6 +108,12 @@ class Semaphore {
 };  // namespace ex_actor::util
 
 namespace ex_actor::internal::util {
+
+/**
+ * std::mutex+std::queue performs surprisingly good on small items. Because there are spin-lock optimization in
+ * std::mutex. In our code the actor message is just a pointer to the operation state, which is very small. So this
+ * simple implementation is good enough. No need to use a sophisticated lock-free MPSC queue.
+ */
 template <class T>
 struct LinearizableUnboundedQueue {
  public:


### PR DESCRIPTION
To explain why we choose std::mutex + std::queue instead of using a sophisticated lock-free MPSC queue.