### PR TITLE
[refactor] split ActorRef into LocalActorRef & ActorRef

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -92,6 +92,7 @@ Checks: >
   -performance-avoid-endl,
   -readability-isolate-declaration,
   -readability-convert-member-functions-to-static,
+  -readability-make-member-function-const,
 
 FormatStyle: file
 CheckOptions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,9 @@ refer README.md and docs/contents for how to use this framework(ignore files lis
 refer "How to build from source" part in CONTRIBUTING.md for how to build&test.
 
 when debugging tests, do not simplify the test code unless you are very confident the test is not correct.
+
+# Code Style
+
+Based on Google Style Guide, with the following additions:
+
+- For all args that can't get its meaning from the variable name, add a `/*arg_name=*/` comment before the arg.

--- a/include/ex_actor/internal/actor.h
+++ b/include/ex_actor/internal/actor.h
@@ -182,8 +182,9 @@ class Actor : public TypeErasedActor {
   /// Async destroy the actor, if there are still messages in the mailbox, they might not be processed.
   exec::task<void> AsyncDestroy() override {
     bool expected = false;
-    bool changed = pending_to_be_destroyed_.compare_exchange_strong(expected, true, std::memory_order_release,
-                                                                    std::memory_order_acquire);
+    bool changed = pending_to_be_destroyed_.compare_exchange_strong(expected, /*desired=*/true,
+                                                                    /*success=*/std::memory_order_release,
+                                                                    /*failure=*/std::memory_order_acquire);
     if (!changed) {
       co_return;
     }

--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "ex_actor/internal/actor.h"
+#include "ex_actor/internal/local_actor_ref.h"
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/message.h"
 #include "ex_actor/internal/network.h"
@@ -28,17 +28,15 @@
 
 namespace ex_actor::internal {
 template <class UserClass>
-class ActorRef {
+class ActorRef : public LocalActorRef<UserClass> {
  public:
-  ActorRef() : is_empty_(true) {}
+  ActorRef() : LocalActorRef<UserClass>() {}
 
   ActorRef(uint32_t this_node_id, uint32_t node_id, uint64_t actor_id, TypeErasedActor* actor,
            MessageBroker* message_broker)
-      : is_empty_(false),
+      : LocalActorRef<UserClass>(actor_id, actor),
         this_node_id_(this_node_id),
         node_id_(node_id),
-        actor_id_(actor_id),
-        type_erased_actor_(actor),
         message_broker_(message_broker) {}
 
   friend bool operator==(const ActorRef& lhs, const ActorRef& rhs) {
@@ -50,7 +48,7 @@ class ActorRef {
 
   void SetLocalRuntimeInfo(uint32_t this_node_id, TypeErasedActor* actor, MessageBroker* message_broker) {
     this_node_id_ = this_node_id;
-    type_erased_actor_ = actor;
+    this->type_erased_actor_ = actor;
     message_broker_ = message_broker;
   }
 
@@ -60,22 +58,20 @@ class ActorRef {
   friend class ActorRef;
 
   // Converting constructor from ActorRef<U> where U* is convertible to UserClass*
-  template <class U>
-    requires std::is_convertible_v<U*, UserClass*>
+  template <class Other>
+    requires std::is_convertible_v<Other*, UserClass*>
   // NOLINTNEXTLINE(google-explicit-constructor) - implicit conversion is intentional for polymorphism support
-  ActorRef(const ActorRef<U>& other)
-      : is_empty_(other.is_empty_),
+  ActorRef(const ActorRef<Other>& other)
+      : LocalActorRef<UserClass>(other),
         this_node_id_(other.this_node_id_),
         node_id_(other.node_id_),
-        actor_id_(other.actor_id_),
-        type_erased_actor_(other.type_erased_actor_),
         message_broker_(other.message_broker_) {}
 
   // Converting assignment operator - delegates to converting constructor
-  template <class U>
-    requires std::is_convertible_v<U*, UserClass*>
-  ActorRef& operator=(const ActorRef<U>& other) {
-    *this = ActorRef(other);
+  template <class Other>
+    requires std::is_convertible_v<Other*, UserClass*>
+  ActorRef<UserClass>& operator=(const ActorRef<Other>& other) {
+    *this = ActorRef<UserClass>(other);
     return *this;
   }
 
@@ -99,26 +95,15 @@ class ActorRef {
    */
   template <auto kMethod, class... Args>
   [[nodiscard]] ex::sender auto SendLocal(Args... args) const {
-    static_assert(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>,
-                  "method is not invocable with the provided arguments");
-    if (IsEmpty()) [[unlikely]] {
-      throw std::runtime_error("Empty ActorRef, cannot call method on it.");
-    }
     EXA_THROW_CHECK_EQ(node_id_, this_node_id_) << "Cannot call remote actor using SendLocal, use Send instead.";
-    return type_erased_actor_->template CallActorMethod<kMethod>(std::move(args)...);
+    return LocalActorRef<UserClass>::template SendLocal<kMethod>(std::move(args)...);
   }
 
-  bool IsEmpty() const { return is_empty_; }
-
   uint32_t GetNodeId() const { return node_id_; }
-  uint64_t GetActorId() const { return actor_id_; }
 
  private:
-  bool is_empty_;
   uint32_t this_node_id_ = 0;
   uint32_t node_id_ = 0;
-  uint64_t actor_id_ = 0;
-  TypeErasedActor* type_erased_actor_ = nullptr;
   MessageBroker* message_broker_ = nullptr;
 
   template <auto kMethod, class... Args>
@@ -126,7 +111,7 @@ class ActorRef {
       -> exec::task<typename decltype(UnwrapReturnSenderIfNested<kMethod>())::type> {
     static_assert(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>,
                   "method is not invocable with the provided arguments");
-    if (IsEmpty()) [[unlikely]] {
+    if (this->IsEmpty()) [[unlikely]] {
       throw std::runtime_error("Empty ActorRef, cannot call method on it.");
     }
     if (node_id_ == this_node_id_) {
@@ -141,7 +126,7 @@ class ActorRef {
 
     NetworkRequest request {ActorMethodCallRequest {
         .handler_key = GetUniqueNameForFunction<kMethod>(),
-        .actor_id = actor_id_,
+        .actor_id = this->actor_id_,
         .serialized_args = Serialize(method_call_args),
     }};
 
@@ -202,7 +187,10 @@ struct Reflector<ex_actor::internal::ActorRef<U>> {
   };
 
   static ex_actor::internal::ActorRef<U> to(const ReflType& rfl_type) noexcept {
-    ex_actor::internal::ActorRef<U> actor(0, rfl_type.node_id, rfl_type.actor_id, nullptr, nullptr);
+    // this_node_id(0) and TypeErasedActor*(nullptr) are placeholders;
+    // filled later in the Parser::read below.
+    ex_actor::internal::ActorRef<U> actor(/*this_node_id=*/0, rfl_type.node_id, rfl_type.actor_id, /*actor=*/nullptr,
+                                          /*message_broker=*/nullptr);
     return actor;
   }
 

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -199,7 +199,7 @@ class SpawnBuilder : public ex::sender_t {
   using completion_signatures = ex::completion_signatures<ex::set_value_t(ActorRef<UserClass>),
                                                           ex::set_error_t(std::exception_ptr), ex::set_stopped_t()>;
 
-  explicit SpawnBuilder(ActorRef<ActorRegistryBackend> backend_ref, Args... args)
+  explicit SpawnBuilder(LocalActorRef<ActorRegistryBackend> backend_ref, Args... args)
       : backend_ref_(std::move(backend_ref)), args_(std::move(args)...) {}
 
   SpawnBuilder& ToNode(uint32_t node_id) & {
@@ -251,7 +251,7 @@ class SpawnBuilder : public ex::sender_t {
         std::forward<Tuple>(args));
   }
 
-  ActorRef<ActorRegistryBackend> backend_ref_;
+  LocalActorRef<ActorRegistryBackend> backend_ref_;
   uint32_t node_id_ = 0;
   ActorConfig config_ {};
   std::tuple<Args...> args_;
@@ -375,7 +375,7 @@ class ActorRegistry {
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
   std::unique_ptr<MessageBroker> message_broker_;
   Actor<ActorRegistryBackend> backend_actor_;
-  ActorRef<ActorRegistryBackend> backend_actor_ref_;
+  LocalActorRef<ActorRegistryBackend> backend_actor_ref_;
   exec::async_scope async_scope_;
 
   explicit ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler,

--- a/include/ex_actor/internal/local_actor_ref.h
+++ b/include/ex_actor/internal/local_actor_ref.h
@@ -1,0 +1,100 @@
+// Copyright 2026 The ex_actor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+#include "ex_actor/internal/actor.h"
+#include "ex_actor/internal/constants.h"
+
+namespace ex_actor::internal {
+
+template <class UserClass>
+class LocalActorRef {
+ public:
+  LocalActorRef() : is_empty_(true) {}
+
+  LocalActorRef(uint64_t actor_id, TypeErasedActor* actor)
+      : is_empty_(false), actor_id_(actor_id), type_erased_actor_(actor) {}
+
+  friend bool operator==(const LocalActorRef& lhs, const LocalActorRef& rhs) {
+    if (lhs.is_empty_ && rhs.is_empty_) {
+      return true;
+    }
+    return lhs.actor_id_ == rhs.actor_id_;
+  }
+
+  template <class U>
+  friend class LocalActorRef;
+
+  template <class U>
+  friend class ActorRef;
+
+  // Converting constructor from LocalActorRef<U> where U* is convertible to UserClass*
+  template <class Other>
+    requires std::is_convertible_v<Other*, UserClass*>
+  // NOLINTNEXTLINE(google-explicit-constructor) - implicit conversion is intentional for polymorphism support
+  LocalActorRef(const LocalActorRef<Other>& other)
+      : is_empty_(other.is_empty_), actor_id_(other.actor_id_), type_erased_actor_(other.type_erased_actor_) {}
+
+  // Converting assignment operator - delegates to converting constructor
+  template <class Other>
+    requires std::is_convertible_v<Other*, UserClass*>
+  LocalActorRef<UserClass>& operator=(const LocalActorRef<Other>& other) {
+    *this = LocalActorRef<UserClass>(other);
+    return *this;
+  }
+
+  /**
+   * @brief Send message to a local actor. No heap allocation.
+   */
+  template <auto kMethod, class... Args>
+  [[nodiscard]] ex::sender auto SendLocal(Args... args) const {
+    static_assert(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>,
+                  "method is not invocable with the provided arguments");
+    EXA_THROW_CHECK(!IsEmpty()) << "Empty LocalActorRef, cannot call method on it.";
+    EXA_THROW_CHECK(type_erased_actor_ != nullptr) << "TypeErasedActor not set";
+    return type_erased_actor_->template CallActorMethod<kMethod>(std::move(args)...);
+  }
+
+  bool IsEmpty() const { return is_empty_; }
+  uint64_t GetActorId() const { return actor_id_; }
+
+ protected:
+  bool is_empty_;
+  uint64_t actor_id_ = 0;
+  TypeErasedActor* type_erased_actor_ = nullptr;
+};
+
+}  // namespace ex_actor::internal
+
+namespace ex_actor {
+using internal::LocalActorRef;
+}  // namespace ex_actor
+
+namespace std {
+template <class UserClass>
+struct hash<ex_actor::LocalActorRef<UserClass>> {
+  size_t operator()(const ex_actor::LocalActorRef<UserClass>& ref) const {
+    if (ref.IsEmpty()) {
+      return ex_actor::internal::kEmptyActorRefHashVal;
+    }
+    return std::hash<uint64_t>()(ref.GetActorId());
+  }
+};
+}  // namespace std

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -204,14 +204,13 @@ ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeEras
       }()),
 
       backend_actor_(scheduler_->Clone(), ActorConfig {}, scheduler_->Clone(), cluster_config, message_broker_.get()),
-      backend_actor_ref_(this_node_id_, this_node_id_, /*actor_id=*/UINT64_MAX, &backend_actor_,
-                         message_broker_.get()) {}
+      backend_actor_ref_(/*actor_id=*/UINT64_MAX, &backend_actor_) {}
 
 exec::task<bool> ActorRegistry::WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms) {
   if (node_id == this_node_id_) {
     co_return true;
   }
-  co_return co_await backend_actor_ref_.Send<&ActorRegistryBackend::WaitNodeAlive>(node_id, timeout_ms);
+  co_return co_await backend_actor_ref_.SendLocal<&ActorRegistryBackend::WaitNodeAlive>(node_id, timeout_ms);
 }
 
 }  // namespace ex_actor::internal


### PR DESCRIPTION
Introduce LocalActorRef<T> for local-only actor references (no network). ActorRef<T> now inherits from LocalActorRef<T>. SpawnBuilder and ActorRegistry use LocalActorRef<ActorRegistryBackend> since the backend is always local.