### PR TITLE
[API] Simplify distributed mode API

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -18,17 +18,17 @@ class YourClass  {
   void Method2() {};
 };
 
-YourClass FactoryCreate() { return YourClass(); }
-EXA_REMOTE(&FactoryCreate, &YourClass::Method1, &YourClass::Method2);
+YourClass CreateFn() { return YourClass(); }
+EXA_REMOTE(&CreateFn, &YourClass::Method1, &YourClass::Method2);
 ```
 
 In the `EXA_REMOTE` macro, the first argument is a factory function to create your class, and the rest are the methods you want to call remotely.
 
 This is used to generate a serialization schema for network communication.
 
-Then instead of calling `ex_actor::Spawn<YourClass>()`, you need to call `ex_actor::Spawn<YourClass, &FactoryCreate>()`. Or an exception will be thrown.
+Then instead of calling `ex_actor::Spawn<YourClass>()`, you need to call `ex_actor::Spawn<&CreateFn>()`. Or an exception will be thrown.
 
-✨ **BTW, this can be simplified in C++26 using reflection, I'll implement it when C++26 is released, stay tuned!** ✨
+Such boilerplate is caused by the lack of reflection before C++26. It can be simplified in C++26 using reflection, we'll add a new set of APIs for C++26 in the future, stay tuned!
 
 ## Example
 
@@ -58,7 +58,7 @@ exec::task<void> MainCoroutine(uint32_t this_node_id, size_t total_nodes) {
   uint32_t remote_node_id = (this_node_id + 1) % total_nodes;
 
   // 2. Specify the factory function in ex_actor::Spawn
-  auto ping_worker = co_await ex_actor::Spawn<PingWorker, &PingWorker::FactoryCreate>(
+  auto ping_worker = co_await ex_actor::Spawn<&PingWorker::FactoryCreate>(
       ex_actor::ActorConfig {.node_id = remote_node_id}, /*name=*/"Alice");
   std::string ping_res = co_await ping_worker.Send<&PingWorker::Ping>("hello");
   assert(ping_res == "ack from Alice, msg got: hello");

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -48,95 +48,62 @@ class ActorRegistryBackend {
   exec::task<void> AsyncDestroyAllActors();
 
   /**
-   * @brief Spawn an actor at current node using default config.
+   * @brief Spawn a local actor with config.
    */
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  exec::task<ActorRef<UserClass>> Spawn(Args... args) {
-    return Spawn<UserClass, kCreateFn>(ActorConfig {.node_id = this_node_id_}, std::move(args)...);
+  template <class UserClass, class... Args>
+  exec::task<ActorRef<UserClass>> SpawnWithClass(ActorConfig config, Args... args) {
+    if (config.node_id != this_node_id_) {
+      EXA_THROW << "Spawn<UserClass> can only be used to create local actor, to create remote actor, use "
+                   "Spawn<&CreateFn> to provide a fixed signature for remote actor creation. node_id="
+                << config.node_id << ", this_node_id=" << this_node_id_ << ", actor_type=" << typeid(UserClass).name();
+    }
+    co_return co_await SpawnLocal<UserClass>(std::move(config), std::move(args)...);
   }
 
   /**
-   * @brief Spawn an actor with a manually specified config.
+   * @brief Spawn an actor (local or remote) using a factory function, with config.
    */
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  exec::task<ActorRef<UserClass>> Spawn(ActorConfig config, Args... args) {
-    if constexpr (kCreateFn != nullptr) {
-      static_assert(std::is_invocable_v<decltype(kCreateFn), Args...>,
-                    "Class can't be created by given args and create function");
-    }
+  template <auto kCreateFn, class... Args>
+  exec::task<ActorRef<FnReturnType<kCreateFn>>> SpawnWithCreateFn(ActorConfig config, Args... args) {
+    using UserClass = FnReturnType<kCreateFn>;
+    static_assert(std::is_invocable_v<decltype(kCreateFn), Args...>,
+                  "Class can't be created by given args and create function");
 
-    // local actor, create directly
     if (config.node_id == this_node_id_) {
-      auto actor_id = GenerateRandomActorId();
-      auto actor = std::make_unique<Actor<UserClass, kCreateFn>>(scheduler_->Clone(), config, std::move(args)...);
-      auto handle = ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, actor.get(), message_broker_);
-      if (config.actor_name.has_value()) {
-        std::string& name = *config.actor_name;
-        EXA_THROW_CHECK(!actor_name_to_id_.contains(name))
-            << "An actor with the same name already exists, name=" << name;
-        actor_name_to_id_[name] = actor_id;
-      }
-      actor_id_to_actor_[actor_id] = std::move(actor);
-      co_return handle;
-    }
-
-    if constexpr (kCreateFn == nullptr) {
-      EXA_THROW << "Spawn<UserClass> can only be used to create local actor, to create remote actor, use "
-                   "Spawn<UserClass, kCreateFn> to provide a fixed signature for remote actor creation. node_id="
-                << config.node_id << ", this_node_id=" << this_node_id_ << ", actor_type=" << typeid(UserClass).name();
+      co_return co_await SpawnLocal<UserClass, kCreateFn>(std::move(config), std::move(args)...);
     }
 
     if (message_broker_ != nullptr) {
       EXA_THROW_CHECK(message_broker_->CheckNodeConnected(config.node_id)) << "Can't find node " << config.node_id;
     }
 
-    if constexpr (kCreateFn != nullptr) {
-      using CreateFnSig = Signature<decltype(kCreateFn)>;
+    using CreateFnSig = Signature<decltype(kCreateFn)>;
 
-      // protocol: [message_type][handler_key_len][handler_key][ActorCreationArgs]
-      typename CreateFnSig::DecayedArgsTupleType args_tuple {std::move(args)...};
-      ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config, std::move(args_tuple)};
-      std::vector<char> serialized = Serialize(actor_creation_args);
-      std::string handler_key = GetUniqueNameForFunction<kCreateFn>();
-      BufferWriter buffer_writer(
-          ByteBufferType {serialized.size() + sizeof(uint64_t) + handler_key.size() + sizeof(NetworkRequestType)});
-      buffer_writer.WritePrimitive(NetworkRequestType::kActorCreationRequest);
-      buffer_writer.WritePrimitive(handler_key.size());
-      // TODO optimize the copy here
-      buffer_writer.CopyFrom(handler_key.data(), handler_key.size());
-      buffer_writer.CopyFrom(serialized.data(), serialized.size());
-      EXA_THROW_CHECK(buffer_writer.EndReached()) << "Buffer writer not ended";
+    // protocol: [message_type][handler_key_len][handler_key][ActorCreationArgs]
+    typename CreateFnSig::DecayedArgsTupleType args_tuple {std::move(args)...};
+    ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config, std::move(args_tuple)};
+    std::vector<char> serialized = Serialize(actor_creation_args);
+    std::string handler_key = GetUniqueNameForFunction<kCreateFn>();
+    BufferWriter buffer_writer(
+        ByteBufferType {serialized.size() + sizeof(uint64_t) + handler_key.size() + sizeof(NetworkRequestType)});
+    buffer_writer.WritePrimitive(NetworkRequestType::kActorCreationRequest);
+    buffer_writer.WritePrimitive(handler_key.size());
+    // TODO optimize the copy here
+    buffer_writer.CopyFrom(handler_key.data(), handler_key.size());
+    buffer_writer.CopyFrom(serialized.data(), serialized.size());
+    EXA_THROW_CHECK(buffer_writer.EndReached()) << "Buffer writer not ended";
 
-      // send to remote
-      auto response_buffer =
-          co_await message_broker_->SendRequest(config.node_id, std::move(buffer_writer).MoveBufferOut());
-      BufferReader reader(std::move(response_buffer));
-      auto type = reader.template NextPrimitive<NetworkReplyType>();
-      if (type == NetworkReplyType::kActorCreationError) {
-        EXA_THROW << "Got actor creation error from remote node:"
-                  << Deserialize<ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
-      }
-      auto actor_id = reader.template NextPrimitive<uint64_t>();
-      co_return ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, nullptr, message_broker_);
+    // send to remote
+    auto response_buffer =
+        co_await message_broker_->SendRequest(config.node_id, std::move(buffer_writer).MoveBufferOut());
+    BufferReader reader(std::move(response_buffer));
+    auto type = reader.template NextPrimitive<NetworkReplyType>();
+    if (type == NetworkReplyType::kActorCreationError) {
+      EXA_THROW << "Got actor creation error from remote node:"
+                << Deserialize<ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
     }
-  }
-
-  /**
-   * @brief Backward-compatible alias for Spawn.
-   */
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  [[deprecated("Use Spawn() instead of CreateActor().")]]
-  exec::task<ActorRef<UserClass>> CreateActor(Args... args) {
-    return Spawn<UserClass, kCreateFn>(std::move(args)...);
-  }
-
-  /**
-   * @brief Backward-compatible alias for Spawn.
-   */
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  [[deprecated("Use Spawn() instead of CreateActor().")]]
-  exec::task<ActorRef<UserClass>> CreateActor(ActorConfig config, Args... args) {
-    return Spawn<UserClass, kCreateFn>(std::move(config), std::move(args)...);
+    auto actor_id = reader.template NextPrimitive<uint64_t>();
+    co_return ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, nullptr, message_broker_);
   }
 
   template <class UserClass>
@@ -195,6 +162,20 @@ class ActorRegistryBackend {
   exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms);
 
  private:
+  template <class UserClass, auto kCreateFn = nullptr, class... Args>
+  exec::task<ActorRef<UserClass>> SpawnLocal(ActorConfig config, Args... args) {
+    auto actor_id = GenerateRandomActorId();
+    auto actor = std::make_unique<Actor<UserClass, kCreateFn>>(scheduler_->Clone(), config, std::move(args)...);
+    auto handle = ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, actor.get(), message_broker_);
+    if (config.actor_name.has_value()) {
+      std::string& name = *config.actor_name;
+      EXA_THROW_CHECK(!actor_name_to_id_.contains(name)) << "An actor with the same name already exists, name=" << name;
+      actor_name_to_id_[name] = actor_id;
+    }
+    actor_id_to_actor_[actor_id] = std::move(actor);
+    co_return handle;
+  }
+
   std::mt19937 random_num_generator_;
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
   uint32_t this_node_id_ = 0;
@@ -247,25 +228,43 @@ class ActorRegistry {
   ~ActorRegistry();
 
   /**
-   * @brief Spawn an actor at current node using default config.
+   * @brief Spawn a local actor at current node using default config.
    */
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
+  template <class UserClass, class... Args>
   AwaitableOf<ActorRef<UserClass>> auto Spawn(Args... args) {
-    // resolve overload ambiguity
-    constexpr exec::task<ActorRef<UserClass>> (ActorRegistryBackend::*kProcessFn)(Args...) =
-        &ActorRegistryBackend::Spawn<UserClass, kCreateFn, Args...>;
-    return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(std::move(args)...));
+    return WrapSenderWithInlineScheduler(
+        backend_actor_ref_.SendLocal<&ActorRegistryBackend::SpawnWithClass<UserClass, Args...>>(
+            ActorConfig {.node_id = this_node_id_}, std::move(args)...));
   }
 
   /**
-   * @brief Spawn an actor with a manually specified config.
+   * @brief Spawn a local actor with a manually specified config.
    */
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
+  template <class UserClass, class... Args>
   AwaitableOf<ActorRef<UserClass>> auto Spawn(ActorConfig config, Args... args) {
-    // resolve overload ambiguity
-    constexpr exec::task<ActorRef<UserClass>> (ActorRegistryBackend::*kProcessFn)(ActorConfig, Args...) =
-        &ActorRegistryBackend::Spawn<UserClass, kCreateFn, Args...>;
-    return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(config, std::move(args)...));
+    return WrapSenderWithInlineScheduler(
+        backend_actor_ref_.SendLocal<&ActorRegistryBackend::SpawnWithClass<UserClass, Args...>>(config,
+                                                                                                std::move(args)...));
+  }
+
+  /**
+   * @brief Spawn an actor (local or remote) using a factory function, at current node using default config.
+   */
+  template <auto kCreateFn, class... Args>
+  AwaitableOf<ActorRef<FnReturnType<kCreateFn>>> auto Spawn(Args... args) {
+    return WrapSenderWithInlineScheduler(
+        backend_actor_ref_.SendLocal<&ActorRegistryBackend::SpawnWithCreateFn<kCreateFn, Args...>>(
+            ActorConfig {.node_id = this_node_id_}, std::move(args)...));
+  }
+
+  /**
+   * @brief Spawn an actor (local or remote) using a factory function, with a manually specified config.
+   */
+  template <auto kCreateFn, class... Args>
+  AwaitableOf<ActorRef<FnReturnType<kCreateFn>>> auto Spawn(ActorConfig config, Args... args) {
+    return WrapSenderWithInlineScheduler(
+        backend_actor_ref_.SendLocal<&ActorRegistryBackend::SpawnWithCreateFn<kCreateFn, Args...>>(config,
+                                                                                                   std::move(args)...));
   }
 
   template <class UserClass>
@@ -304,16 +303,16 @@ class ActorRegistry {
   // ------------deprecated APIs------------
 
   /// Backward-compatible alias for Spawn.
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
+  template <class UserClass, class... Args>
   [[deprecated("Use Spawn() instead of CreateActor().")]]
   AwaitableOf<ActorRef<UserClass>> auto CreateActor(Args... args) {
-    return Spawn<UserClass, kCreateFn>(std::move(args)...);
+    return Spawn<UserClass, Args...>(std::move(args)...);
   }
   /// Backward-compatible alias for Spawn.
-  template <class UserClass, auto kCreateFn = nullptr, class... Args>
+  template <class UserClass, class... Args>
   [[deprecated("Use Spawn() instead of CreateActor().")]]
   AwaitableOf<ActorRef<UserClass>> auto CreateActor(ActorConfig config, Args... args) {
-    return Spawn<UserClass, kCreateFn>(std::move(config), std::move(args)...);
+    return Spawn<UserClass, Args...>(std::move(config), std::move(args)...);
   }
 
  private:
@@ -375,19 +374,35 @@ void HoldResource(std::shared_ptr<void> resource);
 void Shutdown();
 
 /**
- * @brief Spawn an actor at current node using default config.
+ * @brief Spawn a local actor at current node using default config.
  */
-template <class UserClass, auto kCreateFn = nullptr, class... Args>
+template <class UserClass, class... Args>
 internal::AwaitableOf<ActorRef<UserClass>> auto Spawn(Args... args) {
-  return internal::GetGlobalDefaultRegistry().Spawn<UserClass, kCreateFn, Args...>(std::move(args)...);
+  return internal::GetGlobalDefaultRegistry().Spawn<UserClass, Args...>(std::move(args)...);
 }
 
 /**
- * @brief Spawn an actor with a manually specified config.
+ * @brief Spawn a local actor with a manually specified config.
  */
-template <class UserClass, auto kCreateFn = nullptr, class... Args>
+template <class UserClass, class... Args>
 internal::AwaitableOf<ActorRef<UserClass>> auto Spawn(ActorConfig config, Args... args) {
-  return internal::GetGlobalDefaultRegistry().Spawn<UserClass, kCreateFn, Args...>(config, std::move(args)...);
+  return internal::GetGlobalDefaultRegistry().Spawn<UserClass, Args...>(config, std::move(args)...);
+}
+
+/**
+ * @brief Spawn an actor (local or remote) using a factory function, at current node using default config.
+ */
+template <auto kCreateFn, class... Args>
+internal::AwaitableOf<ActorRef<internal::FnReturnType<kCreateFn>>> auto Spawn(Args... args) {
+  return internal::GetGlobalDefaultRegistry().Spawn<kCreateFn, Args...>(std::move(args)...);
+}
+
+/**
+ * @brief Spawn an actor (local or remote) using a factory function, with a manually specified config.
+ */
+template <auto kCreateFn, class... Args>
+internal::AwaitableOf<ActorRef<internal::FnReturnType<kCreateFn>>> auto Spawn(ActorConfig config, Args... args) {
+  return internal::GetGlobalDefaultRegistry().Spawn<kCreateFn, Args...>(config, std::move(args)...);
 }
 
 /**

--- a/include/ex_actor/internal/reflect.h
+++ b/include/ex_actor/internal/reflect.h
@@ -115,4 +115,7 @@ std::string GetUniqueNameForFunction() {
   // it's an unique mangled name. So it works now, maybe replace it with a more robust way in the future.
   return typeid(kFunc).name();
 }
+template <auto kFn>
+using FnReturnType = std::decay_t<typename Signature<decltype(kFn)>::ReturnType>;
+
 }  // namespace ex_actor::internal

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -120,7 +120,7 @@ TEST(BasicApiTest, SpawnWithFullConfig) {
     i.e. you can't `co_await Spawn<X>(ActorConfig {.actor_name = "A"})`, instead, you should do this:
     ```cpp
     ex_actor::ActorConfig a_config {.actor_name = "A"};
-    auto remote_a = co_await registry.Spawn<A, &A::Create>(a_config);
+    auto remote_a = co_await registry.Spawn<&A::Create>(a_config);
     ```
 
     see https://gcc.gnu.org/pipermail/gcc-bugs/2022-October/800402.html

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -121,9 +121,8 @@ TEST(DistributedTest, ConstructionInDistributedModeWithDefaultScheduler) {
     uint32_t remote_node_id = (this_node_id + 1) % cluster_node_info.size();
     bool connected = co_await registry.WaitNodeAlive(remote_node_id, 5000);
     EXPECT_TRUE(connected);
-    auto ping_worker =
-        co_await registry.Spawn<PingWorker, &PingWorker::Create>(ex_actor::ActorConfig {.node_id = remote_node_id},
-                                                                 /*name=*/"Alice");
+    auto ping_worker = co_await registry.Spawn<&PingWorker::Create>(ex_actor::ActorConfig {.node_id = remote_node_id},
+                                                                    /*name=*/"Alice");
     auto ping = ping_worker.Send<&PingWorker::Ping>("hello");
     auto ping_res = co_await std::move(ping);
     EXPECT_EQ(ping_res, "ack from Alice, msg got: hello");
@@ -161,21 +160,21 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
     i.e. you can't `co_await Spawn<X>(ActorConfig {.actor_name = "A"})`, instead, you should do this:
     ```cpp
     ex_actor::ActorConfig a_config {.actor_name = "A"};
-    auto remote_a = co_await registry.Spawn<A, &A::Create>(a_config);
+    auto remote_a = co_await registry.Spawn<&A::Create>(a_config);
     ```
 
     see https://gcc.gnu.org/pipermail/gcc-bugs/2022-October/800402.html
     */
     ex_actor::ActorConfig a_config {.node_id = remote_node_id, .actor_name = "A"};
-    auto remote_a = co_await registry.Spawn<A, &A::Create>(a_config);
+    auto remote_a = co_await registry.Spawn<&A::Create>(a_config);
 
     logging::Info("node {} creating remote actor B", this_node_id);
     ex_actor::ActorConfig b_config {.node_id = remote_node_id};
-    auto remote_b = co_await registry.Spawn<B, &B::Create>(b_config, 1, "asd", std::make_unique<int>());
+    auto remote_b = co_await registry.Spawn<&B::Create>(b_config, 1, "asd", std::make_unique<int>());
 
     logging::Info("creating remote actor C without registering with EXA_REMOTE");
     auto do_create = [&]() -> void {
-      stdexec::sync_wait(registry.Spawn<C, &C::Create>(ex_actor::ActorConfig {.node_id = remote_node_id}));
+      stdexec::sync_wait(registry.Spawn<&C::Create>(ex_actor::ActorConfig {.node_id = remote_node_id}));
     };
     EXPECT_THAT(do_create, Throws<std::exception>(
                                Property(&std::exception::what, HasSubstr("forgot to register it with EXA_REMOTE"))));
@@ -187,15 +186,14 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
 
     // test remote creation error propagation
     auto do_create_error = [&]() -> void {
-      stdexec::sync_wait(registry.Spawn<Error, &Error::Create>(ex_actor::ActorConfig {.node_id = remote_node_id}));
+      stdexec::sync_wait(registry.Spawn<&Error::Create>(ex_actor::ActorConfig {.node_id = remote_node_id}));
     };
     EXPECT_THAT(do_create_error, Throws<std::exception>(Property(&std::exception::what, HasSubstr("Just an error"))));
 
     // test remote call
     logging::Info("creating remote actor PingWorker");
-    auto ping_worker =
-        co_await registry.Spawn<PingWorker, &PingWorker::Create>(ex_actor::ActorConfig {.node_id = remote_node_id},
-                                                                 /*name=*/"Alice");
+    auto ping_worker = co_await registry.Spawn<&PingWorker::Create>(ex_actor::ActorConfig {.node_id = remote_node_id},
+                                                                    /*name=*/"Alice");
     logging::Info("calling PingWorker::Ping");
     auto sender = ping_worker.Send<&PingWorker::Ping>("hello");
     auto reply = co_await std::move(sender);
@@ -215,7 +213,7 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
 
     // test remote call with void as return value
     logging::Info("calling RetVoid::ReturnVoid and Retvoid::CoroutineReturnVoid");
-    auto empty_actor = co_await registry.Spawn<RetVoid, &RetVoid::Create>({.node_id = remote_node_id});
+    auto empty_actor = co_await registry.Spawn<&RetVoid::Create>({.node_id = remote_node_id});
     co_await empty_actor.Send<&RetVoid::ReturnVoid>();
     co_await empty_actor.Send<&RetVoid::CoroutineReturnVoid>();
   };
@@ -242,7 +240,7 @@ TEST(DistributedTest, ActorLookUpInDistributeMode) {
     bool connected = co_await registry.WaitNodeAlive(remote_node_id, 5000);
     EXPECT_TRUE(connected);
     ex_actor::ActorConfig echoer_config {.node_id = remote_node_id, .actor_name = "Alice"};
-    auto remote_actor = co_await registry.Spawn<Echoer, &Echoer::Create>(echoer_config);
+    auto remote_actor = co_await registry.Spawn<&Echoer::Create>(echoer_config);
     auto lookup_result = co_await registry.GetActorRefByName<Echoer>(remote_node_id, "Alice");
     auto lookup_error = co_await registry.GetActorRefByName<Echoer>(remote_node_id, "A");
 
@@ -283,8 +281,8 @@ TEST(DistributedTest, ActorRefSerializationTest) {
     auto local_actor_b = co_await registry.Spawn<Echoer>();
     ex_actor::ActorConfig echoer_config_a {.node_id = remote_node_id, .actor_name = "Alice"};
     ex_actor::ActorConfig echoer_config_b {.node_id = remote_node_id, .actor_name = "Bob"};
-    auto remote_actor_a = co_await registry.Spawn<Echoer, &Echoer::Create>(echoer_config_a);
-    auto remote_actor_b = co_await registry.Spawn<Echoer, &Echoer::Create>(echoer_config_b);
+    auto remote_actor_a = co_await registry.Spawn<&Echoer::Create>(echoer_config_a);
+    auto remote_actor_b = co_await registry.Spawn<&Echoer::Create>(echoer_config_b);
     std::string msg = "hi";
 
     // Pass the local actor to remote actor
@@ -305,8 +303,8 @@ TEST(DistributedTest, ActorRefSerializationTest) {
     EXPECT_EQ(vec_reply, expected_vec_reply);
 
     // Pass a local actor to the constructor of remote actor
-    auto proxy_echoer = co_await registry.Spawn<ProxyEchoer, &ProxyEchoer::Create>(
-        ex_actor::ActorConfig {.node_id = remote_node_id}, local_actor_a);
+    auto proxy_echoer =
+        co_await registry.Spawn<&ProxyEchoer::Create>(ex_actor::ActorConfig {.node_id = remote_node_id}, local_actor_a);
     auto proxy_echoer_sender = proxy_echoer.Send<&ProxyEchoer::Echo>(msg);
     auto proxy_echoer_reply = co_await std::move(proxy_echoer_sender);
     EXPECT_EQ(proxy_echoer_reply, msg);

--- a/test/dynamic_connectivity_test.cc
+++ b/test/dynamic_connectivity_test.cc
@@ -101,7 +101,7 @@ class DynamicConnectivityTest {
     auto [method_calling_return_val] = stdexec::sync_wait(std::move(actor_method_calling_sender)).value();
     EXA_THROW_CHECK(method_calling_return_val == str) << ex_actor::fmt_lib::format("Error: local method calling error");
 
-    auto remote_actor_creation_sender = ex_actor::Spawn<Echoer, &Echoer::Create>({.node_id = target_node_id});
+    auto remote_actor_creation_sender = ex_actor::Spawn<&Echoer::Create>({.node_id = target_node_id});
     auto [remote_actor_ref] = stdexec::sync_wait(std::move(remote_actor_creation_sender)).value();
     auto remote_actor_calling_sender = remote_actor_ref.Send<&Echoer::Echo>(str);
     auto [remote_method_calling_return_val] = stdexec::sync_wait(std::move(remote_actor_calling_sender)).value();

--- a/test/heartbeat_test.cc
+++ b/test/heartbeat_test.cc
@@ -28,8 +28,8 @@ int main(int /*argc*/, char** argv) {
     uint32_t remote_node_id = (this_node_id + 1) % cluster_node_info.size();
     bool connected = co_await ex_actor::WaitNodeAlive(remote_node_id, 5000);
     EXA_THROW_CHECK(connected) << "Cannot connect to node " << remote_node_id;
-    auto ping_worker = co_await ex_actor::Spawn<PingWorker, &PingWorker::Create>(
-        ex_actor::ActorConfig {.node_id = remote_node_id}, /*name=*/"Alice");
+    auto ping_worker = co_await ex_actor::Spawn<&PingWorker::Create>(ex_actor::ActorConfig {.node_id = remote_node_id},
+                                                                     /*name=*/"Alice");
     // Loop forever
     while (true) {
       auto ping = ping_worker.Send<&PingWorker::Ping>("hello");

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -28,8 +28,8 @@ exec::task<void> MainCoroutine(uint32_t this_node_id, size_t total_nodes) {
   bool connected = co_await ex_actor::WaitNodeAlive(remote_node_id, 5000);
   EXA_THROW_CHECK(connected) << "Cannot connected to node " << remote_node_id;
 
-  // 2. Specify the factory function in registry.Spawn
-  auto ping_worker = co_await ex_actor::Spawn<PingWorker, &PingWorker::FactoryCreate>(
+  // 2. Specify the factory function in Spawn
+  auto ping_worker = co_await ex_actor::Spawn<&PingWorker::FactoryCreate>(
       ex_actor::ActorConfig {.node_id = remote_node_id}, /*name=*/"Alice");
   std::string ping_res = co_await ping_worker.Send<&PingWorker::Ping>("hello");
   assert(ping_res == "ack from Alice, msg got: hello");


### PR DESCRIPTION
before: `Spawn<Class, &CreateFn>`

after: `Spawn<&CreateFn>`