### PR TITLE
[API] Ask user to Shutdown() explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ exec::task<void> MainCoroutine() {
   // 2. Call it! It returns a `std::execution::task`.
   int res = co_await actor.Send<&Counter::Add>(1);
   assert(res == 1);
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -99,6 +101,8 @@ exec::task<void> MainCoroutine() {
   ex_actor::ActorRef<Father> father = co_await ex_actor::Spawn<Father>();
   std::string res = co_await father.Send<&Father::SpawnChildAndPing>();
   assert(res == "Where is my child? Dad, I'm here!");
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }

--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -69,7 +69,10 @@ int main(int argc, char** argv) {
   std::vector<ex_actor::NodeInfo> cluster_node_info = {{.node_id = 0, .address = "tcp://127.0.0.1:5301"},
                                                        {.node_id = 1, .address = "tcp://127.0.0.1:5302"}};
   ex_actor::Init(/*thread_pool_size=*/4, this_node_id, cluster_node_info);
+
   stdexec::sync_wait(MainCoroutine(this_node_id, cluster_node_info.size()));
+
+  ex_actor::Shutdown();
 }
 ```
 <!-- doc test end -->

--- a/docs/contents/schedulers.md
+++ b/docs/contents/schedulers.md
@@ -20,14 +20,14 @@ int main() {
   // pass the scheduler to the ex_actor::Init function
   ex_actor::Init(thread_pool.GetScheduler());
   
-  // IMPORTANT: shutdown the runtime before your execution resource is destroyed
+  // caution: shutdown the runtime before your execution resource is destroyed
   // or the program will crash or hang forever, because we are still using your execution resource.
   ex_actor::Shutdown();
 }
 ```
 <!-- doc test end -->
 
-Another way is to make your execution resource an `unique_ptr` or `shared_ptr`, and use `ex_actor::HoldResource` to hold it, then we're able to control its lifecycle, and you don't need to call `ex_actor::Shutdown` explicitly anymore.
+If you want ex_actor to control the lifecycle of your execution resource, you can use `ex_actor::HoldResource` to hold it, the resource will be released when calling `ex_actor::Shutdown()`.
 
 <!-- doc test start -->
 ```cpp
@@ -38,6 +38,10 @@ int main() {
   auto thread_pool = std::make_unique<ex_actor::WorkSharingThreadPool>(/*thread_count=*/10);
   ex_actor::Init(thread_pool->GetScheduler());
   ex_actor::HoldResource(std::move(thread_pool));
+
+  // do some work...
+
+  ex_actor::Shutdown(); // the thread_pool will be destroyed here
 }
 ```
 <!-- doc test end -->

--- a/docs/contents/tutorial.md
+++ b/docs/contents/tutorial.md
@@ -62,6 +62,8 @@ exec::task<void> MainCoroutine() {
   // A shorter way
   res = co_await actor.Send<&Counter::Add>(1);
   assert(res == 2);
+
+  ex_actor::Shutdown();
 }
 
 
@@ -122,6 +124,8 @@ exec::task<void> MainCoroutine() {
   // unwrap the result for you, so you don't need to `co_await` twice.
   std::string res = co_await father.Send<&Father::SpawnChildAndPing>();
   assert(res == "Where is my child? Dad, I'm here!");
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -170,6 +174,8 @@ exec::task<void> MainCoroutine() {
   // 2. call through the proxy actor.
   std::string res = co_await proxy.Send<&Proxy::ProxyPing>();
   assert(res == "Hi from Proxy");
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -218,6 +224,8 @@ exec::task<void> MainCoroutine() {
   // you must wait for all task done before destroying the scope,
   // or an exception will be thrown.
   co_await scope.on_empty();
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -293,6 +301,8 @@ exec::task<void> MainCoroutine() {
     int value = co_await std::move(futures[i]);
     assert(value == 3);
   }
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -334,6 +344,8 @@ int main() {
 
   auto [res1] = stdexec::sync_wait(std::move(task1)).value();
   assert(res1 == 2);
+
+  ex_actor::Shutdown();
 }
 ```
 <!-- doc test end -->
@@ -387,6 +399,8 @@ exec::task<void> MainCoroutine() {
   scope.spawn(proxy.Send<&Proxy::SomeMethod>());
   scope.spawn(proxy.Send<&Proxy::AnotherMethod>());
   co_await scope.on_empty();
+
+  ex_actor::Shutdown();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -343,7 +343,7 @@ void Init(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo
 void HoldResource(std::shared_ptr<void> resource);
 
 /**
- * @brief Shutdown the global default registry. Will also be called automatically when `main` exits. Not thread-safe.
+ * @brief Shutdown the global default registry. Must be called explicitly before `main` exits. Not thread-safe.
  */
 void Shutdown();
 
@@ -401,8 +401,6 @@ template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler) {
   internal::logging::Info("Initializing ex_actor in single-node mode with custom scheduler.");
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
-  // IMPORTANT: Create the registry BEFORE registering the atexit handler.
-  // See comment in actor_registry.cc Init() for explanation.
   AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler)));
   internal::SetupGlobalHandlers();
 }
@@ -413,8 +411,6 @@ void Init(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo
       "Initializing ex_actor in distributed mode with custom scheduler. this_node_id={}, total_nodes={}", this_node_id,
       cluster_node_info.size());
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
-  // IMPORTANT: Create the registry BEFORE registering the atexit handler.
-  // See comment in actor_registry.cc Init() for explanation.
   AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler), this_node_id, cluster_node_info));
   internal::SetupGlobalHandlers();
 }

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -43,4 +43,5 @@ int main(int /*argc*/, char** argv) {
   ex_actor::HoldResource(shared_pool);
   stdexec::sync_wait(MainCoroutine(this_node_id, cluster_node_info.size()));
   logging::Info("main exit, node id: {}", this_node_id);
+  ex_actor::Shutdown();
 }

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -122,5 +122,5 @@ TEST(SchedulerTest, TestResourceHolder) {
     EXPECT_NE(thread_id1, thread_id2);
   };
   ex::sync_wait(coroutine());
-  // not shutdown here, intentionally, to test the resource holder
+  ex_actor::Shutdown();
 }

--- a/test/skynet_test.cc
+++ b/test/skynet_test.cc
@@ -43,6 +43,10 @@ exec::task<uint64_t> SkynetActor::Process(int level, bool verbose) {
     children.push_back(co_await std::move(future));
   }
 
+  // Use async_scope to spawn all child tasks in parallel and collect results
+  // This avoids the when_all limitation with many senders in newer stdexec versions
+  exec::async_scope child_scope;
+
   auto make_child_sender = [&children, verbose, level](int index) {
     // test ephemeral stacks
     return children.at(index).Send<&SkynetActor::Process>(level - 1, false) | ex::then([verbose, index](uint64_t res) {
@@ -51,17 +55,21 @@ exec::task<uint64_t> SkynetActor::Process(int level, bool verbose) {
            });
   };
 
-  auto all = ex::when_all(make_child_sender(0), make_child_sender(1), make_child_sender(2), make_child_sender(3),
-                          make_child_sender(4), make_child_sender(5), make_child_sender(6), make_child_sender(7),
-                          make_child_sender(8), make_child_sender(9));
+  using ResultFutureType = decltype(child_scope.spawn_future(make_child_sender(0)));
+  std::vector<ResultFutureType> result_futures;
+  result_futures.reserve(10);
 
-  auto sum_sender = std::move(all) | ex::then([](uint64_t r0, uint64_t r1, uint64_t r2, uint64_t r3, uint64_t r4,
-                                                 uint64_t r5, uint64_t r6, uint64_t r7, uint64_t r8, uint64_t r9) {
-                      return r0 + r1 + r2 + r3 + r4 + r5 + r6 + r7 + r8 + r9;
-                    });
+  for (int i = 0; i < 10; ++i) {
+    result_futures.push_back(child_scope.spawn_future(make_child_sender(i)));
+  }
+
+  co_await child_scope.on_empty();
 
   if (verbose) std::cout << "DEBUG: Awaiting children for level " << level << std::endl;
-  uint64_t sum = co_await std::move(sum_sender);
+  uint64_t sum = 0;
+  for (auto& future : result_futures) {
+    sum += co_await std::move(future);
+  }
 
   for (auto& child : children) {
     co_await ex_actor::DestroyActor(child);
@@ -89,4 +97,5 @@ TEST(SkynetTest, ActorRegistryCanBeInvokeInsideActorMethods) {
 
   logging::Info("Result: {} ms", result);
   logging::Info("Time: {} ms", duration);
+  ex_actor::Shutdown();
 }


### PR DESCRIPTION
in https://github.com/ex-actor/ex-actor/pull/151 we introduced a queue with thread-local optimization.

In std::atexit handler, the thread_local objects are already destroyed, so when can't destroy ActorRegistry safely there.

After thinking for a long time, made a hard decision - make a break change, remove the auto-shutdown feature, ask user to Shutdown() explicitly.

Now we'll print error message in std::atexit handler once we find Shutdown() is not called, and call quick_exit(1) to avoid entering static obj destruction, which will crash due to static order fiasco.
