### PR TITLE
[refactor] flatten namespaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
-refer docs/contents for how to use this framework
+refer README.md and docs/contents for how to use this framework(ignore files listed in .gitignore, which might be stale)
 
-refer "How to build from source" part in docs/contents/contributing.md for how to build&test.
+refer "How to build from source" part in CONTRIBUTING.md for how to build&test.
 
-When work finished, you should fix lint errors, and run `./scripts/format.sh` to format the code.
-
-When I ask to you to write test, if your test fails and you think your test is correct, you should ask me to check, instead of just modify the test code to make it pass.
+when debugging tests, do not simplify the test code unless you are very confident the test is not correct.

--- a/include/ex_actor/internal/actor_ref_serialization/actor_ref_deserialization_info.h
+++ b/include/ex_actor/internal/actor_ref_serialization/actor_ref_deserialization_info.h
@@ -21,6 +21,6 @@ namespace ex_actor::internal {
 struct ActorRefDeserializationInfo {
   uint32_t this_node_id = 0;
   std::function<TypeErasedActor*(uint64_t)> actor_look_up_fn;
-  network::MessageBroker* message_broker = nullptr;
+  MessageBroker* message_broker = nullptr;
 };
 }  // namespace ex_actor::internal

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -42,7 +42,7 @@ namespace ex_actor::internal {
 class ActorRegistryBackend {
  public:
   explicit ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler, uint32_t this_node_id,
-                                const std::vector<NodeInfo>& cluster_node_info, network::MessageBroker* message_broker);
+                                const std::vector<NodeInfo>& cluster_node_info, MessageBroker* message_broker);
 
   exec::task<void> AsyncDestroyAllActors();
 
@@ -89,17 +89,16 @@ class ActorRegistryBackend {
     }
 
     if constexpr (kCreateFn != nullptr) {
-      using CreateFnSig = reflect::Signature<decltype(kCreateFn)>;
+      using CreateFnSig = Signature<decltype(kCreateFn)>;
 
       // protocol: [message_type][handler_key_len][handler_key][ActorCreationArgs]
       typename CreateFnSig::DecayedArgsTupleType args_tuple {std::move(args)...};
-      serde::ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config,
-                                                                                                std::move(args_tuple)};
-      std::vector<char> serialized = serde::Serialize(actor_creation_args);
-      std::string handler_key = reflect::GetUniqueNameForFunction<kCreateFn>();
-      serde::BufferWriter buffer_writer(network::ByteBufferType {
-          serialized.size() + sizeof(uint64_t) + handler_key.size() + sizeof(serde::NetworkRequestType)});
-      buffer_writer.WritePrimitive(serde::NetworkRequestType::kActorCreationRequest);
+      ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config, std::move(args_tuple)};
+      std::vector<char> serialized = Serialize(actor_creation_args);
+      std::string handler_key = GetUniqueNameForFunction<kCreateFn>();
+      BufferWriter buffer_writer(
+          ByteBufferType {serialized.size() + sizeof(uint64_t) + handler_key.size() + sizeof(NetworkRequestType)});
+      buffer_writer.WritePrimitive(NetworkRequestType::kActorCreationRequest);
       buffer_writer.WritePrimitive(handler_key.size());
       // TODO optimize the copy here
       buffer_writer.CopyFrom(handler_key.data(), handler_key.size());
@@ -109,11 +108,11 @@ class ActorRegistryBackend {
       // send to remote
       auto response_buffer =
           co_await message_broker_->SendRequest(config.node_id, std::move(buffer_writer).MoveBufferOut());
-      serde::BufferReader reader(std::move(response_buffer));
-      auto type = reader.template NextPrimitive<serde::NetworkReplyType>();
-      if (type == serde::NetworkReplyType::kActorCreationError) {
+      BufferReader reader(std::move(response_buffer));
+      auto type = reader.template NextPrimitive<NetworkReplyType>();
+      if (type == NetworkReplyType::kActorCreationError) {
         EXA_THROW << "Got actor creation error from remote node:"
-                  << serde::Deserialize<serde::ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
+                  << Deserialize<ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
       }
       auto actor_id = reader.template NextPrimitive<uint64_t>();
       co_return ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, nullptr, message_broker_);
@@ -151,19 +150,18 @@ class ActorRegistryBackend {
       co_return GetActorRefByName<UserClass>(name);
     }
 
-    std::vector<char> serialized = serde::Serialize(serde::ActorLookUpRequest {name});
-    serde::BufferWriter<network::ByteBufferType> writer(
-        network::ByteBufferType(sizeof(serde::NetworkRequestType) + serialized.size()));
-    writer.WritePrimitive(serde::NetworkRequestType::kActorLookUpRequest);
+    std::vector<char> serialized = Serialize(ActorLookUpRequest {name});
+    BufferWriter<ByteBufferType> writer(ByteBufferType(sizeof(NetworkRequestType) + serialized.size()));
+    writer.WritePrimitive(NetworkRequestType::kActorLookUpRequest);
     writer.CopyFrom(serialized.data(), serialized.size());
 
     auto response_buffer =
-        co_await message_broker_->SendRequest(node_id, network::ByteBufferType {std::move(writer).MoveBufferOut()});
+        co_await message_broker_->SendRequest(node_id, ByteBufferType {std::move(writer).MoveBufferOut()});
 
     std::optional<uint64_t> actor_id = std::nullopt;
-    serde::BufferReader<network::ByteBufferType> reader(std::move(response_buffer));
-    auto type = reader.NextPrimitive<serde::NetworkReplyType>();
-    if (type == serde::NetworkReplyType::kActorLookUpReturn) {
+    BufferReader<ByteBufferType> reader(std::move(response_buffer));
+    auto type = reader.NextPrimitive<NetworkReplyType>();
+    if (type == NetworkReplyType::kActorLookUpReturn) {
       actor_id = reader.NextPrimitive<uint64_t>();
     }
 
@@ -174,7 +172,7 @@ class ActorRegistryBackend {
     co_return std::nullopt;
   }
 
-  exec::task<void> HandleNetworkRequest(uint64_t received_request_id, network::ByteBufferType request_buffer);
+  exec::task<void> HandleNetworkRequest(uint64_t received_request_id, ByteBufferType request_buffer);
 
  private:
   bool is_distributed_mode_ = false;
@@ -182,18 +180,17 @@ class ActorRegistryBackend {
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
   uint32_t this_node_id_ = 0;
   std::unordered_map<uint32_t, std::string> node_id_to_address_;
-  network::MessageBroker* message_broker_ = nullptr;
+  MessageBroker* message_broker_ = nullptr;
   std::unordered_map<uint64_t, std::unique_ptr<TypeErasedActor>> actor_id_to_actor_;
   std::unordered_map<std::string, std::uint64_t> actor_name_to_id_;
 
   void InitRandomNumGenerator();
   uint64_t GenerateRandomActorId();
   void ValidateNodeInfo(const std::vector<NodeInfo>& cluster_node_info);
-  serde::NetworkRequestType ParseMessageType(const network::ByteBufferType& buffer);
-  void ReplyError(uint64_t received_request_id, serde::NetworkReplyType reply_type, std::string error_msg);
-  void HandleActorCreationRequest(uint64_t received_request_id, serde::BufferReader<network::ByteBufferType> reader);
-  exec::task<void> HandleActorMethodCallRequest(uint64_t received_request_id,
-                                                serde::BufferReader<network::ByteBufferType> reader);
+  NetworkRequestType ParseMessageType(const ByteBufferType& buffer);
+  void ReplyError(uint64_t received_request_id, NetworkReplyType reply_type, std::string error_msg);
+  void HandleActorCreationRequest(uint64_t received_request_id, BufferReader<ByteBufferType> reader);
+  exec::task<void> HandleActorMethodCallRequest(uint64_t received_request_id, BufferReader<ByteBufferType> reader);
 };
 
 /**
@@ -221,7 +218,7 @@ class ActorRegistry {
    * @brief Construct in distributed mode, use the default work-sharing thread pool as the scheduler.
    */
   explicit ActorRegistry(uint32_t thread_pool_size, uint32_t this_node_id,
-                         const std::vector<NodeInfo>& cluster_node_info, network::HeartbeatConfig heartbeat_config = {})
+                         const std::vector<NodeInfo>& cluster_node_info, HeartbeatConfig heartbeat_config = {})
       : ActorRegistry(thread_pool_size, /*scheduler=*/nullptr, this_node_id, cluster_node_info, heartbeat_config) {}
 
   /**
@@ -229,7 +226,7 @@ class ActorRegistry {
    */
   template <ex::scheduler Scheduler>
   explicit ActorRegistry(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info,
-                         network::HeartbeatConfig heartbeat_config = {})
+                         HeartbeatConfig heartbeat_config = {})
       : ActorRegistry(/*thread_pool_size=*/0, std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler), this_node_id,
                       cluster_node_info, heartbeat_config) {}
 
@@ -239,29 +236,29 @@ class ActorRegistry {
    * @brief Create actor at current node using default config.
    */
   template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  reflect::AwaitableOf<ActorRef<UserClass>> auto CreateActor(Args... args) {
+  AwaitableOf<ActorRef<UserClass>> auto CreateActor(Args... args) {
     // resolve overload ambiguity
     constexpr exec::task<ActorRef<UserClass>> (ActorRegistryBackend::*kProcessFn)(Args...) =
         &ActorRegistryBackend::CreateActor<UserClass, kCreateFn, Args...>;
 
-    return util::WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(std::move(args)...));
+    return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(std::move(args)...));
   }
 
   /**
    * @brief Create an actor with a manually specified config.
    */
   template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  reflect::AwaitableOf<ActorRef<UserClass>> auto CreateActor(ActorConfig config, Args... args) {
+  AwaitableOf<ActorRef<UserClass>> auto CreateActor(ActorConfig config, Args... args) {
     // resolve overload ambiguity
     constexpr exec::task<ActorRef<UserClass>> (ActorRegistryBackend::*kProcessFn)(ActorConfig, Args...) =
         &ActorRegistryBackend::CreateActor<UserClass, kCreateFn, Args...>;
 
-    return util::WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(config, std::move(args)...));
+    return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(config, std::move(args)...));
   }
 
   template <class UserClass>
-  reflect::AwaitableOf<void> auto DestroyActor(const ActorRef<UserClass>& actor_ref) {
-    return util::WrapSenderWithInlineScheduler(
+  AwaitableOf<void> auto DestroyActor(const ActorRef<UserClass>& actor_ref) {
+    return WrapSenderWithInlineScheduler(
         backend_actor_ref_.SendLocal<&ActorRegistryBackend::DestroyActor<UserClass>>(actor_ref));
   }
 
@@ -269,25 +266,25 @@ class ActorRegistry {
    * @brief Find the actor by name at current node.
    */
   template <class UserClass>
-  reflect::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const std::string& name) const {
+  AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const std::string& name) const {
     // resolve overload ambiguity
     constexpr std::optional<ActorRef<UserClass>> (ActorRegistryBackend::*kProcessFn)(const std::string& name) const =
         &ActorRegistryBackend::GetActorRefByName<UserClass>;
 
-    return util::WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(name));
+    return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(name));
   }
 
   /**
    * @brief Find the actor by name at remote node.
    */
   template <class UserClass>
-  reflect::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32_t& node_id,
-                                                                                  const std::string& name) const {
+  AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32_t& node_id,
+                                                                         const std::string& name) const {
     // resolve overload ambiguity
     constexpr exec::task<std::optional<ActorRef<UserClass>>> (ActorRegistryBackend::*kProcessFn)(
         const uint32_t& node_id, const std::string& name) const = &ActorRegistryBackend::GetActorRefByName<UserClass>;
 
-    return util::WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(node_id, name));
+    return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(node_id, name));
   }
 
  private:
@@ -295,14 +292,14 @@ class ActorRegistry {
   uint32_t this_node_id_;
   WorkSharingThreadPool default_work_sharing_thread_pool_;
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
-  std::unique_ptr<network::MessageBroker> message_broker_;
+  std::unique_ptr<MessageBroker> message_broker_;
   Actor<ActorRegistryBackend> backend_actor_;
   ActorRef<ActorRegistryBackend> backend_actor_ref_;
   exec::async_scope async_scope_;
 
   explicit ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler,
                          uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info,
-                         network::HeartbeatConfig heartbeat_config = {});
+                         HeartbeatConfig heartbeat_config = {});
 };
 }  // namespace ex_actor::internal
 
@@ -358,7 +355,7 @@ void Shutdown();
  * @brief Create actor at current node using default config.
  */
 template <class UserClass, auto kCreateFn = nullptr, class... Args>
-internal::reflect::AwaitableOf<ActorRef<UserClass>> auto Spawn(Args... args) {
+internal::AwaitableOf<ActorRef<UserClass>> auto Spawn(Args... args) {
   return internal::GetGlobalDefaultRegistry().CreateActor<UserClass, kCreateFn, Args...>(std::move(args)...);
 }
 
@@ -366,7 +363,7 @@ internal::reflect::AwaitableOf<ActorRef<UserClass>> auto Spawn(Args... args) {
  * @brief Create an actor with a manually specified config.
  */
 template <class UserClass, auto kCreateFn = nullptr, class... Args>
-internal::reflect::AwaitableOf<ActorRef<UserClass>> auto Spawn(ActorConfig config, Args... args) {
+internal::AwaitableOf<ActorRef<UserClass>> auto Spawn(ActorConfig config, Args... args) {
   return internal::GetGlobalDefaultRegistry().CreateActor<UserClass, kCreateFn, Args...>(config, std::move(args)...);
 }
 
@@ -374,7 +371,7 @@ internal::reflect::AwaitableOf<ActorRef<UserClass>> auto Spawn(ActorConfig confi
  * @brief Destroy an actor.
  */
 template <class UserClass>
-internal::reflect::AwaitableOf<void> auto DestroyActor(const ActorRef<UserClass>& actor_ref) {
+internal::AwaitableOf<void> auto DestroyActor(const ActorRef<UserClass>& actor_ref) {
   return internal::GetGlobalDefaultRegistry().DestroyActor<UserClass>(actor_ref);
 }
 
@@ -382,7 +379,7 @@ internal::reflect::AwaitableOf<void> auto DestroyActor(const ActorRef<UserClass>
  * @brief Find the actor by name at current node.
  */
 template <class UserClass>
-internal::reflect::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const std::string& name) {
+internal::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const std::string& name) {
   return internal::GetGlobalDefaultRegistry().GetActorRefByName<UserClass>(name);
 }
 
@@ -390,15 +387,15 @@ internal::reflect::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActor
  * @brief Find the actor by name at specified node.
  */
 template <class UserClass>
-internal::reflect::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32_t& node_id,
-                                                                                          const std::string& name) {
+internal::AwaitableOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32_t& node_id,
+                                                                                 const std::string& name) {
   return internal::GetGlobalDefaultRegistry().GetActorRefByName<UserClass>(node_id, name);
 }
 
 /**
  * @brief Configure the logging of ex_actor. Not thread-safe, please call it only when no logs are printing.
  */
-void ConfigureLogging(const logging::LogConfig& config = {});
+void ConfigureLogging(const LogConfig& config = {});
 }  // namespace ex_actor
 
 // -----------template function implementations-------------
@@ -406,7 +403,7 @@ void ConfigureLogging(const logging::LogConfig& config = {});
 namespace ex_actor {
 template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler) {
-  internal::logging::Info("Initializing ex_actor in single-node mode with custom scheduler.");
+  internal::log::Info("Initializing ex_actor in single-node mode with custom scheduler.");
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler)));
   internal::SetupGlobalHandlers();
@@ -414,7 +411,7 @@ void Init(Scheduler scheduler) {
 
 template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info) {
-  internal::logging::Info(
+  internal::log::Info(
       "Initializing ex_actor in distributed mode with custom scheduler. this_node_id={}, total_nodes={}", this_node_id,
       cluster_node_info.size());
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";

--- a/include/ex_actor/internal/logging.h
+++ b/include/ex_actor/internal/logging.h
@@ -21,7 +21,7 @@
 #include <rfl/to_view.hpp>
 #include <spdlog/spdlog.h>
 
-namespace ex_actor::logging {
+namespace ex_actor {
 enum class LogLevel : uint8_t {
   kDebug = 0,
   kInfo = 1,
@@ -35,14 +35,14 @@ struct LogConfig {
   // empty means print to stdout
   std::string log_file_path;
 };
-}  // namespace ex_actor::logging
+}  // namespace ex_actor
 
-namespace ex_actor::internal::logging {
+namespace ex_actor::internal {
 inline constexpr char kDefaultLoggerPattern[] = "[%Y-%m-%d %T.%e%z] [%^%L%$] [%t] %v";
 
-spdlog::level::level_enum ToSpdlogLevel(ex_actor::logging::LogLevel level);
+spdlog::level::level_enum ToSpdlogLevel(LogLevel level);
 
-std::unique_ptr<spdlog::logger> CreateLoggerUsingConfig(const ex_actor::logging::LogConfig& config);
+std::unique_ptr<spdlog::logger> CreateLoggerUsingConfig(const LogConfig& config);
 
 std::unique_ptr<spdlog::logger>& GlobalLogger();
 
@@ -78,52 +78,46 @@ struct ThrowStream : public std::exception {
   mutable std::string what_;
 };
 
-#define EXA_THROW throw ::ex_actor::internal::logging::ThrowStream() << __FILE__ << ":" << __LINE__ << " "
+#define EXA_THROW throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " "
 
 #define EXA_THROW_IF(condition) \
   if (condition) [[unlikely]]   \
-  throw ::ex_actor::internal::logging::ThrowStream() << __FILE__ << ":" << __LINE__ << " `" << #condition << "` "
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " `" << #condition << "` "
 
-#define EXA_THROW_CHECK(condition)                   \
-  if (!(condition)) [[unlikely]]                     \
-  throw ::ex_actor::internal::logging::ThrowStream() \
+#define EXA_THROW_CHECK(condition)          \
+  if (!(condition)) [[unlikely]]            \
+  throw ::ex_actor::internal::ThrowStream() \
       << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #condition << "` is true, got false. "
 
-#define EXA_THROW_CHECK_EQ(val1, val2)                                                                                 \
-  if ((val1) != (val2)) [[unlikely]]                                                                                   \
-  throw ::ex_actor::internal::logging::ThrowStream()                                                                   \
-      << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 << " == " << #val2 << "`, got " << (val1) \
-      << " vs " << (val2) << ". "
+#define EXA_THROW_CHECK_EQ(val1, val2)                                                                             \
+  if ((val1) != (val2)) [[unlikely]]                                                                               \
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 \
+                                            << " == " << #val2 << "`, got " << (val1) << " vs " << (val2) << ". "
 
-#define EXA_THROW_CHECK_LE(val1, val2)                                                                                 \
-  if ((val1) > (val2)) [[unlikely]]                                                                                    \
-  throw ::ex_actor::internal::logging::ThrowStream()                                                                   \
-      << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 << " <= " << #val2 << "`, got " << (val1) \
-      << " vs " << (val2) << ". "
+#define EXA_THROW_CHECK_LE(val1, val2)                                                                             \
+  if ((val1) > (val2)) [[unlikely]]                                                                                \
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 \
+                                            << " <= " << #val2 << "`, got " << (val1) << " vs " << (val2) << ". "
 
-#define EXA_THROW_CHECK_LT(val1, val2)                                                                                \
-  if ((val1) >= (val2)) [[unlikely]]                                                                                  \
-  throw ::ex_actor::internal::logging::ThrowStream()                                                                  \
-      << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 << " < " << #val2 << "`, got " << (val1) \
-      << " vs " << (val2) << ". "
+#define EXA_THROW_CHECK_LT(val1, val2)                                                                             \
+  if ((val1) >= (val2)) [[unlikely]]                                                                               \
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 \
+                                            << " < " << #val2 << "`, got " << (val1) << " vs " << (val2) << ". "
 
-#define EXA_THROW_CHECK_GE(val1, val2)                                                                                 \
-  if ((val1) < (val2)) [[unlikely]]                                                                                    \
-  throw ::ex_actor::internal::logging::ThrowStream()                                                                   \
-      << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 << " >= " << #val2 << "`, got " << (val1) \
-      << " vs " << (val2) << ". "
+#define EXA_THROW_CHECK_GE(val1, val2)                                                                             \
+  if ((val1) < (val2)) [[unlikely]]                                                                                \
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 \
+                                            << " >= " << #val2 << "`, got " << (val1) << " vs " << (val2) << ". "
 
-#define EXA_THROW_CHECK_GT(val1, val2)                                                                                \
-  if ((val1) <= (val2)) [[unlikely]]                                                                                  \
-  throw ::ex_actor::internal::logging::ThrowStream()                                                                  \
-      << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 << " > " << #val2 << "`, got " << (val1) \
-      << " vs " << (val2) << ". "
+#define EXA_THROW_CHECK_GT(val1, val2)                                                                             \
+  if ((val1) <= (val2)) [[unlikely]]                                                                               \
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 \
+                                            << " > " << #val2 << "`, got " << (val1) << " vs " << (val2) << ". "
 
-#define EXA_THROW_CHECK_NE(val1, val2)                                                                                 \
-  if ((val1) == (val2)) [[unlikely]]                                                                                   \
-  throw ::ex_actor::internal::logging::ThrowStream()                                                                   \
-      << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 << " != " << #val2 << "`, got " << (val1) \
-      << " vs " << (val2) << ". "
+#define EXA_THROW_CHECK_NE(val1, val2)                                                                             \
+  if ((val1) == (val2)) [[unlikely]]                                                                               \
+  throw ::ex_actor::internal::ThrowStream() << __FILE__ << ":" << __LINE__ << " Check failed, expected `" << #val1 \
+                                            << " != " << #val2 << "`, got " << (val1) << " vs " << (val2) << ". "
 
 template <class T>
 concept HasOstreamOperator = requires(T t, std::ostream& os) {
@@ -158,22 +152,32 @@ std::string JoinVarsNameValue(std::string_view names, T&& first, Args&&... remai
   return builder.str();
 }
 
-#define EXA_DUMP_VARS(...) ::ex_actor::internal::logging::JoinVarsNameValue(#__VA_ARGS__, __VA_ARGS__)
+#define EXA_DUMP_VARS(...) ::ex_actor::internal::JoinVarsNameValue(#__VA_ARGS__, __VA_ARGS__)
 
+}  // namespace ex_actor::internal
+
+namespace ex_actor::internal::log {
 template <typename... Args>
 inline void Info(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-  logging::GlobalLogger()->info(fmt, std::forward<Args>(args)...);
+  internal::GlobalLogger()->info(fmt, std::forward<Args>(args)...);
 }
 template <typename... Args>
 inline void Warn(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-  logging::GlobalLogger()->warn(fmt, std::forward<Args>(args)...);
+  internal::GlobalLogger()->warn(fmt, std::forward<Args>(args)...);
 }
 template <typename... Args>
 inline void Error(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-  logging::GlobalLogger()->error(fmt, std::forward<Args>(args)...);
+  internal::GlobalLogger()->error(fmt, std::forward<Args>(args)...);
 }
 template <typename... Args>
 inline void Critical(spdlog::format_string_t<Args...> fmt, Args&&... args) {
-  logging::GlobalLogger()->critical(fmt, std::forward<Args>(args)...);
+  internal::GlobalLogger()->critical(fmt, std::forward<Args>(args)...);
 }
-}  // namespace ex_actor::internal::logging
+}  // namespace ex_actor::internal::log
+
+// Backward-compatibility aliases — these namespaces were removed in favor of ex_actor.
+// Use ex_actor::LogLevel and ex_actor::LogConfig directly.
+namespace ex_actor::logging {
+using LogLevel [[deprecated("Use ex_actor::LogLevel instead")]] = ex_actor::LogLevel;
+using LogConfig [[deprecated("Use ex_actor::LogConfig instead")]] = ex_actor::LogConfig;
+}  // namespace ex_actor::logging

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -37,7 +37,7 @@ struct NodeInfo {
 };
 }  // namespace ex_actor
 
-namespace ex_actor::internal::network {
+namespace ex_actor::internal {
 using ByteBufferType = zmq::message_t;
 
 enum class MessageFlag : uint8_t { kNormal = 0, kQuit, kHeartbeat };
@@ -85,7 +85,7 @@ class MessageBroker {
       bool expected = false;
       bool changed = started.compare_exchange_strong(expected, true);
       if (!changed) [[unlikely]] {
-        logging::Critical("MessageBroker Operation already started");
+        log::Critical("MessageBroker Operation already started");
         std::terminate();
       }
       message_broker->PushOperation(this);
@@ -134,13 +134,13 @@ class MessageBroker {
   std::atomic_uint64_t received_request_id_counter_ = 0;
 
   zmq::context_t context_ {/*io_threads_=*/1};
-  util::LockGuardedMap<uint32_t, zmq::socket_t> node_id_to_send_socket_;
+  LockGuardedMap<uint32_t, zmq::socket_t> node_id_to_send_socket_;
   zmq::socket_t recv_socket_ {context_, zmq::socket_type::dealer};
 
-  util::LinearizableUnboundedMpscQueue<TypeErasedSendOperation*> pending_send_operations_;
-  util::LockGuardedMap<uint64_t, TypeErasedSendOperation*> send_request_id_to_operation_;
-  util::LinearizableUnboundedMpscQueue<ReplyOperation> pending_reply_operations_;
-  util::LockGuardedMap<uint64_t, Identifier> received_request_id_to_identifier_;
+  LinearizableUnboundedMpscQueue<TypeErasedSendOperation*> pending_send_operations_;
+  LockGuardedMap<uint64_t, TypeErasedSendOperation*> send_request_id_to_operation_;
+  LinearizableUnboundedMpscQueue<ReplyOperation> pending_reply_operations_;
+  LockGuardedMap<uint64_t, Identifier> received_request_id_to_identifier_;
 
   std::jthread send_thread_;
   std::jthread recv_thread_;
@@ -153,8 +153,8 @@ class MessageBroker {
   std::unordered_map<uint32_t, TimePoint> last_seen_;
 };
 
-}  // namespace ex_actor::internal::network
+}  // namespace ex_actor::internal
 
 namespace ex_actor {
-using internal::network::HeartbeatConfig;
+using internal::HeartbeatConfig;
 }  // namespace ex_actor

--- a/include/ex_actor/internal/reflect.h
+++ b/include/ex_actor/internal/reflect.h
@@ -22,7 +22,7 @@
 #include <rfl/Tuple.hpp>
 #include <stdexec/execution.hpp>
 
-namespace ex_actor::internal::reflect {
+namespace ex_actor::internal {
 
 template <typename T>
 struct Signature;
@@ -91,55 +91,6 @@ consteval std::optional<size_t> GetIndexInParamPack() {
 template <size_t kIndex, class... Ts>
 using ParamPackElement = std::tuple_element_t<kIndex, std::tuple<Ts...>>;
 
-// ---------------- Actor Methods Related ----------------
-#ifndef EXA_ACTOR_METHODS_KEYWORD
-#define EXA_ACTOR_METHODS_KEYWORD kActorMethods
-#endif
-
-template <class T>
-constexpr std::tuple EXA_ACTOR_METHODS_KEYWORD = {};
-
-template <typename, typename = void>
-struct HasStaticMemberActorMethods : std::false_type {};
-template <typename T>
-struct HasStaticMemberActorMethods<T, std::void_t<decltype(T::EXA_ACTOR_METHODS_KEYWORD)>> : std::true_type {};
-template <typename T>
-inline constexpr bool kHasStaticMemberActorMethods = HasStaticMemberActorMethods<T>::value;
-
-template <class UserClass>
-consteval auto GetActorMethodsTuple() {
-  if constexpr (kHasStaticMemberActorMethods<UserClass>) {
-    return UserClass::EXA_ACTOR_METHODS_KEYWORD;
-  } else {
-    return EXA_ACTOR_METHODS_KEYWORD<UserClass>;
-  }
-}
-
-template <class T>
-concept HasActorMethods = (std::tuple_size_v<decltype(GetActorMethodsTuple<T>())> > 0);
-
-template <class UserClass>
-consteval void CheckHasActorMethods() {
-  static_assert(HasActorMethods<UserClass>,
-                "Actor class must define constexpr static member `kActorMethods`, which is a std::tuple contains "
-                "method pointers to your actor methods.");
-}
-
-template <auto kFunc, size_t kIndex = 0>
-  requires std::is_member_function_pointer_v<decltype(kFunc)>
-consteval std::optional<uint64_t> GetActorMethodIndex() {
-  using ClassType = Signature<decltype(kFunc)>::ClassType;
-  constexpr auto kActorMethodsTuple = GetActorMethodsTuple<ClassType>();
-  if constexpr (std::tuple_size_v<decltype(kActorMethodsTuple)> == 0) {
-    return std::nullopt;
-  } else if constexpr (IsSameMemberFn<std::get<kIndex>(kActorMethodsTuple), kFunc>()) {
-    return kIndex;
-  } else if constexpr (kIndex + 1 < std::tuple_size_v<decltype(kActorMethodsTuple)>) {
-    return GetActorMethodIndex<kFunc, kIndex + 1>();
-  }
-  return std::optional<uint64_t> {};
-};
-
 template <stdexec::sender Sender>
 using CoAwaitType =
     decltype(std::declval<exec::task<void>::promise_type>().await_transform(std::declval<Sender>()).await_resume());
@@ -164,8 +115,4 @@ std::string GetUniqueNameForFunction() {
   // it's an unique mangled name. So it works now, maybe replace it with a more robust way in the future.
   return typeid(kFunc).name();
 }
-}  // namespace ex_actor::internal::reflect
-
-namespace ex_actor::reflect {
-using ::ex_actor::internal::reflect::EXA_ACTOR_METHODS_KEYWORD;
-}  // namespace ex_actor::reflect
+}  // namespace ex_actor::internal

--- a/include/ex_actor/internal/remote_handler_registry.h
+++ b/include/ex_actor/internal/remote_handler_registry.h
@@ -37,11 +37,11 @@ class RemoteActorRequestHandlerRegistry {
 
   struct RemoteActorMethodCallHandlerContext {
     TypeErasedActor* actor;
-    serde::BufferReader<network::ByteBufferType> request_buffer;
+    BufferReader<ByteBufferType> request_buffer;
     ActorRefDeserializationInfo info;
   };
   struct RemoteActorCreationHandlerContext {
-    serde::BufferReader<network::ByteBufferType> request_buffer;
+    BufferReader<ByteBufferType> request_buffer;
     std::unique_ptr<TypeErasedActorScheduler> scheduler;
     ActorRefDeserializationInfo info;
   };
@@ -51,7 +51,7 @@ class RemoteActorRequestHandlerRegistry {
   };
 
   using RemoteActorMethodCallHandler =
-      std::function<exec::task<network::ByteBufferType>(RemoteActorMethodCallHandlerContext context)>;
+      std::function<exec::task<ByteBufferType>(RemoteActorMethodCallHandlerContext context)>;
   using RemoteActorCreationHandler = std::function<CreateActorResult(RemoteActorCreationHandlerContext context)>;
 
   void RegisterRemoteActorMethodCallHandler(const std::string& key, RemoteActorMethodCallHandler func) {
@@ -89,19 +89,19 @@ class RemoteFuncHandlerRegistrar {
   explicit RemoteFuncHandlerRegistrar() {
     static_assert(!std::is_member_function_pointer_v<decltype(kActorCreateFn)>,
                   "kActorCreateFn must be a non-member function pointer");
-    using CreateFnSig = reflect::Signature<decltype(kActorCreateFn)>;
+    using CreateFnSig = Signature<decltype(kActorCreateFn)>;
     static_assert(!std::is_void_v<std::decay_t<typename CreateFnSig::ReturnType>>,
                   "kActorCreateFn must return a non-void value");
     static_assert(!std::is_fundamental_v<typename CreateFnSig::ReturnType>,
                   "kActorCreateFn must return a non-fundamental value");
     auto check_fn_class = []<class C, auto kMemberFn>() {
-      using MemberFnSig = reflect::Signature<decltype(kMemberFn)>;
+      using MemberFnSig = Signature<decltype(kMemberFn)>;
       static_assert(std::is_same_v<C, typename MemberFnSig::ClassType>,
                     "Actor methods' class does not match the create function's class");
     };
     (check_fn_class.template operator()<typename CreateFnSig::ReturnType, kActorMethods>(), ...);
     auto register_handler = [this]<auto kFuncPtr>() {
-      std::string func_name = reflect::GetUniqueNameForFunction<kFuncPtr>();
+      std::string func_name = GetUniqueNameForFunction<kFuncPtr>();
       if constexpr (std::is_member_function_pointer_v<decltype(kFuncPtr)>) {
         RemoteActorRequestHandlerRegistry::GetInstance().RegisterRemoteActorMethodCallHandler(
             func_name, [this](RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext context) {
@@ -122,8 +122,8 @@ class RemoteFuncHandlerRegistrar {
   template <auto kCreateFn>
   RemoteActorRequestHandlerRegistry::CreateActorResult DeserializeAndCreateActor(
       RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext context) {
-    using ActorClass = reflect::Signature<decltype(kCreateFn)>::ReturnType;
-    serde::ActorCreationArgs creation_args = serde::DeserializeFnArgs<kCreateFn>(
+    using ActorClass = Signature<decltype(kCreateFn)>::ReturnType;
+    ActorCreationArgs creation_args = DeserializeFnArgs<kCreateFn>(
         context.request_buffer.Current(), context.request_buffer.RemainingSize(), context.info);
     std::unique_ptr<TypeErasedActor> actor = Actor<ActorClass, kCreateFn>::CreateUseArgTuple(
         std::move(context.scheduler), std::move(creation_args.actor_config), std::move(creation_args.args_tuple));
@@ -138,13 +138,13 @@ class RemoteFuncHandlerRegistrar {
    * @returns A coroutine carrying the serialized result of the actor method call.
    */
   template <auto kMethod>
-  exec::task<network::ByteBufferType> DeserializeAndInvokeActorMethod(
+  exec::task<ByteBufferType> DeserializeAndInvokeActorMethod(
       RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext context) {
     EXA_THROW_CHECK(context.actor != nullptr);
-    using Sig = reflect::Signature<decltype(kMethod)>;
-    using UnwrappedType = decltype(reflect::UnwrapReturnSenderIfNested<kMethod>())::type;
+    using Sig = Signature<decltype(kMethod)>;
+    using UnwrappedType = decltype(UnwrapReturnSenderIfNested<kMethod>())::type;
 
-    serde::ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> call_args = serde::DeserializeFnArgs<kMethod>(
+    ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> call_args = DeserializeFnArgs<kMethod>(
         context.request_buffer.Current(), context.request_buffer.RemainingSize(), context.info);
 
     std::vector<char> serialized {};
@@ -153,12 +153,12 @@ class RemoteFuncHandlerRegistrar {
     } else {
       auto return_value =
           co_await context.actor->template CallActorMethodUseTuple<kMethod>(std::move(call_args.args_tuple));
-      serialized = serde::Serialize(serde::ActorMethodReturnValue<UnwrappedType> {std::move(return_value)});
+      serialized = Serialize(ActorMethodReturnValue<UnwrappedType> {std::move(return_value)});
     }
 
-    serde::BufferWriter writer(network::ByteBufferType {sizeof(serde::NetworkRequestType) + serialized.size()});
+    BufferWriter writer(ByteBufferType {sizeof(NetworkRequestType) + serialized.size()});
     // TODO optimize the copy here
-    writer.WritePrimitive(serde::NetworkReplyType::kActorMethodCallReturn);
+    writer.WritePrimitive(NetworkReplyType::kActorMethodCallReturn);
     if constexpr (!std::is_void_v<UnwrappedType>) {
       writer.CopyFrom(serialized.data(), serialized.size());
     }

--- a/include/ex_actor/internal/scheduler.h
+++ b/include/ex_actor/internal/scheduler.h
@@ -68,7 +68,7 @@ class WorkSharingThreadPoolBase {
     void start() noexcept {
       uint32_t priority = UINT32_MAX;
       if constexpr (std::is_same_v<Queue<TypeEasedOperation*>,
-                                   internal::util::UnboundedBlockingPriorityQueue<TypeEasedOperation*>>) {
+                                   internal::UnboundedBlockingPriorityQueue<TypeEasedOperation*>>) {
         auto env = stdexec::get_env(receiver);
         priority = ex_actor::get_priority(env);
       }
@@ -107,7 +107,7 @@ class WorkSharingThreadPoolBase {
 
   void EnqueueOperation(TypeEasedOperation* operation, uint32_t priority = 0) {
     if constexpr (std::is_same_v<Queue<TypeEasedOperation*>,
-                                 internal::util::UnboundedBlockingPriorityQueue<TypeEasedOperation*>>) {
+                                 internal::UnboundedBlockingPriorityQueue<TypeEasedOperation*>>) {
       queue_.Push(operation, priority);
     } else {
       queue_.Push(operation);
@@ -120,7 +120,7 @@ class WorkSharingThreadPoolBase {
   std::vector<std::jthread> workers_;
 
   void WorkerThreadLoop(const std::stop_token& stop_token) {
-    internal::util::SetThreadName("ws_pool_worker");
+    internal::SetThreadName("ws_pool_worker");
     while (!stop_token.stop_requested()) {
       auto optional_operation = queue_.Pop(/*timeout_ms=*/10);
       if (!optional_operation) {
@@ -131,8 +131,8 @@ class WorkSharingThreadPoolBase {
   }
 };
 
-using WorkSharingThreadPool = WorkSharingThreadPoolBase<internal::util::UnboundedBlockingQueue>;
-using PriorityThreadPool = WorkSharingThreadPoolBase<internal::util::UnboundedBlockingPriorityQueue>;
+using WorkSharingThreadPool = WorkSharingThreadPoolBase<internal::UnboundedBlockingQueue>;
+using PriorityThreadPool = WorkSharingThreadPoolBase<internal::UnboundedBlockingPriorityQueue>;
 
 class WorkStealingThreadPool : public exec::static_thread_pool {
  public:

--- a/include/ex_actor/internal/serialization.h
+++ b/include/ex_actor/internal/serialization.h
@@ -28,7 +28,7 @@
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/reflect.h"
 
-namespace ex_actor::internal::serde {
+namespace ex_actor::internal {
 
 template <class T>
 static auto GetCachedSchema() {
@@ -100,7 +100,7 @@ struct ActorLookUpRequest {
 
 template <auto kFn>
 auto DeserializeFnArgs(const uint8_t* data, size_t size, const ActorRefDeserializationInfo& info) {
-  using Sig = reflect::Signature<decltype(kFn)>;
+  using Sig = Signature<decltype(kFn)>;
   if constexpr (std::is_member_function_pointer_v<decltype(kFn)>) {
     return Deserialize<ActorMethodCallArgs<typename Sig::DecayedArgsTupleType>>(data, size, info);
   } else {
@@ -203,4 +203,4 @@ inline std::string BufferToHex(const uint8_t* data, size_t size) {
 inline std::string BufferToHex(const char* data, size_t size) {
   return BufferToHex(reinterpret_cast<const uint8_t*>(data), size);
 }
-}  // namespace ex_actor::internal::serde
+}  // namespace ex_actor::internal

--- a/include/ex_actor/internal/util.h
+++ b/include/ex_actor/internal/util.h
@@ -30,7 +30,7 @@
 #include "ex_actor/internal/alias.h"  // IWYU pragma: keep
 #include "ex_actor/internal/logging.h"
 
-namespace ex_actor::util {
+namespace ex_actor {
 /**
  * @brief A std::execution style semaphore. support on_negative sender.
  */
@@ -106,9 +106,9 @@ class Semaphore {
   std::atomic_int64_t count_;
 };
 
-};  // namespace ex_actor::util
+};  // namespace ex_actor
 
-namespace ex_actor::internal::util {
+namespace ex_actor::internal {
 
 template <class T>
 struct LinearizableUnboundedMpscQueue {
@@ -287,11 +287,7 @@ class MoveOnlyAny {
   std::unique_ptr<AnyValueHolder> value_holder_;
 };
 
-#if defined(_WIN32)
-inline void SetThreadName(const std::string& name) {
-  // TODO
-}
-#elif defined(__linux__)
+#if defined(__linux__)
 #include <pthread.h>
 inline void SetThreadName(const std::string& name) { pthread_setname_np(pthread_self(), name.c_str()); }
 #else
@@ -301,4 +297,10 @@ inline void SetThreadName(const std::string&) {}
 inline auto WrapSenderWithInlineScheduler(auto task) {
   return std::move(task) | stdexec::write_env(ex::prop {stdexec::get_scheduler, stdexec::inline_scheduler {}});
 }
-}  // namespace ex_actor::internal::util
+}  // namespace ex_actor::internal
+
+// Backward-compatibility alias — this namespace was removed in favor of ex_actor.
+// Use ex_actor::Semaphore directly.
+namespace ex_actor::util {
+using Semaphore [[deprecated("Use ex_actor::Semaphore instead")]] = ex_actor::Semaphore;
+}  // namespace ex_actor::util

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -23,7 +23,7 @@ namespace ex_actor::internal {
 // ----------------------ActorRegistryBackend--------------------------
 ActorRegistryBackend::ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler, uint32_t this_node_id,
                                            const std::vector<NodeInfo>& cluster_node_info,
-                                           network::MessageBroker* message_broker)
+                                           MessageBroker* message_broker)
     : is_distributed_mode_(!cluster_node_info.empty()),
       scheduler_(std::move(scheduler)),
       this_node_id_(this_node_id),
@@ -35,44 +35,42 @@ ActorRegistryBackend::ActorRegistryBackend(std::unique_ptr<TypeErasedActorSchedu
 exec::task<void> ActorRegistryBackend::AsyncDestroyAllActors() {
   exec::async_scope async_scope;
   // bulk destroy actors
-  logging::Info("Sending destroy messages to actors");
+  log::Info("Sending destroy messages to actors");
   for (auto& [_, actor] : actor_id_to_actor_) {
     async_scope.spawn(actor->AsyncDestroy());
   }
-  logging::Info("Waiting for actors to be destroyed");
+  log::Info("Waiting for actors to be destroyed");
   co_await async_scope.on_empty();
-  logging::Info("All actors destroyed");
+  log::Info("All actors destroyed");
 }
 
 exec::task<void> ActorRegistryBackend::HandleNetworkRequest(uint64_t received_request_id,
-                                                            network::ByteBufferType request_buffer) {
-  serde::BufferReader<network::ByteBufferType> reader(std::move(request_buffer));
-  auto message_type = reader.NextPrimitive<serde::NetworkRequestType>();
+                                                            ByteBufferType request_buffer) {
+  BufferReader<ByteBufferType> reader(std::move(request_buffer));
+  auto message_type = reader.NextPrimitive<NetworkRequestType>();
 
-  if (message_type == serde::NetworkRequestType::kActorCreationRequest) {
+  if (message_type == NetworkRequestType::kActorCreationRequest) {
     HandleActorCreationRequest(received_request_id, std::move(reader));
     co_return;
   }
 
-  if (message_type == serde::NetworkRequestType::kActorMethodCallRequest) {
+  if (message_type == NetworkRequestType::kActorMethodCallRequest) {
     co_await HandleActorMethodCallRequest(received_request_id, std::move(reader));
     co_return;
   }
 
-  if (message_type == serde::NetworkRequestType::kActorLookUpRequest) {
-    auto actor_name =
-        serde::Deserialize<serde::ActorLookUpRequest>(reader.Current(), reader.RemainingSize()).actor_name;
+  if (message_type == NetworkRequestType::kActorLookUpRequest) {
+    auto actor_name = Deserialize<ActorLookUpRequest>(reader.Current(), reader.RemainingSize()).actor_name;
 
     if (actor_name_to_id_.contains(actor_name)) {
-      serde::BufferWriter<network::ByteBufferType> writer(
-          network::ByteBufferType(sizeof(serde::NetworkRequestType) + sizeof(uint64_t)));
+      BufferWriter<ByteBufferType> writer(ByteBufferType(sizeof(NetworkRequestType) + sizeof(uint64_t)));
       auto actor_id = actor_name_to_id_.at(actor_name);
-      writer.WritePrimitive(serde::NetworkReplyType::kActorLookUpReturn);
+      writer.WritePrimitive(NetworkReplyType::kActorLookUpReturn);
       writer.WritePrimitive(actor_id);
       message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
     } else {
-      serde::BufferWriter writer(network::ByteBufferType(sizeof(serde::NetworkRequestType)));
-      writer.WritePrimitive(serde::NetworkReplyType::kActorLookUpError);
+      BufferWriter writer(ByteBufferType(sizeof(NetworkRequestType)));
+      writer.WritePrimitive(NetworkReplyType::kActorLookUpError);
       message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
     }
     co_return;
@@ -101,22 +99,22 @@ void ActorRegistryBackend::ValidateNodeInfo(const std::vector<NodeInfo>& cluster
   }
 }
 
-serde::NetworkRequestType ActorRegistryBackend::ParseMessageType(const network::ByteBufferType& buffer) {
+NetworkRequestType ActorRegistryBackend::ParseMessageType(const ByteBufferType& buffer) {
   EXA_THROW_CHECK_LE(buffer.size(), 1) << "Invalid buffer size, " << buffer.size();
-  return static_cast<serde::NetworkRequestType>(*static_cast<const uint8_t*>(buffer.data()));
+  return static_cast<NetworkRequestType>(*static_cast<const uint8_t*>(buffer.data()));
 }
 
-void ActorRegistryBackend::ReplyError(uint64_t received_request_id, serde::NetworkReplyType reply_type,
+void ActorRegistryBackend::ReplyError(uint64_t received_request_id, NetworkReplyType reply_type,
                                       std::string error_msg) {
-  std::vector<char> serialized = serde::Serialize(serde::ActorMethodReturnError {std::move(error_msg)});
-  serde::BufferWriter writer(network::ByteBufferType(sizeof(serde::NetworkRequestType) + serialized.size()));
+  std::vector<char> serialized = Serialize(ActorMethodReturnError {std::move(error_msg)});
+  BufferWriter writer(ByteBufferType(sizeof(NetworkRequestType) + serialized.size()));
   writer.WritePrimitive(reply_type);
   writer.CopyFrom(serialized.data(), serialized.size());
   message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
 }
 
 void ActorRegistryBackend::HandleActorCreationRequest(uint64_t received_request_id,
-                                                      serde::BufferReader<network::ByteBufferType> reader) {
+                                                      BufferReader<ByteBufferType> reader) {
   auto handler_key_len = reader.NextPrimitive<uint64_t>();
   auto handler_key = reader.PullString(handler_key_len);
   try {
@@ -138,25 +136,24 @@ void ActorRegistryBackend::HandleActorCreationRequest(uint64_t received_request_
       actor_name_to_id_[result.actor_name.value()] = actor_id;
     }
     actor_id_to_actor_[actor_id] = std::move(result.actor);
-    serde::BufferWriter<network::ByteBufferType> writer(
-        network::ByteBufferType(sizeof(serde::NetworkReplyType) + sizeof(actor_id)));
-    writer.WritePrimitive(serde::NetworkReplyType::kActorCreationReturn);
+    BufferWriter<ByteBufferType> writer(ByteBufferType(sizeof(NetworkReplyType) + sizeof(actor_id)));
+    writer.WritePrimitive(NetworkReplyType::kActorCreationReturn);
     writer.WritePrimitive(actor_id);
     message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    ReplyError(received_request_id, serde::NetworkReplyType::kActorCreationError, std::move(error_msg));
+    ReplyError(received_request_id, NetworkReplyType::kActorCreationError, std::move(error_msg));
   }
 }
 
-exec::task<void> ActorRegistryBackend::HandleActorMethodCallRequest(
-    uint64_t received_request_id, serde::BufferReader<network::ByteBufferType> reader) {
+exec::task<void> ActorRegistryBackend::HandleActorMethodCallRequest(uint64_t received_request_id,
+                                                                    BufferReader<ByteBufferType> reader) {
   auto handler_key_len = reader.NextPrimitive<uint64_t>();
   auto handler_key = reader.PullString(handler_key_len);
   auto actor_id = reader.NextPrimitive<uint64_t>();
   if (!actor_id_to_actor_.contains(actor_id)) {
     ReplyError(
-        received_request_id, serde::NetworkReplyType::kActorMethodCallError,
+        received_request_id, NetworkReplyType::kActorMethodCallError,
         fmt_lib::format("Can't find actor at remote node, actor_id={}, node_id={}, maybe it's already destroyed.",
                         actor_id, this_node_id_));
     co_return;
@@ -167,7 +164,7 @@ exec::task<void> ActorRegistryBackend::HandleActorMethodCallRequest(
     handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorMethodCallHandler(handler_key);
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    ReplyError(received_request_id, serde::NetworkReplyType::kActorMethodCallError, std::move(error_msg));
+    ReplyError(received_request_id, NetworkReplyType::kActorMethodCallError, std::move(error_msg));
     co_return;
   }
 
@@ -187,39 +184,39 @@ exec::task<void> ActorRegistryBackend::HandleActorMethodCallRequest(
     message_broker_->ReplyRequest(received_request_id, std::move(buffer));
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    ReplyError(received_request_id, serde::NetworkReplyType::kActorMethodCallError, std::move(error_msg));
+    ReplyError(received_request_id, NetworkReplyType::kActorMethodCallError, std::move(error_msg));
   }
 }
 
 // ----------------------ActorRegistry--------------------------
 ActorRegistry::~ActorRegistry() {
-  logging::Info("Start to shutdown actor registry");
+  log::Info("Start to shutdown actor registry");
   if (is_distributed_mode_) {
     message_broker_->ClusterAlignedStop();
   }
   ex::sync_wait(backend_actor_.CallActorMethod<&ActorRegistryBackend::AsyncDestroyAllActors>());
   ex::sync_wait(backend_actor_.AsyncDestroy());
   ex::sync_wait(async_scope_.on_empty());
-  logging::Info("Actor registry shutdown completed");
+  log::Info("Actor registry shutdown completed");
 }
 
 ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler,
                              uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info,
-                             network::HeartbeatConfig heartbeat_config)
+                             HeartbeatConfig heartbeat_config)
     : is_distributed_mode_(!cluster_node_info.empty()),
       this_node_id_(this_node_id),
       default_work_sharing_thread_pool_(thread_pool_size),
       scheduler_(scheduler != nullptr ? std::move(scheduler)
                                       : std::make_unique<AnyStdExecScheduler<WorkSharingThreadPool::Scheduler>>(
                                             default_work_sharing_thread_pool_.GetScheduler())),
-      message_broker_([&cluster_node_info, &heartbeat_config, this]() -> std::unique_ptr<network::MessageBroker> {
+      message_broker_([&cluster_node_info, &heartbeat_config, this]() -> std::unique_ptr<MessageBroker> {
         if (cluster_node_info.empty()) {
           return nullptr;
         }
-        return std::make_unique<network::MessageBroker>(
+        return std::make_unique<MessageBroker>(
             cluster_node_info, this_node_id_,
             /*request_handler=*/
-            [this](uint64_t received_request_id, network::ByteBufferType data) {
+            [this](uint64_t received_request_id, ByteBufferType data) {
               auto task = backend_actor_.CallActorMethod<&ActorRegistryBackend::HandleNetworkRequest>(
                   received_request_id, std::move(data));
               async_scope_.spawn(std::move(task));
@@ -271,7 +268,7 @@ static void RegisterAtExitCleanup() {
     if (!IsGlobalDefaultRegistryInitialized()) {
       return;
     }
-    logging::Error(
+    log::Error(
         "ex_actor is not shutdown when exiting main(), calling std::quick_exit(1) to force exit, resources may not be "
         "cleaned properly. To fix this error, call ex_actor::Shutdown() before main() exits.");
     std::quick_exit(1);
@@ -279,22 +276,22 @@ static void RegisterAtExitCleanup() {
 }
 
 void SetupGlobalHandlers() {
-  logging::InstallFallbackExceptionHandler();
+  InstallFallbackExceptionHandler();
   RegisterAtExitCleanup();
 }
 }  // namespace ex_actor::internal
 
 namespace ex_actor {
 void Init(uint32_t thread_pool_size) {
-  internal::logging::Info("Initializing ex_actor in single-node mode with default scheduler, thread_pool_size={}",
-                          thread_pool_size);
+  internal::log::Info("Initializing ex_actor in single-node mode with default scheduler, thread_pool_size={}",
+                      thread_pool_size);
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size);
   internal::SetupGlobalHandlers();
 }
 
 void Init(uint32_t thread_pool_size, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info) {
-  internal::logging::Info(
+  internal::log::Info(
       "Initializing ex_actor in distributed mode with default scheduler, thread_pool_size={}, this_node_id={}, "
       "total_nodes={}",
       thread_pool_size, this_node_id, cluster_node_info.size());
@@ -306,14 +303,12 @@ void Init(uint32_t thread_pool_size, uint32_t this_node_id, const std::vector<No
 void HoldResource(std::shared_ptr<void> resource) { resource_holder.push_back(std::move(resource)); }
 
 void Shutdown() {
-  internal::logging::Info("Shutting down ex_actor.");
+  internal::log::Info("Shutting down ex_actor.");
   EXA_THROW_CHECK(internal::IsGlobalDefaultRegistryInitialized()) << "Not initialized.";
   global_default_registry.reset();
   resource_holder.clear();
 }
 
-void ConfigureLogging(const logging::LogConfig& config) {
-  internal::logging::GlobalLogger() = internal::logging::CreateLoggerUsingConfig(config);
-}
+void ConfigureLogging(const LogConfig& config) { internal::GlobalLogger() = internal::CreateLoggerUsingConfig(config); }
 
 }  // namespace ex_actor

--- a/src/ex_actor/internal/logging.cc
+++ b/src/ex_actor/internal/logging.cc
@@ -5,8 +5,8 @@
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 
-namespace ex_actor::internal::logging {
-using ex_actor::logging::LogLevel;
+namespace ex_actor::internal {
+using ex_actor::LogLevel;
 
 spdlog::level::level_enum ToSpdlogLevel(LogLevel level) {
   switch (level) {
@@ -24,7 +24,7 @@ spdlog::level::level_enum ToSpdlogLevel(LogLevel level) {
   EXA_THROW << "Invalid log level: " << level;
 }
 
-std::unique_ptr<spdlog::logger> CreateLoggerUsingConfig(const ex_actor::logging::LogConfig& config) {
+std::unique_ptr<spdlog::logger> CreateLoggerUsingConfig(const ex_actor::LogConfig& config) {
   constexpr char kLoggerName[] = "ex_actor";
   std::unique_ptr<spdlog::logger> logger;
   if (config.log_file_path.empty()) {
@@ -49,14 +49,14 @@ void InstallFallbackExceptionHandler() {
       try {
         std::rethrow_exception(ex);
       } catch (const std::exception& e) {
-        logging::Critical("terminate called with an active exception, type: {}, what: {}", typeid(e).name(), e.what());
+        log::Critical("terminate called with an active exception, type: {}, what: {}", typeid(e).name(), e.what());
       } catch (...) {
-        logging::Critical("terminate called with an unknown exception");
+        log::Critical("terminate called with an unknown exception");
       }
     } else {
-      logging::Critical("terminate called without an active exception");
+      log::Critical("terminate called without an active exception");
     }
     std::abort();
   });
 };
-}  // namespace ex_actor::internal::logging
+}  // namespace ex_actor::internal

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -14,7 +14,7 @@ using testing::HasSubstr;
 using testing::Property;
 using testing::Throws;
 
-namespace logging = ex_actor::internal::logging;
+namespace logging = ex_actor::internal::log;
 
 class A {
  public:

--- a/test/logging_test.cc
+++ b/test/logging_test.cc
@@ -55,7 +55,7 @@ TEST(LoggingTest, InitShutdownWithoutConfigureLogging) {
   ex_actor::Shutdown();
 
   // flush log
-  ex_actor::internal::logging::GlobalLogger()->flush();
+  ex_actor::internal::GlobalLogger()->flush();
 
   // Read log file and verify both Init and Shutdown logs are present
   std::string log_contents = ReadFile(log_file);
@@ -78,7 +78,7 @@ TEST(LoggingTest, ConfigureLoggingWithErrorLevel) {
 
   // Configure logging to file with Error level (should filter out Info logs)
   ex_actor::ConfigureLogging({
-      .level = ex_actor::logging::LogLevel::kError,
+      .level = ex_actor::LogLevel::kError,
       .log_file_path = log_file,
   });
 
@@ -87,7 +87,7 @@ TEST(LoggingTest, ConfigureLoggingWithErrorLevel) {
   ex_actor::Shutdown();
 
   // flush log
-  ex_actor::internal::logging::GlobalLogger()->flush();
+  ex_actor::internal::GlobalLogger()->flush();
 
   // Read log file - should be empty or not contain Info logs
   std::string log_contents = ReadFile(log_file);
@@ -112,7 +112,7 @@ TEST(LoggingTest, ConfigureLoggingInMiddle) {
 
   // Configure logging to file with Info level initially
   ex_actor::ConfigureLogging({
-      .level = ex_actor::logging::LogLevel::kInfo,
+      .level = ex_actor::LogLevel::kInfo,
       .log_file_path = log_file,
   });
 
@@ -121,7 +121,7 @@ TEST(LoggingTest, ConfigureLoggingInMiddle) {
 
   // Change log level to Error in the middle
   ex_actor::ConfigureLogging({
-      .level = ex_actor::logging::LogLevel::kError,
+      .level = ex_actor::LogLevel::kError,
       .log_file_path = log_file,
   });
 
@@ -129,7 +129,7 @@ TEST(LoggingTest, ConfigureLoggingInMiddle) {
   ex_actor::Shutdown();
 
   // flush log
-  ex_actor::internal::logging::GlobalLogger()->flush();
+  ex_actor::internal::GlobalLogger()->flush();
 
   // Read log file
   std::string log_contents = ReadFile(log_file);

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -3,7 +3,7 @@
 
 #include "ex_actor/api.h"
 
-namespace logging = ex_actor::internal::logging;
+namespace logging = ex_actor::internal::log;
 
 class PingWorker {
  public:

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -7,8 +7,8 @@
 
 #include "ex_actor/api.h"
 
-using ex_actor::internal::network::ByteBufferType;
-namespace logging = ex_actor::internal::logging;
+using ex_actor::internal::ByteBufferType;
+namespace logging = ex_actor::internal::log;
 
 TEST(NetworkTest, MessageBrokerTest) {
   auto test_once = []() {
@@ -17,8 +17,8 @@ TEST(NetworkTest, MessageBrokerTest) {
                                                  {.node_id = 2, .address = "tcp://127.0.0.1:5203"}};
 
     auto node_main = [](const std::vector<ex_actor::NodeInfo>& node_list, uint32_t node_id) {
-      ex_actor::internal::util::SetThreadName("node_" + std::to_string(node_id));
-      ex_actor::internal::network::MessageBroker message_broker(
+      ex_actor::internal::SetThreadName("node_" + std::to_string(node_id));
+      ex_actor::internal::MessageBroker message_broker(
           node_list,
           /*this_node_id=*/node_id, [&message_broker](uint64_t received_request_id, ByteBufferType data) {
             message_broker.ReplyRequest(received_request_id, std::move(data));

--- a/test/skynet_test.cc
+++ b/test/skynet_test.cc
@@ -10,7 +10,7 @@
 #include "ex_actor/api.h"
 
 namespace ex = stdexec;
-namespace logging = ex_actor::internal::logging;
+namespace logging = ex_actor::internal::log;
 
 struct SkynetActor;
 

--- a/test/util_test.cc
+++ b/test/util_test.cc
@@ -5,7 +5,7 @@
 #include "ex_actor/api.h"
 
 TEST(UtilTest, SemaphoreBasicUsageCase) {
-  ex_actor::util::Semaphore semaphore(0);
+  ex_actor::Semaphore semaphore(0);
   ex_actor::ex::sync_wait(semaphore.OnDrained());
   ASSERT_EQ(semaphore.Release(10), 10);
   std::jthread t([&semaphore]() {


### PR DESCRIPTION
only keeps 2 namespaces `ex_actor` and `ex_actor::internal`, to make development easier.