### PR TITLE
[refactor] cleanup serialization code path

### DIFF
--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -138,32 +138,25 @@ class ActorRef {
     using Sig = Signature<decltype(kMethod)>;
     ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> method_call_args {
         .args_tuple = typename Sig::DecayedArgsTupleType(std::move(args)...)};
-    auto serialized_args = Serialize(method_call_args);
-    std::string handler_key = GetUniqueNameForFunction<kMethod>();
-    BufferWriter buffer_writer(ByteBufferType {sizeof(NetworkRequestType) + sizeof(uint64_t) +
-                                               sizeof(handler_key.size()) + handler_key.size() + sizeof(actor_id_) +
-                                               serialized_args.size()});
-    // protocol: [request_type][handler_key_len][handler_key][actor_id][ActorMethodCallArgs]
 
-    buffer_writer.WritePrimitive(NetworkRequestType::kActorMethodCallRequest);
-    buffer_writer.WritePrimitive(handler_key.size());
-    buffer_writer.CopyFrom(handler_key.data(), handler_key.size());
-    buffer_writer.WritePrimitive(actor_id_);
-    buffer_writer.CopyFrom(serialized_args.data(), serialized_args.size());
+    NetworkRequest request {ActorMethodCallRequest {
+        .handler_key = GetUniqueNameForFunction<kMethod>(),
+        .actor_id = actor_id_,
+        .serialized_args = Serialize(method_call_args),
+    }};
 
     using UnwrappedType = decltype(UnwrapReturnSenderIfNested<kMethod>())::type;
-    ByteBufferType response_buffer =
-        co_await message_broker_->SendRequest(node_id_, std::move(buffer_writer).MoveBufferOut());
-    BufferReader reader {std::move(response_buffer)};
-    auto type = reader.NextPrimitive<NetworkReplyType>();
-    if (type == NetworkReplyType::kActorMethodCallError) {
-      auto res = Deserialize<ActorMethodReturnError>(reader.Current(), reader.RemainingSize());
-      EXA_THROW << res.error;
+    ByteBuffer response_buf = co_await message_broker_->SendRequest(node_id_, Serialize(request));
+    auto reply = Deserialize<NetworkReply>(response_buf);
+
+    auto& ret = std::get<ActorMethodCallReply>(reply.variant);
+    if (!ret.success) {
+      EXA_THROW << ret.error;
     }
     if constexpr (std::is_void_v<UnwrappedType>) {
       co_return;
     } else {
-      auto res = Deserialize<ActorMethodReturnValue<UnwrappedType>>(reader.Current(), reader.RemainingSize());
+      auto res = Deserialize<ActorMethodReturnValue<UnwrappedType>>(ret.serialized_result);
       co_return res.return_value;
     }
   }

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -79,31 +79,22 @@ class ActorRegistryBackend {
 
     using CreateFnSig = Signature<decltype(kCreateFn)>;
 
-    // protocol: [message_type][handler_key_len][handler_key][ActorCreationArgs]
     typename CreateFnSig::DecayedArgsTupleType args_tuple {std::move(args)...};
     ActorCreationArgs<typename CreateFnSig::DecayedArgsTupleType> actor_creation_args {config, std::move(args_tuple)};
-    std::vector<char> serialized = Serialize(actor_creation_args);
-    std::string handler_key = GetUniqueNameForFunction<kCreateFn>();
-    BufferWriter buffer_writer(
-        ByteBufferType {serialized.size() + sizeof(uint64_t) + handler_key.size() + sizeof(NetworkRequestType)});
-    buffer_writer.WritePrimitive(NetworkRequestType::kActorCreationRequest);
-    buffer_writer.WritePrimitive(handler_key.size());
-    // TODO optimize the copy here
-    buffer_writer.CopyFrom(handler_key.data(), handler_key.size());
-    buffer_writer.CopyFrom(serialized.data(), serialized.size());
-    EXA_THROW_CHECK(buffer_writer.EndReached()) << "Buffer writer not ended";
 
-    // send to remote
-    auto response_buffer =
-        co_await message_broker_->SendRequest(config.node_id, std::move(buffer_writer).MoveBufferOut());
-    BufferReader reader(std::move(response_buffer));
-    auto type = reader.template NextPrimitive<NetworkReplyType>();
-    if (type == NetworkReplyType::kActorCreationError) {
-      EXA_THROW << "Got actor creation error from remote node:"
-                << Deserialize<ActorCreationError>(reader.Current(), reader.RemainingSize()).error;
+    NetworkRequest request {ActorCreationRequest {
+        .handler_key = GetUniqueNameForFunction<kCreateFn>(),
+        .serialized_args = Serialize(actor_creation_args),
+    }};
+
+    ByteBuffer response_buf = co_await message_broker_->SendRequest(config.node_id, Serialize(request));
+    auto reply = Deserialize<NetworkReply>(response_buf);
+
+    auto& ret = std::get<ActorCreationReply>(reply.variant);
+    if (!ret.success) {
+      EXA_THROW << "Got actor creation error from remote node:" << ret.error;
     }
-    auto actor_id = reader.template NextPrimitive<uint64_t>();
-    co_return ActorRef<UserClass>(this_node_id_, config.node_id, actor_id, nullptr, message_broker_);
+    co_return ActorRef<UserClass>(this_node_id_, config.node_id, ret.actor_id, nullptr, message_broker_);
   }
 
   template <class UserClass>
@@ -137,28 +128,18 @@ class ActorRegistryBackend {
       co_return GetActorRefByName<UserClass>(name);
     }
 
-    std::vector<char> serialized = Serialize(ActorLookUpRequest {name});
-    BufferWriter<ByteBufferType> writer(ByteBufferType(sizeof(NetworkRequestType) + serialized.size()));
-    writer.WritePrimitive(NetworkRequestType::kActorLookUpRequest);
-    writer.CopyFrom(serialized.data(), serialized.size());
+    NetworkRequest request {ActorLookUpRequest {.actor_name = name}};
+    ByteBuffer response_buf = co_await message_broker_->SendRequest(node_id, Serialize(request));
+    auto reply = Deserialize<NetworkReply>(response_buf);
 
-    auto response_buffer =
-        co_await message_broker_->SendRequest(node_id, ByteBufferType {std::move(writer).MoveBufferOut()});
-
-    std::optional<uint64_t> actor_id = std::nullopt;
-    BufferReader<ByteBufferType> reader(std::move(response_buffer));
-    auto type = reader.NextPrimitive<NetworkReplyType>();
-    if (type == NetworkReplyType::kActorLookUpReturn) {
-      actor_id = reader.NextPrimitive<uint64_t>();
-    }
-
-    if (actor_id.has_value()) {
-      co_return ActorRef<UserClass>(this_node_id_, node_id, actor_id.value(), nullptr, message_broker_);
+    auto& ret = std::get<ActorLookUpReply>(reply.variant);
+    if (ret.success) {
+      co_return ActorRef<UserClass>(this_node_id_, node_id, ret.actor_id, nullptr, message_broker_);
     }
     co_return std::nullopt;
   }
 
-  exec::task<void> HandleNetworkRequest(uint64_t received_request_id, ByteBufferType request_buffer);
+  exec::task<void> HandleNetworkRequest(uint64_t received_request_id, ByteBuffer request_buffer);
   exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms);
 
  private:
@@ -185,10 +166,9 @@ class ActorRegistryBackend {
 
   void InitRandomNumGenerator();
   uint64_t GenerateRandomActorId();
-  NetworkRequestType ParseMessageType(const ByteBufferType& buffer);
-  void ReplyError(uint64_t received_request_id, NetworkReplyType reply_type, std::string error_msg);
-  void HandleActorCreationRequest(uint64_t received_request_id, BufferReader<ByteBufferType> reader);
-  exec::task<void> HandleActorMethodCallRequest(uint64_t received_request_id, BufferReader<ByteBufferType> reader);
+  void ReplyToBroker(uint64_t received_request_id, const NetworkReply& reply);
+  void HandleActorCreationRequest(uint64_t received_request_id, ActorCreationRequest msg);
+  exec::task<void> HandleActorMethodCallRequest(uint64_t received_request_id, ActorMethodCallRequest msg);
 };
 
 /**

--- a/include/ex_actor/internal/message.h
+++ b/include/ex_actor/internal/message.h
@@ -14,8 +14,11 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <span>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "ex_actor/internal/actor_config.h"
@@ -24,30 +27,14 @@
 
 namespace ex_actor::internal {
 
-enum class NetworkRequestType : uint8_t {
-  kActorCreationRequest = 0,
-  kActorMethodCallRequest,
-  kActorLookUpRequest,
-};
-
-enum class NetworkReplyType : uint8_t {
-  kActorCreationReturn = 0,
-  kActorCreationError,
-  kActorMethodCallReturn,
-  kActorMethodCallError,
-  kActorLookUpReturn,
-  kActorLookUpError,
-
-};
+// ===================================================
+// Payload structs (used inside serialized_args/serialized_result)
+// ===================================================
 
 template <class Tuple>
 struct ActorCreationArgs {
   ActorConfig actor_config;
   Tuple args_tuple;
-};
-
-struct ActorCreationError {
-  std::string error;
 };
 
 template <class Tuple>
@@ -59,17 +46,60 @@ template <class T>
 struct ActorMethodReturnValue {
   T return_value;
 };
-
-struct ActorMethodReturnError {
-  std::string error;
-};
-
 template <>
 struct ActorMethodReturnValue<void> {};
+
+// ===================================================
+// Typed network request messages (variant-based)
+// ===================================================
+
+struct ActorCreationRequest {
+  std::string handler_key;
+  ByteBuffer serialized_args;  // serialized ActorCreationArgs
+};
+
+struct ActorMethodCallRequest {
+  std::string handler_key;
+  uint64_t actor_id {};
+  ByteBuffer serialized_args;  // serialized ActorMethodCallArgs
+};
 
 struct ActorLookUpRequest {
   std::string actor_name;
 };
+
+struct NetworkRequest {
+  std::variant<ActorCreationRequest, ActorMethodCallRequest, ActorLookUpRequest> variant;
+};
+
+// ===================================================
+// Typed network reply messages (variant-based)
+// ===================================================
+
+struct ActorCreationReply {
+  bool success {};
+  uint64_t actor_id {};
+  std::string error;
+};
+
+struct ActorMethodCallReply {
+  bool success {};
+  ByteBuffer serialized_result;  // serialized ActorMethodReturnValue
+  std::string error;
+};
+
+struct ActorLookUpReply {
+  bool success {};
+  uint64_t actor_id {};
+};
+
+struct NetworkReply {
+  std::variant<ActorCreationReply, ActorMethodCallReply, ActorLookUpReply> variant;
+};
+
+// ===================================================
+// Node states and gossip message
+// ===================================================
 
 struct NodeState {
   enum class Liveness : uint8_t { kAlive = 0, kConnecting, kQuitting, kDead };
@@ -83,13 +113,17 @@ struct GossipMessage {
   std::vector<NodeState> node_states;
 };
 
+// ===================================================
+// Util functions
+// ===================================================
+
 template <auto kFn, class Ctx>
-auto DeserializeFnArgs(const uint8_t* data, size_t size, const Ctx& ctx) {
+auto DeserializeFnArgs(std::span<const std::byte> data, const Ctx& ctx) {
   using Sig = Signature<decltype(kFn)>;
   if constexpr (std::is_member_function_pointer_v<decltype(kFn)>) {
-    return Deserialize<ActorMethodCallArgs<typename Sig::DecayedArgsTupleType>>(data, size, ctx);
+    return Deserialize<ActorMethodCallArgs<typename Sig::DecayedArgsTupleType>>(data, ctx);
   } else {
-    return Deserialize<ActorCreationArgs<typename Sig::DecayedArgsTupleType>>(data, size, ctx);
+    return Deserialize<ActorCreationArgs<typename Sig::DecayedArgsTupleType>>(data, ctx);
   }
 }
 }  // namespace ex_actor::internal

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>
@@ -65,7 +66,6 @@ struct ClusterConfig {
 }  // namespace ex_actor
 
 namespace ex_actor::internal {
-using ByteBufferType = zmq::message_t;
 
 enum class MessageFlag : uint8_t { kNormal = 0, kQuit, kGossip };
 
@@ -112,7 +112,7 @@ class NodeInfoManager {
 class MessageBroker {
  public:
   explicit MessageBroker(const ClusterConfig& cluster_config,
-                         std::function<void(uint64_t received_request_id, ByteBufferType data)> request_handler);
+                         std::function<void(uint64_t received_request_id, ByteBuffer data)> request_handler);
 
   ~MessageBroker();
 
@@ -121,19 +121,19 @@ class MessageBroker {
   // -------- std::execution sender adaption start--------
   struct TypeErasedSendOperation {
     virtual ~TypeErasedSendOperation() = default;
-    virtual void Complete(ByteBufferType /*response_data*/) = 0;
+    virtual void Complete(ByteBuffer /*response_data*/) = 0;
 
     virtual void SetError(std::exception_ptr /*error*/) = 0;
 
-    TypeErasedSendOperation(Identifier identifier, ByteBufferType data, MessageBroker* message_broker)
+    TypeErasedSendOperation(Identifier identifier, ByteBuffer data, MessageBroker* message_broker)
         : identifier(identifier), data(std::move(data)), message_broker(message_broker) {}
     Identifier identifier;
-    ByteBufferType data;
+    ByteBuffer data;
     MessageBroker* message_broker {};
   };
   template <ex::receiver R>
   struct SendRequestOperation : TypeErasedSendOperation {
-    SendRequestOperation(Identifier identifier, ByteBufferType data, MessageBroker* message_broker, R receiver)
+    SendRequestOperation(Identifier identifier, ByteBuffer data, MessageBroker* message_broker, R receiver)
         : TypeErasedSendOperation(identifier, std::move(data), message_broker), receiver(std::move(receiver)) {}
     R receiver;
     std::atomic_bool started = false;
@@ -146,14 +146,14 @@ class MessageBroker {
       }
       message_broker->PushOperation(this);
     }
-    void Complete(ByteBufferType response_data) override { receiver.set_value(std::move(response_data)); }
+    void Complete(ByteBuffer response_data) override { receiver.set_value(std::move(response_data)); }
     void SetError(std::exception_ptr error) override { receiver.set_error(std::move(error)); };
   };
   struct SendRequestSender : ex::sender_t {
     using completion_signatures =
-        ex::completion_signatures<ex::set_value_t(ByteBufferType), ex::set_error_t(std::exception_ptr)>;
+        ex::completion_signatures<ex::set_value_t(ByteBuffer), ex::set_error_t(std::exception_ptr)>;
     Identifier identifier;
-    ByteBufferType data;
+    ByteBuffer data;
     MessageBroker* message_broker;
     template <ex::receiver R>
     SendRequestOperation<R> connect(R receiver) {
@@ -166,9 +166,9 @@ class MessageBroker {
    * @brief Send buffer to the remote node.
    * @return A sender containing raw response buffer.
    */
-  SendRequestSender SendRequest(uint32_t to_node_id, ByteBufferType data, MessageFlag flag = MessageFlag::kNormal);
+  SendRequestSender SendRequest(uint32_t to_node_id, ByteBuffer data, MessageFlag flag = MessageFlag::kNormal);
 
-  void ReplyRequest(uint64_t received_request_id, ByteBufferType data);
+  void ReplyRequest(uint64_t received_request_id, ByteBuffer data);
 
   bool CheckNodeConnected(uint32_t node_id);
 
@@ -185,7 +185,7 @@ class MessageBroker {
 
   struct ReplyOperation {
     Identifier identifier;
-    ByteBufferType data;
+    ByteBuffer data;
   };
 
   class DeferredOperations {
@@ -210,7 +210,7 @@ class MessageBroker {
   };
 
   NodeInfo this_node_ {};
-  std::function<void(uint64_t received_request_id, ByteBufferType data)> request_handler_;
+  std::function<void(uint64_t received_request_id, ByteBuffer data)> request_handler_;
   NetworkConfig network_config_;
   std::atomic_uint64_t send_request_id_counter_ = 0;
   std::atomic_uint64_t received_request_id_counter_ = 0;

--- a/include/ex_actor/internal/remote_handler_registry.h
+++ b/include/ex_actor/internal/remote_handler_registry.h
@@ -23,7 +23,6 @@
 #include "ex_actor/internal/actor.h"
 #include "ex_actor/internal/actor_ref.h"
 #include "ex_actor/internal/message.h"
-#include "ex_actor/internal/network.h"
 #include "ex_actor/internal/reflect.h"
 #include "ex_actor/internal/serialization.h"
 
@@ -38,22 +37,22 @@ class RemoteActorRequestHandlerRegistry {
 
   struct RemoteActorMethodCallHandlerContext {
     TypeErasedActor* actor;
-    BufferReader<ByteBufferType> request_buffer;
-    ActorRefSerdeContext info;
+    ByteBuffer serialized_args;
+    ActorRefSerdeContext actor_ref_serde_ctx;
   };
   struct RemoteActorCreationHandlerContext {
-    BufferReader<ByteBufferType> request_buffer;
+    ByteBuffer serialized_args;
     std::unique_ptr<TypeErasedActorScheduler> scheduler;
-    ActorRefSerdeContext info;
+    ActorRefSerdeContext actor_ref_serde_ctx;
   };
-  struct CreateActorResult {
+  struct ActorCreationResult {
     std::unique_ptr<TypeErasedActor> actor;
     std::optional<std::string> actor_name;
   };
 
   using RemoteActorMethodCallHandler =
-      std::function<exec::task<ByteBufferType>(RemoteActorMethodCallHandlerContext context)>;
-  using RemoteActorCreationHandler = std::function<CreateActorResult(RemoteActorCreationHandlerContext context)>;
+      std::function<exec::task<NetworkReply>(RemoteActorMethodCallHandlerContext context)>;
+  using RemoteActorCreationHandler = std::function<ActorCreationResult(RemoteActorCreationHandlerContext context)>;
 
   void RegisterRemoteActorMethodCallHandler(const std::string& key, RemoteActorMethodCallHandler func) {
     EXA_THROW_CHECK(!remote_actor_method_call_handler_.contains(key))
@@ -121,11 +120,11 @@ class RemoteFuncHandlerRegistrar {
 
  private:
   template <auto kCreateFn>
-  RemoteActorRequestHandlerRegistry::CreateActorResult DeserializeAndCreateActor(
+  RemoteActorRequestHandlerRegistry::ActorCreationResult DeserializeAndCreateActor(
       RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext context) {
     using ActorClass = Signature<decltype(kCreateFn)>::ReturnType;
-    ActorCreationArgs creation_args = DeserializeFnArgs<kCreateFn>(
-        context.request_buffer.Current(), context.request_buffer.RemainingSize(), context.info);
+    ActorCreationArgs creation_args =
+        DeserializeFnArgs<kCreateFn>(context.serialized_args, context.actor_ref_serde_ctx);
     std::unique_ptr<TypeErasedActor> actor = Actor<ActorClass, kCreateFn>::CreateUseArgTuple(
         std::move(context.scheduler), std::move(creation_args.actor_config), std::move(creation_args.args_tuple));
     auto actor_name = actor->GetActorConfig().actor_name;
@@ -139,31 +138,25 @@ class RemoteFuncHandlerRegistrar {
    * @returns A coroutine carrying the serialized result of the actor method call.
    */
   template <auto kMethod>
-  exec::task<ByteBufferType> DeserializeAndInvokeActorMethod(
+  exec::task<NetworkReply> DeserializeAndInvokeActorMethod(
       RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext context) {
     EXA_THROW_CHECK(context.actor != nullptr);
     using Sig = Signature<decltype(kMethod)>;
     using UnwrappedType = decltype(UnwrapReturnSenderIfNested<kMethod>())::type;
 
-    ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> call_args = DeserializeFnArgs<kMethod>(
-        context.request_buffer.Current(), context.request_buffer.RemainingSize(), context.info);
+    ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> call_args =
+        DeserializeFnArgs<kMethod>(context.serialized_args, context.actor_ref_serde_ctx);
 
-    std::vector<char> serialized {};
     if constexpr (std::is_void_v<UnwrappedType>) {
       co_await context.actor->template CallActorMethodUseTuple<kMethod>(std::move(call_args.args_tuple));
+      co_return NetworkReply {ActorMethodCallReply {.success = true}};
     } else {
       auto return_value =
           co_await context.actor->template CallActorMethodUseTuple<kMethod>(std::move(call_args.args_tuple));
-      serialized = Serialize(ActorMethodReturnValue<UnwrappedType> {std::move(return_value)});
+      co_return NetworkReply {ActorMethodCallReply {
+          .success = true,
+          .serialized_result = Serialize(ActorMethodReturnValue<UnwrappedType> {std::move(return_value)})}};
     }
-
-    BufferWriter writer(ByteBufferType {sizeof(NetworkRequestType) + serialized.size()});
-    // TODO optimize the copy here
-    writer.WritePrimitive(NetworkReplyType::kActorMethodCallReturn);
-    if constexpr (!std::is_void_v<UnwrappedType>) {
-      writer.CopyFrom(serialized.data(), serialized.size());
-    }
-    co_return std::move(writer).MoveBufferOut();
   };
 };
 
@@ -172,9 +165,7 @@ class RemoteFuncHandlerRegistrar {
 #define EXA_ANONYMOUS_VARIABLE(str) EXA_CONCATENATE(str, __LINE__, _, __COUNTER__)
 }  // namespace ex_actor::internal
 
-namespace ex_actor {
 #define EXA_REMOTE(...)                                                                        \
   /* NOLINTNEXTLINE(misc-use-internal-linkage) */                                              \
   inline ::ex_actor::internal::RemoteFuncHandlerRegistrar<__VA_ARGS__> EXA_ANONYMOUS_VARIABLE( \
       exa_remote_func_registrar_);
-};  // namespace ex_actor

--- a/include/ex_actor/internal/serialization.h
+++ b/include/ex_actor/internal/serialization.h
@@ -15,7 +15,10 @@
 #pragma once
 
 #include <concepts>
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <span>
 #include <type_traits>
 #include <vector>
 
@@ -85,6 +88,8 @@ Result<internal::wrap_in_rfl_array_t<T>> read(const concepts::ByteLike auto* byt
 // ===================================================
 namespace ex_actor::internal {
 
+using ByteBuffer = std::vector<std::byte>;
+
 template <class T>
 static auto GetCachedSchema() {
   thread_local auto schema = rfl::capnproto::to_schema<T>();
@@ -92,18 +97,25 @@ static auto GetCachedSchema() {
 }
 
 template <class T>
-std::vector<char> Serialize(const T& obj) {
-  return rfl::capnproto::write(obj, GetCachedSchema<T>());
+ByteBuffer Serialize(const T& obj) {
+  std::vector<char> chars = rfl::capnproto::write(obj, GetCachedSchema<T>());
+  ByteBuffer result(chars.size());
+  // TODO: a copy here, optimize it in the future. Find a way to convert the vector<char> to vector<std::byte> without
+  // copy and not causing undefined behavior(don't violating strict aliasing rules, specifically).
+  std::memcpy(result.data(), chars.data(), chars.size());
+  return result;
 }
 
 template <class T>
-T Deserialize(const uint8_t* data, size_t size) {
-  return rfl::capnproto::read<T>(data, size, GetCachedSchema<T>()).value();
+T Deserialize(std::span<const std::byte> data) {
+  return rfl::capnproto::read<T>(reinterpret_cast<const char*>(data.data()), data.size(), GetCachedSchema<T>()).value();
 }
 
 template <class T, class Ctx>
-T Deserialize(const uint8_t* data, size_t size, const Ctx& ctx) {
-  return rfl::capnproto::read<T, Ctx>(data, size, GetCachedSchema<T>(), ctx).value();
+T Deserialize(std::span<const std::byte> data, const Ctx& ctx) {
+  return rfl::capnproto::read<T, Ctx>(reinterpret_cast<const char*>(data.data()), data.size(), GetCachedSchema<T>(),
+                                      ctx)
+      .value();
 }
 
 struct MemoryBuf : std::streambuf {
@@ -175,6 +187,9 @@ class BufferWriter {
     offset_ += size;
   }
   void CopyFrom(const char* data, size_t size) { CopyFrom(reinterpret_cast<const uint8_t*>(data), size); }
+  void CopyFrom(std::span<const std::byte> data) {
+    CopyFrom(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+  }
 
   const B& GetBuffer() const { return buffer_; }
 

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -48,38 +48,28 @@ exec::task<void> ActorRegistryBackend::AsyncDestroyAllActors() {
   log::Info("All actors destroyed");
 }
 
-exec::task<void> ActorRegistryBackend::HandleNetworkRequest(uint64_t received_request_id,
-                                                            ByteBufferType request_buffer) {
-  BufferReader<ByteBufferType> reader(std::move(request_buffer));
-  auto message_type = reader.NextPrimitive<NetworkRequestType>();
+exec::task<void> ActorRegistryBackend::HandleNetworkRequest(uint64_t received_request_id, ByteBuffer request_buffer) {
+  auto request = Deserialize<NetworkRequest>(request_buffer);
 
-  if (message_type == NetworkRequestType::kActorCreationRequest) {
-    HandleActorCreationRequest(received_request_id, std::move(reader));
+  if (auto* msg = std::get_if<ActorCreationRequest>(&request.variant)) {
+    HandleActorCreationRequest(received_request_id, std::move(*msg));
     co_return;
   }
 
-  if (message_type == NetworkRequestType::kActorMethodCallRequest) {
-    co_await HandleActorMethodCallRequest(received_request_id, std::move(reader));
+  if (auto* msg = std::get_if<ActorMethodCallRequest>(&request.variant)) {
+    co_await HandleActorMethodCallRequest(received_request_id, std::move(*msg));
     co_return;
   }
 
-  if (message_type == NetworkRequestType::kActorLookUpRequest) {
-    auto actor_name = Deserialize<ActorLookUpRequest>(reader.Current(), reader.RemainingSize()).actor_name;
-
-    if (actor_name_to_id_.contains(actor_name)) {
-      BufferWriter<ByteBufferType> writer(ByteBufferType(sizeof(NetworkRequestType) + sizeof(uint64_t)));
-      auto actor_id = actor_name_to_id_.at(actor_name);
-      writer.WritePrimitive(NetworkReplyType::kActorLookUpReturn);
-      writer.WritePrimitive(actor_id);
-      message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
+  if (auto* msg = std::get_if<ActorLookUpRequest>(&request.variant)) {
+    if (actor_name_to_id_.contains(msg->actor_name)) {
+      ReplyToBroker(received_request_id, NetworkReply {ActorLookUpReply {
+                                             .success = true, .actor_id = actor_name_to_id_.at(msg->actor_name)}});
     } else {
-      BufferWriter writer(ByteBufferType(sizeof(NetworkRequestType)));
-      writer.WritePrimitive(NetworkReplyType::kActorLookUpError);
-      message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
+      ReplyToBroker(received_request_id, NetworkReply {ActorLookUpReply {.success = false}});
     }
     co_return;
   }
-  EXA_THROW << "Invalid message type: " << static_cast<int>(message_type);
 }
 
 void ActorRegistryBackend::InitRandomNumGenerator() {
@@ -96,26 +86,13 @@ uint64_t ActorRegistryBackend::GenerateRandomActorId() {
   }
 }
 
-NetworkRequestType ActorRegistryBackend::ParseMessageType(const ByteBufferType& buffer) {
-  EXA_THROW_CHECK_GE(buffer.size(), 1) << "Invalid buffer size, " << buffer.size();
-  return static_cast<NetworkRequestType>(*static_cast<const uint8_t*>(buffer.data()));
+void ActorRegistryBackend::ReplyToBroker(uint64_t received_request_id, const NetworkReply& reply) {
+  message_broker_->ReplyRequest(received_request_id, Serialize(reply));
 }
 
-void ActorRegistryBackend::ReplyError(uint64_t received_request_id, NetworkReplyType reply_type,
-                                      std::string error_msg) {
-  std::vector<char> serialized = Serialize(ActorMethodReturnError {std::move(error_msg)});
-  BufferWriter writer(ByteBufferType(sizeof(NetworkRequestType) + serialized.size()));
-  writer.WritePrimitive(reply_type);
-  writer.CopyFrom(serialized.data(), serialized.size());
-  message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
-}
-
-void ActorRegistryBackend::HandleActorCreationRequest(uint64_t received_request_id,
-                                                      BufferReader<ByteBufferType> reader) {
-  auto handler_key_len = reader.NextPrimitive<uint64_t>();
-  auto handler_key = reader.PullString(handler_key_len);
+void ActorRegistryBackend::HandleActorCreationRequest(uint64_t received_request_id, ActorCreationRequest msg) {
   try {
-    auto handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorCreationHandler(handler_key);
+    auto handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorCreationHandler(msg.handler_key);
     ActorRefSerdeContext info {.this_node_id = this_node_id_,
                                .actor_look_up_fn = [&](uint64_t actor_id) -> TypeErasedActor* {
                                  if (actor_id_to_actor_.contains(actor_id)) {
@@ -125,7 +102,9 @@ void ActorRegistryBackend::HandleActorCreationRequest(uint64_t received_request_
                                },
                                .message_broker = message_broker_};
     auto result = handler(RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext {
-        .request_buffer = std::move(reader), .scheduler = scheduler_->Clone(), .info = info});
+        .serialized_args = std::move(msg.serialized_args),
+        .scheduler = scheduler_->Clone(),
+        .actor_ref_serde_ctx = info});
     uint64_t actor_id = GenerateRandomActorId();
     if (result.actor_name.has_value()) {
       EXA_THROW_CHECK(!actor_name_to_id_.contains(result.actor_name.value()))
@@ -133,55 +112,55 @@ void ActorRegistryBackend::HandleActorCreationRequest(uint64_t received_request_
       actor_name_to_id_[result.actor_name.value()] = actor_id;
     }
     actor_id_to_actor_[actor_id] = std::move(result.actor);
-    BufferWriter<ByteBufferType> writer(ByteBufferType(sizeof(NetworkReplyType) + sizeof(actor_id)));
-    writer.WritePrimitive(NetworkReplyType::kActorCreationReturn);
-    writer.WritePrimitive(actor_id);
-    message_broker_->ReplyRequest(received_request_id, std::move(writer).MoveBufferOut());
+    ReplyToBroker(received_request_id, NetworkReply {ActorCreationReply {.success = true, .actor_id = actor_id}});
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    ReplyError(received_request_id, NetworkReplyType::kActorCreationError, std::move(error_msg));
+    ReplyToBroker(received_request_id,
+                  NetworkReply {ActorCreationReply {.success = false, .error = std::move(error_msg)}});
   }
 }
 
 exec::task<void> ActorRegistryBackend::HandleActorMethodCallRequest(uint64_t received_request_id,
-                                                                    BufferReader<ByteBufferType> reader) {
-  auto handler_key_len = reader.NextPrimitive<uint64_t>();
-  auto handler_key = reader.PullString(handler_key_len);
-  auto actor_id = reader.NextPrimitive<uint64_t>();
-  if (!actor_id_to_actor_.contains(actor_id)) {
-    ReplyError(
-        received_request_id, NetworkReplyType::kActorMethodCallError,
+                                                                    ActorMethodCallRequest msg) {
+  if (!actor_id_to_actor_.contains(msg.actor_id)) {
+    auto error_msg =
         fmt_lib::format("Can't find actor at remote node, actor_id={}, node_id={}, maybe it's already destroyed.",
-                        actor_id, this_node_id_));
+                        msg.actor_id, this_node_id_);
+    ReplyToBroker(received_request_id,
+                  NetworkReply {ActorMethodCallReply {.success = false, .error = std::move(error_msg)}});
     co_return;
   }
 
   RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandler handler = nullptr;
   try {
-    handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorMethodCallHandler(handler_key);
+    handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorMethodCallHandler(msg.handler_key);
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    ReplyError(received_request_id, NetworkReplyType::kActorMethodCallError, std::move(error_msg));
+    ReplyToBroker(received_request_id,
+                  NetworkReply {ActorMethodCallReply {.success = false, .error = std::move(error_msg)}});
     co_return;
   }
 
   EXA_THROW_CHECK(handler != nullptr);
   ActorRefSerdeContext info {.this_node_id = this_node_id_,
-                             .actor_look_up_fn = [&](uint64_t actor_id) -> TypeErasedActor* {
-                               if (actor_id_to_actor_.contains(actor_id)) {
-                                 return actor_id_to_actor_.at(actor_id).get();
+                             .actor_look_up_fn = [&](uint64_t aid) -> TypeErasedActor* {
+                               if (actor_id_to_actor_.contains(aid)) {
+                                 return actor_id_to_actor_.at(aid).get();
                                }
                                return nullptr;
                              },
                              .message_broker = message_broker_};
   try {
     auto task = handler(RemoteActorRequestHandlerRegistry::RemoteActorMethodCallHandlerContext {
-        .actor = actor_id_to_actor_.at(actor_id).get(), .request_buffer = std::move(reader), .info = info});
-    auto buffer = co_await std::move(task);
-    message_broker_->ReplyRequest(received_request_id, std::move(buffer));
+        .actor = actor_id_to_actor_.at(msg.actor_id).get(),
+        .serialized_args = std::move(msg.serialized_args),
+        .actor_ref_serde_ctx = info});
+    auto reply = co_await std::move(task);
+    ReplyToBroker(received_request_id, reply);
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    ReplyError(received_request_id, NetworkReplyType::kActorMethodCallError, std::move(error_msg));
+    ReplyToBroker(received_request_id,
+                  NetworkReply {ActorMethodCallReply {.success = false, .error = std::move(error_msg)}});
   }
 }
 
@@ -217,7 +196,7 @@ ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeEras
         return std::make_unique<MessageBroker>(
             cluster_config,
             /*request_handler=*/
-            [this](uint64_t received_request_id, ByteBufferType data) {
+            [this](uint64_t received_request_id, ByteBuffer data) {
               auto task = backend_actor_.CallActorMethod<&ActorRegistryBackend::HandleNetworkRequest>(
                   received_request_id, std::move(data));
               async_scope_.spawn(std::move(task));

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -22,6 +22,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <span>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -38,6 +39,23 @@ namespace {
 inline uint64_t GetTimeMs() {
   return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
       .count();
+}
+
+std::span<const std::byte> ZmqMsgBytes(const zmq::message_t& msg) {
+  return {static_cast<const std::byte*>(msg.data()), msg.size()};
+}
+
+ex_actor::internal::ByteBuffer ZmqMsgToBytes(zmq::message_t&& msg) {
+  auto span = ZmqMsgBytes(msg);
+  // TODO: a copy here, optimize it in the future
+  return {span.begin(), span.end()};
+}
+
+zmq::message_t BytesToZmqMsg(ex_actor::internal::ByteBuffer&& bytes) {
+  if (bytes.empty()) return {};
+  auto* owned = new ex_actor::internal::ByteBuffer(std::move(bytes));
+  auto deleter = [](void*, void* hint) { delete static_cast<ex_actor::internal::ByteBuffer*>(hint); };
+  return zmq::message_t(owned->data(), owned->size(), deleter, owned);
 }
 }  // namespace
 
@@ -228,7 +246,7 @@ void NodeInfoManager::CheckHeartbeatAndExpireWaiters(uint64_t timeout_ms) {
 }
 
 MessageBroker::MessageBroker(const ClusterConfig& cluster_config,
-                             std::function<void(uint64_t received_request_id, ByteBufferType data)> request_handler)
+                             std::function<void(uint64_t received_request_id, ByteBuffer data)> request_handler)
     : this_node_(cluster_config.this_node),
       request_handler_(std::move(request_handler)),
       node_manager_(cluster_config.this_node.node_id),
@@ -264,7 +282,7 @@ void MessageBroker::ClusterAlignedStop() {
 
   for (const auto& node : node_list) {
     if (node.node_id != this_node_.node_id) {
-      auto sender = SendRequest(node.node_id, ByteBufferType {}, MessageFlag::kQuit) | ex::then([](auto empty) {});
+      auto sender = SendRequest(node.node_id, ByteBuffer {}, MessageFlag::kQuit) | ex::then([](const auto&) {});
       async_scope_.spawn(std::move(sender));
     }
   }
@@ -304,8 +322,7 @@ void MessageBroker::EstablishConnectionTo(const NodeInfo& node_info) {
   node_manager_.NotifyWaiters(node_id);
 }
 
-MessageBroker::SendRequestSender MessageBroker::SendRequest(uint32_t to_node_id, ByteBufferType data,
-                                                            MessageFlag flag) {
+MessageBroker::SendRequestSender MessageBroker::SendRequest(uint32_t to_node_id, ByteBuffer data, MessageFlag flag) {
   EXA_THROW_CHECK_NE(to_node_id, this_node_.node_id) << "Cannot send message to current node";
   Identifier identifier {
       .request_node_id = this_node_.node_id,
@@ -320,7 +337,7 @@ MessageBroker::SendRequestSender MessageBroker::SendRequest(uint32_t to_node_id,
   };
 }
 
-void MessageBroker::ReplyRequest(uint64_t received_request_id, ByteBufferType data) {
+void MessageBroker::ReplyRequest(uint64_t received_request_id, ByteBuffer data) {
   auto identifier = received_request_id_to_identifier_.At(received_request_id);
   received_request_id_to_identifier_.Erase(received_request_id);
 
@@ -346,12 +363,12 @@ void MessageBroker::SendProcessLoop(const std::stop_token& stop_token) {
         auto serialized_identifier = Serialize(operation->identifier);
         zmq::multipart_t multi;
         multi.addmem(serialized_identifier.data(), serialized_identifier.size());
-        multi.add(std::move(operation->data));
+        multi.add(BytesToZmqMsg(std::move(operation->data)));
         auto& send_socket = node_id_to_send_socket_.At(operation->identifier.response_node_id);
         EXA_THROW_CHECK(multi.send(send_socket));
         if (operation->identifier.flag == MessageFlag::kQuit || operation->identifier.flag == MessageFlag::kGossip) {
           send_request_id_to_operation_.Erase(operation->identifier.request_id_in_node);
-          operation->Complete(ByteBufferType {});
+          operation->Complete(ByteBuffer {});
         }
         any_item_pulled = true;
       } else {
@@ -370,7 +387,7 @@ void MessageBroker::SendProcessLoop(const std::stop_token& stop_token) {
         auto serialized_identifier = Serialize(reply_operation.identifier);
         zmq::multipart_t multi;
         multi.addmem(serialized_identifier.data(), serialized_identifier.size());
-        multi.add(std::move(reply_operation.data));
+        multi.add(BytesToZmqMsg(std::move(reply_operation.data)));
         EXA_THROW_CHECK(multi.send(send_socket));
         any_item_pulled = true;
       } else {
@@ -414,7 +431,7 @@ void MessageBroker::HandleReceivedMessage(zmq::multipart_t multi) {
   zmq::message_t identifier_bytes = multi.pop();
   zmq::message_t data_bytes = multi.pop();
 
-  auto identifier = Deserialize<Identifier>(identifier_bytes.data<uint8_t>(), identifier_bytes.size());
+  auto identifier = Deserialize<Identifier>(ZmqMsgBytes(identifier_bytes));
 
   // all received messages will update the last seen time;
   // For responses, the peer is response_node_id.
@@ -439,12 +456,12 @@ void MessageBroker::HandleReceivedMessage(zmq::multipart_t multi) {
     // Response from remote node
     TypeErasedSendOperation* operation = send_request_id_to_operation_.At(identifier.request_id_in_node);
     send_request_id_to_operation_.Erase(identifier.request_id_in_node);
-    operation->Complete(std::move(data_bytes));
+    operation->Complete(ZmqMsgToBytes(std::move(data_bytes)));
   } else if (identifier.response_node_id == this_node_.node_id) {
     // Request from remote node - pass to handler, which will send response back
     auto received_request_id = received_request_id_counter_.fetch_add(1);
     received_request_id_to_identifier_.Insert(received_request_id, identifier);
-    request_handler_(received_request_id, std::move(data_bytes));
+    request_handler_(received_request_id, ZmqMsgToBytes(std::move(data_bytes)));
   } else {
     EXA_THROW << "Invalid identifier, " << EXA_DUMP_VARS(identifier);
   }
@@ -459,16 +476,10 @@ void MessageBroker::SendGossip() {
                                    .last_seen = GetTimeMs(),
                                    .node_id = this_node_.node_id,
                                    .address = this_node_.address});
-    auto serialized_message = Serialize(message);
-    BufferWriter writer {ByteBufferType(serialized_message.size())};
-    writer.CopyFrom(serialized_message.data(), serialized_message.size());
-    auto payload = std::move(writer).MoveBufferOut();
+    auto payload = Serialize(message);
 
     for (const auto& node : node_list) {
-      ByteBufferType per_node_payload;
-      per_node_payload.copy(payload);
-      auto gossip =
-          SendRequest(node.node_id, std::move(per_node_payload), MessageFlag::kGossip) | ex::then([](auto&& null) {});
+      auto gossip = SendRequest(node.node_id, ByteBuffer(payload), MessageFlag::kGossip) | ex::then([](auto&& null) {});
       async_scope_.spawn(std::move(gossip));
     }
     last_heartbeat_ms_ = GetTimeMs();
@@ -476,7 +487,7 @@ void MessageBroker::SendGossip() {
 }
 
 void MessageBroker::HandleGossip(zmq::message_t gossip_msg) {
-  const auto message = Deserialize<GossipMessage>(gossip_msg.data<uint8_t>(), gossip_msg.size());
+  const auto message = Deserialize<GossipMessage>(ZmqMsgBytes(gossip_msg));
   for (const auto& state : message.node_states) {
     if (state.node_id == this_node_.node_id) {
       if (state.address != this_node_.address) {

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -15,7 +15,7 @@
 
 #include "ex_actor/api.h"
 
-using ex_actor::internal::ByteBufferType;
+using ex_actor::internal::ByteBuffer;
 using ex_actor::internal::NodeInfoManager;
 using Liveness = ex_actor::internal::NodeState::Liveness;
 namespace logging = ex_actor::internal::log;
@@ -125,17 +125,20 @@ TEST(NetworkTest, MessageBrokerClusterConfigTest) {
         config.contact_node = node_list.front();
       }
       ex_actor::internal::MessageBroker message_broker(
-          config, [&message_broker](uint64_t received_request_id, ByteBufferType data) {
+          config, [&message_broker](uint64_t received_request_id, ByteBuffer data) {
             message_broker.ReplyRequest(received_request_id, std::move(data));
           });
       uint32_t to_node_id = (node_id + 1) % node_list.size();
       // Waiting all the nodes find its contact node
       stdexec::sync_wait(message_broker.WaitNodeAlive(to_node_id, 500));
       exec::async_scope scope;
+      auto str = std::to_string(node_id);
       for (int i = 0; i < 5; ++i) {
-        scope.spawn(message_broker.SendRequest(to_node_id, ByteBufferType(std::to_string(node_id))) |
-                    stdexec::then([node_id](ByteBufferType data) {
-                      std::string data_str(static_cast<char*>(data.data()), data.size());
+        auto bytes = ByteBuffer(reinterpret_cast<const std::byte*>(str.data()),
+                                reinterpret_cast<const std::byte*>(str.data() + str.size()));
+        scope.spawn(message_broker.SendRequest(to_node_id, std::move(bytes)) |
+                    stdexec::then([node_id](ByteBuffer data) {
+                      std::string data_str(reinterpret_cast<const char*>(data.data()), data.size());
                       logging::Info("got response data, node id: {}, data: {}", node_id, data_str);
                       ASSERT_EQ(data_str, std::to_string(node_id));
                     }));
@@ -156,7 +159,7 @@ TEST(NetworkTest, MessageBrokerClusterConfigTest) {
 }
 
 TEST(NetworkTest, MessageBrokerDuplicateContactNodeTest) {
-  auto request_handler = [](uint64_t /*received_request_id*/, ByteBufferType /*data*/) {};
+  auto request_handler = [](uint64_t /*received_request_id*/, const ByteBuffer& /*data*/) {};
 
   auto make_cluster_config = [](std::string this_address, std::string contact_address) {
     ex_actor::ClusterConfig config;
@@ -180,7 +183,7 @@ TEST(NetworkTest, MessageBrokerDuplicateContactNodeTest) {
 }
 
 TEST(NetworkTest, MessageBrokerDuplicateClusterNodesTest) {
-  auto request_handler = [](uint64_t /*received_request_id*/, ByteBufferType /*data*/) {};
+  auto request_handler = [](uint64_t /*received_request_id*/, const ByteBuffer& /*data*/) {};
 
   std::vector<ex_actor::NodeInfo> nodes {ex_actor::NodeInfo {.node_id = 0, .address = "tcp://127.0.0.1:5000"},
                                          ex_actor::NodeInfo {.node_id = 2, .address = "tcp://127.0.0.1:5001"},
@@ -221,7 +224,7 @@ TEST(NetworkTest, MessageBrokerDuplicateClusterNodesTest) {
 }
 
 TEST(NetworkTest, MessageBrokerUnknownNodesTest) {
-  auto request_handler = [](uint64_t /*received_request_id*/, ByteBufferType /*data*/) {};
+  auto request_handler = [](uint64_t /*received_request_id*/, const ByteBuffer& /*data*/) {};
 
   auto send_msg_to_unconnected_node = [&]() {
     ex_actor::ClusterConfig cluster_config {.this_node = {.node_id = 0, .address = "tcp://127.0.0.1:5000"},


### PR DESCRIPTION
1. move manually written network schema to strongly-typed structs in message.h. Polish the message names.
2. use std::byte when possible
3. replace zmq::message_t with std::vector<byte> in interfaces.