### PR TITLE
[API,feat] Node fault tolerance support

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -2,12 +2,46 @@
 
 !!! Note
 
-    This feature is currently experimental. While it's fully functional and ready for use, it's not massively tested in production yet. Bugs, performance issues and API changes should be expected. Welcome to have a try and build together with us!
-
+```
+This feature is currently experimental. While it's fully functional and ready for use, it's not massively tested in production yet. Bugs, performance issues and API changes should be expected. Welcome to have a try and build together with us!
+```
 
 Distributed mode enables you to create actors at remote nodes. When calling a remote actor, all arguments will be
 serialized and sent to the remote node through network, after execution the return value will be deserialized and sent
 back to the caller.
+
+## Start or join a cluster
+
+To start a cluster, you need to pass a `ex_actor::ClusterConfig` to `ex_actor::Init()`.
+
+```cpp
+ex_actor::ClusterConfig cluster_config {
+  // the public address other nodes use to connect to you.
+  // we'll open a listening port at this address.
+  .listen_address = "tcp://10.10.2.145:5301",
+  // set to any node in the cluster to join an existing cluster.
+  // for the first node, leave it empty.
+  .contact_node_address = "tcp://10.10.2.113:5665",
+};
+ex_actor::Init(/*thread_pool_size=*/4, cluster_config);
+```
+
+The cluster is dynamically connected, for the first node, leave the contact node address empty.
+For the remaining nodes, set the contact node address to **any node** in the cluster to join.
+
+## Discover remote nodes
+
+Use `ex_actor::WaitNodeCondition()` to wait until the cluster reaches a desired state. It takes a predicate on the list of alive nodes and a timeout:
+
+```cpp
+auto [nodes, condition_met] = co_await ex_actor::WaitNodeCondition(
+    [](const std::vector<ex_actor::NodeInfo>& nodes) {
+      return nodes.size() >= 2;
+    },
+    /*timeout_ms=*/5000);
+```
+
+The returned `nodes` is a vector of `ex_actor::NodeInfo` (each with `.node_id` and `.address`). Use the address to identify which node is which, then extract `node_id` for use with `Spawn().ToNode()`.
 
 ## Make your actor class be able to be created remotely
 
@@ -23,6 +57,7 @@ class YourClass {
 
 EXA_REMOTE(&YourClass::Create, &YourClass::Method1, &YourClass::Method2);
 
+// `node_id` is extracted from the `NodeInfo` returned by `WaitNodeCondition()`.
 co_await ex_actor::Spawn<&YourClass::Create>().ToNode(node_id);
 ```
 
@@ -31,37 +66,14 @@ Then in `Spawn<>`, provide the factory function pointer (the first argument of `
 
 Such boilerplate is caused by the lack of reflection before C++26. It can be simplified in C++26 using reflection, we'll add a new set of APIs for C++26 in the future, stay tuned!
 
-## Start or join a cluster
-
-To start a cluster, you need to pass a `ex_actor::ClusterConfig` to `ex_actor::Init()`.
-
-```cpp
-ex_actor::ClusterConfig cluster_config {
-  .this_node_id = 19,
-  // the public address other nodes use to connect to you.
-  // we'll open a listening port at this address.
-  .listen_address = "tcp://10.10.2.145:5301",
-  // set to any node in the cluster to join an existing cluster.
-  // for the first node, leave it empty.
-  .contact_node_address = "tcp://10.10.2.113:5665",
-};
-ex_actor::Init(..., cluster_config);
-
-co_await ex_actor::WaitNodeAlive(remote_node_id, /*timeout_ms=*/5000);
-```
-
-The cluster is dynamically connected, for the first node, leave the contact node address empty.
-For the remaining nodes, set the contact node address to **any node** in the cluster to join.
-
-Before operating with the remote node, call `ex_actor::WaitNodeAlive()` to confirm it is reachable; otherwise an exception will be thrown when you call `ex_actor::Spawn()` or `actor_ref.Send()`
-
-## Example
+## Full example
 
 <!-- doc test start, wrapper_script: test/multi_process_test.py -->
 ```cpp
+#include <algorithm>
 #include <cassert>
-#include <cstdlib>
 #include <iostream>
+#include <string>
 #include "ex_actor/api.h"
 
 class PingWorker {
@@ -80,15 +92,12 @@ class PingWorker {
 // 0. Register the class & methods using EXA_REMOTE
 EXA_REMOTE(&PingWorker::Create, &PingWorker::Ping);
 
-// Usage: ./distributed_node <node_id> <listen_address> <remote_node_id> [contact_address]
+// Usage: ./distributed_node <listen_address> [contact_address]
 // The first node in the cluster should omit contact_address.
 exec::task<void> MainCoroutine(int argc, char** argv) {
-  uint32_t this_node_id = std::atoi(argv[1]);
-  std::string listen_address = argv[2];
-  uint32_t remote_node_id = std::atoi(argv[3]);
-  std::string contact_address = (argc > 4) ? argv[4] : "";
+  std::string listen_address = argv[1];
+  std::string contact_address = (argc > 2) ? argv[2] : "";
   ex_actor::ClusterConfig cluster_config {
-      .this_node_id = this_node_id,
       .listen_address = listen_address,
       .contact_node_address = contact_address,
   };
@@ -96,18 +105,27 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
   // 1. Start or join the cluster
   ex_actor::Init(/*thread_pool_size=*/4, cluster_config);
 
-  // 2. Wait for the remote node to be alive
-  bool connected = co_await ex_actor::WaitNodeAlive(remote_node_id, /*timeout_ms=*/5000);
-  if (!connected) {
-    throw std::runtime_error("Cannot connect to node " + std::to_string(remote_node_id));
+  // 2. Wait for the remote node to be discovered
+  auto [nodes, condition_met] = co_await ex_actor::WaitNodeCondition(
+      [](const auto& nodes) { return nodes.size() >= 2; },
+      /*timeout_ms=*/5000);
+  if (!condition_met) {
+    throw std::runtime_error("Cannot connect to any remote node");
   }
 
-  // 3. Create a remote actor and send messages to it
+  // 3. Pick the first remote node (any node whose address differs from ours)
+  auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address != listen_address; });
+  if (it == nodes.end()) {
+    throw std::runtime_error("Cannot find any remote node");
+  }
+  auto remote_node_id = it->node_id;
+
+  // 4. Create a remote actor and send messages to it
   auto ping_worker =
       co_await ex_actor::Spawn<&PingWorker::Create>(/*name=*/"Alice").ToNode(remote_node_id);
   std::string ping_res = co_await ping_worker.Send<&PingWorker::Ping>("hello");
   assert(ping_res == "ack from Alice, msg got: hello");
-  std::cout << "All work done, node id: " << this_node_id << std::endl;
+  std::cout << "All work done" << std::endl;
 
   // Wait for OS exit signal(like CTRL+C or kill) before shutting down, otherwise the process
   // will exit immediately, which might be earlier than the other node finishes its work,
@@ -118,18 +136,55 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
 
 int main(int argc, char** argv) { stdexec::sync_wait(MainCoroutine(argc, argv)); }
 ```
-<!-- doc test end -->
+
+
 
 Compile this program into a binary, let's say `distributed_node`.
 
-usage: `./distributed_node <node_id> <listen_address> <remote_node_id> [contact_address]`
+usage: `./distributed_node <listen_address> [contact_address]`
 
-In one shell, run: `./distributed_node 0 tcp://127.0.0.1:5301 1`, in another shell, run: `./distributed_node 1 tcp://127.0.0.1:5302 0 tcp://127.0.0.1:5301`. Both processes should print "All work done" log.
+In one shell, run: `./distributed_node tcp://127.0.0.1:5301`, in another shell, run: `./distributed_node tcp://127.0.0.1:5302 tcp://127.0.0.1:5301`. Both processes should print "All work done" log.
 
-Node 0 is the first node so it doesn't need a contact address. Node 1 specifies node 0's address as the contact address to join the cluster.
+The first node doesn't need a contact address. The second node specifies the first node's address as the contact address to join the cluster.
 
 The process will block on `ex_actor::WaitOsExitSignal()` until OS exit signal is received. You should kill them manually by CTRL+C or kill command.
 
+## Fault tolerance
+
+When a remote node becomes unreachable (dead, heartbeat timeout, connection refused, etc.), in-flight RPCs throw `ex_actor::ConnectionLost`, by catching this exception you can handle the failure gracefully.
+
+```cpp
+try {
+  co_await ref.Send<&YourClass::Method>();
+} catch (const ex_actor::ConnectionLost& e) {
+  // e.node_id tells you which node was lost
+  // e.what() has a human-readable message
+}
+```
+
+For example, now a node dies, you want to recreate your actor to another node:
+
+```cpp
+bool connection_lost = false;
+try {
+  co_await ref.Send<&YourClass::Method>();
+} catch (const ex_actor::ConnectionLost& e) {
+  connection_lost = true;
+}
+
+if (connection_lost) {
+  std::cout << "I need a new node to join the cluster!" << std::endl;
+  // 1. launch a new node, either by starting a process manually,
+  // or using outer system's API if you are using k8s or slurm etc.
+
+  // 2. wait for the new node to be ready.
+  co_await ex_actor::WaitNodeCondition(...);
+
+  // 3. recreate your actor to the new node. The original actor's state
+  // is lost forever, it's your responsibility to handle the state recovery.
+  auto new_ref = co_await ex_actor::Spawn<&YourClass::Create>().ToNode(new_node_id);
+}
+```
 
 ## Architecture details
 
@@ -140,7 +195,6 @@ It is a reflection-based C++20 serialization library, which can serialize basic 
 
 As for the protocol, since we have a fixed schema by nature(all nodes use the same binary, so the types are the same across all nodes),
 we can take advantage of a schemafull protocol. For this reason, we choose [Cap'n Proto](https://capnproto.org/) from reflect-cpp's supported protocols.
-
 
 ### Network
 

--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -32,7 +32,7 @@ class ActorRef : public LocalActorRef<UserClass> {
  public:
   ActorRef() : LocalActorRef<UserClass>() {}
 
-  ActorRef(uint32_t this_node_id, uint32_t node_id, uint64_t actor_id, TypeErasedActor* actor,
+  ActorRef(uint64_t this_node_id, uint64_t node_id, uint64_t actor_id, TypeErasedActor* actor,
            const LocalActorRef<MessageBroker>& broker_actor_ref)
       : LocalActorRef<UserClass>(actor_id, actor),
         this_node_id_(this_node_id),
@@ -46,7 +46,7 @@ class ActorRef : public LocalActorRef<UserClass> {
     return lhs.node_id_ == rhs.node_id_ && lhs.actor_id_ == rhs.actor_id_;
   }
 
-  void SetLocalRuntimeInfo(uint32_t this_node_id, TypeErasedActor* actor,
+  void SetLocalRuntimeInfo(uint64_t this_node_id, TypeErasedActor* actor,
                            const LocalActorRef<MessageBroker>& broker_actor_ref) {
     this_node_id_ = this_node_id;
     this->type_erased_actor_ = actor;
@@ -100,11 +100,11 @@ class ActorRef : public LocalActorRef<UserClass> {
     return LocalActorRef<UserClass>::template SendLocal<kMethod>(std::move(args)...);
   }
 
-  uint32_t GetNodeId() const { return node_id_; }
+  uint64_t GetNodeId() const { return node_id_; }
 
  private:
-  uint32_t this_node_id_ = 0;
-  uint32_t node_id_ = 0;
+  uint64_t this_node_id_ = 0;
+  uint64_t node_id_ = 0;
   LocalActorRef<MessageBroker> broker_actor_ref_;
 
   template <auto kMethod, class... Args>
@@ -177,7 +177,7 @@ struct hash<ex_actor::ActorRef<UserClass>> {
     if (ref.IsEmpty()) {
       return ex_actor::internal::kEmptyActorRefHashVal;
     }
-    return std::hash<uint64_t>()(ref.GetActorId()) ^ std::hash<uint32_t>()(ref.GetNodeId());
+    return std::hash<uint64_t>()(ref.GetActorId()) ^ std::hash<uint64_t>()(ref.GetNodeId());
   }
 };
 }  // namespace std
@@ -188,7 +188,7 @@ struct hash<ex_actor::ActorRef<UserClass>> {
 
 namespace ex_actor::internal {
 struct ActorRefSerdeContext {
-  uint32_t this_node_id = 0;
+  uint64_t this_node_id = 0;
   std::function<TypeErasedActor*(uint64_t)> actor_look_up_fn;
   LocalActorRef<MessageBroker> broker_actor_ref;
 };
@@ -199,7 +199,7 @@ template <typename U>
 struct Reflector<ex_actor::internal::ActorRef<U>> {
   struct ReflType {
     bool is_empty {};
-    uint32_t node_id {};
+    uint64_t node_id {};
     uint64_t actor_id {};
   };
 

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -41,8 +41,8 @@ namespace ex_actor::internal {
  */
 class ActorRegistryBackend {
  public:
-  explicit ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler,
-                                const ClusterConfig& cluster_config, LocalActorRef<MessageBroker> broker_actor_ref);
+  explicit ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler, uint64_t this_node_id,
+                                LocalActorRef<MessageBroker> broker_actor_ref);
 
   exec::task<void> AsyncDestroyAllActors();
 
@@ -50,7 +50,7 @@ class ActorRegistryBackend {
    * @brief Spawn a local actor with config.
    */
   template <class UserClass, class... Args>
-  exec::task<ActorRef<UserClass>> SpawnWithClass(uint32_t node_id, ActorConfig config, Args... args) {
+  exec::task<ActorRef<UserClass>> SpawnWithClass(uint64_t node_id, ActorConfig config, Args... args) {
     if (node_id != this_node_id_) {
       EXA_THROW << "Spawn<UserClass> can only be used to create local actor, to create remote actor, use "
                    "Spawn<&CreateFn> to provide a fixed signature for remote actor creation. node_id="
@@ -63,7 +63,7 @@ class ActorRegistryBackend {
    * @brief Spawn an actor (local or remote) using a factory function, with config.
    */
   template <auto kCreateFn, class... Args>
-  exec::task<ActorRef<FnReturnType<kCreateFn>>> SpawnWithCreateFn(uint32_t node_id, ActorConfig config, Args... args) {
+  exec::task<ActorRef<FnReturnType<kCreateFn>>> SpawnWithCreateFn(uint64_t node_id, ActorConfig config, Args... args) {
     using UserClass = FnReturnType<kCreateFn>;
     static_assert(std::is_invocable_v<decltype(kCreateFn), Args...>,
                   "Class can't be created by given args and create function");
@@ -120,7 +120,7 @@ class ActorRegistryBackend {
   }
 
   template <class UserClass>
-  exec::task<std::optional<ActorRef<UserClass>>> GetActorRefByName(const uint32_t& node_id,
+  exec::task<std::optional<ActorRef<UserClass>>> GetActorRefByName(const uint64_t& node_id,
                                                                    const std::string& name) const {
     if (node_id == this_node_id_) {
       co_return GetActorRefByName<UserClass>(name);
@@ -144,11 +144,10 @@ class ActorRegistryBackend {
    * @brief Handle a network request. Returns the serialized reply data.
    */
   exec::task<ByteBuffer> HandleNetworkRequest(ByteBuffer request_buffer);
-  exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms);
 
  private:
   template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  exec::task<ActorRef<UserClass>> SpawnLocal(uint32_t node_id, ActorConfig config, Args... args) {
+  exec::task<ActorRef<UserClass>> SpawnLocal(uint64_t node_id, ActorConfig config, Args... args) {
     auto actor_id = GenerateRandomActorId();
     auto actor = std::make_unique<Actor<UserClass, kCreateFn>>(scheduler_->Clone(), config, std::move(args)...);
     auto handle = ActorRef<UserClass>(this_node_id_, node_id, actor_id, actor.get(), broker_actor_ref_);
@@ -164,7 +163,7 @@ class ActorRegistryBackend {
 
   std::mt19937 random_num_generator_;
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
-  uint32_t this_node_id_ = 0;
+  uint64_t this_node_id_ = 0;
   LocalActorRef<MessageBroker> broker_actor_ref_;
   std::unordered_map<uint64_t, std::unique_ptr<TypeErasedActor>> actor_id_to_actor_;
   std::unordered_map<std::string, std::uint64_t> actor_name_to_id_;
@@ -207,12 +206,12 @@ class SpawnBuilder : public ex::sender_t {
   explicit SpawnBuilder(LocalActorRef<ActorRegistryBackend> backend_ref, Args... args)
       : backend_ref_(std::move(backend_ref)), args_(std::move(args)...) {}
 
-  SpawnBuilder& ToNode(uint32_t node_id) & {
+  SpawnBuilder& ToNode(uint64_t node_id) & {
     node_id_ = node_id;
     return *this;
   }
 
-  SpawnBuilder&& ToNode(uint32_t node_id) && {
+  SpawnBuilder&& ToNode(uint64_t node_id) && {
     node_id_ = node_id;
     return std::move(*this);
   }
@@ -240,7 +239,7 @@ class SpawnBuilder : public ex::sender_t {
 
  private:
   template <class Config, class Tuple>
-  auto MakeSender(uint32_t node_id, Config&& config, Tuple&& args) {
+  auto MakeSender(uint64_t node_id, Config&& config, Tuple&& args) {
     return std::apply(
         [this, node_id, config = std::forward<Config>(config)](auto&&... a) mutable {
           if constexpr (kCreateFn == nullptr) {
@@ -257,7 +256,7 @@ class SpawnBuilder : public ex::sender_t {
   }
 
   LocalActorRef<ActorRegistryBackend> backend_ref_;
-  uint32_t node_id_ = 0;
+  uint64_t node_id_ = 0;
   ActorConfig config_ {};
   std::tuple<Args...> args_;
 };
@@ -340,42 +339,20 @@ class ActorRegistry {
    * @brief Find the actor by name at remote node.
    */
   template <class UserClass>
-  SenderOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32_t& node_id,
+  SenderOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint64_t& node_id,
                                                                       const std::string& name) const {
     // resolve overload ambiguity
     constexpr exec::task<std::optional<ActorRef<UserClass>>> (ActorRegistryBackend::*kProcessFn)(
-        const uint32_t& node_id, const std::string& name) const = &ActorRegistryBackend::GetActorRefByName<UserClass>;
+        const uint64_t& node_id, const std::string& name) const = &ActorRegistryBackend::GetActorRefByName<UserClass>;
 
     return WrapSenderWithInlineScheduler(backend_actor_ref_.SendLocal<kProcessFn>(node_id, name));
   }
 
-  exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms);
-
-  // ------------deprecated APIs------------
-
-  /// Backward-compatible alias for Spawn.
-  template <class UserClass, class... Args>
-  [[deprecated("Use Spawn() instead of CreateActor().")]]
-  SenderOf<ActorRef<UserClass>> auto CreateActor(Args... args) {
-    return Spawn<UserClass, Args...>(std::move(args)...);
-  }
-
-  /// @deprecated Use Spawn<UserClass>(args...).ToNode(node_id).WithConfig(config) instead.
-  template <class UserClass, class... Args>
-  [[deprecated("Use Spawn<UserClass>(args...).ToNode(node_id).WithConfig(config) instead.")]]
-  SenderOf<ActorRef<UserClass>> auto SpawnWithConfig(uint32_t node_id, ActorConfig config, Args... args) {
-    return Spawn<UserClass, Args...>(std::move(args)...).ToNode(node_id).WithConfig(std::move(config));
-  }
-
-  /// @deprecated Use Spawn<kCreateFn>(args...).ToNode(node_id).WithConfig(config) instead.
-  template <auto kCreateFn, class... Args>
-  [[deprecated("Use Spawn<kCreateFn>(args...).ToNode(node_id).WithConfig(config) instead.")]]
-  SenderOf<ActorRef<FnReturnType<kCreateFn>>> auto SpawnWithConfig(uint32_t node_id, ActorConfig config, Args... args) {
-    return Spawn<kCreateFn, Args...>(std::move(args)...).ToNode(node_id).WithConfig(std::move(config));
-  }
+  exec::task<WaitNodeConditionResult> WaitNodeCondition(std::function<bool(const std::vector<NodeInfo>&)> predicate,
+                                                        uint64_t timeout_ms);
 
  private:
-  uint32_t this_node_id_;
+  uint64_t this_node_id_;
   WorkSharingThreadPool default_work_sharing_thread_pool_;
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
   std::unique_ptr<Actor<MessageBroker>> broker_actor_;

--- a/include/ex_actor/internal/constants.h
+++ b/include/ex_actor/internal/constants.h
@@ -20,7 +20,6 @@ namespace internal {
 constexpr size_t kEmptyActorRefHashVal = 10086;
 constexpr uint64_t kDefaultHeartbeatTimeoutMs = 5000;
 constexpr uint64_t kDefaultGossipIntervalMs = 500;
-constexpr uint64_t kDefaultWaitNodeAliveTimeoutMs = 4000;
 constexpr size_t kDefaultGossipFanout = 3;
 constexpr uint64_t kDefaultHeartbeatCheckIntervalMs = 100;
 constexpr uint64_t kDefaultWaiterExpirationCheckIntervalMs = 100;

--- a/include/ex_actor/internal/global_registry.h
+++ b/include/ex_actor/internal/global_registry.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -83,10 +84,11 @@ void Shutdown();
 exec::task<void> WaitOsExitSignal();
 
 /**
- * @brief Wait for the node to be alive.
- * @return True if the node is alive before the timeout, false otherwise.
+ * @brief Wait until a predicate on the set of alive nodes is satisfied, or timeout.
+ * @return The list of alive nodes and whether the condition was met before the timeout.
  */
-exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms);
+exec::task<WaitNodeConditionResult> WaitNodeCondition(std::function<bool(const std::vector<NodeInfo>&)> predicate,
+                                                      uint64_t timeout_ms);
 
 /**
  * @brief Ask ex_actor to hold a resource, the resource won't be released until runtime is shut down.
@@ -150,7 +152,7 @@ SenderOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const std::s
  * @brief Find the actor by name at specified node.
  */
 template <class UserClass>
-SenderOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32_t& node_id, const std::string& name) {
+SenderOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint64_t& node_id, const std::string& name) {
   return internal::GetGlobalDefaultRegistry().GetActorRefByName<UserClass>(node_id, name);
 }
 
@@ -160,38 +162,11 @@ SenderOf<std::optional<ActorRef<UserClass>>> auto GetActorRefByName(const uint32
  */
 void ConfigureLogging(const LogConfig& config = {});
 
-// -------------deprecated APIs-------------
-
-struct NodeInfo {
-  /// Unique ID for this node, should be unique within the cluster.
-  uint32_t node_id = 0;
-  /// Format: "<protocol>://<IP>:<port>". For the current node, we'll open a listener on this address. For other nodes,
-  /// we'll connect to this address.
-  std::string address;
-};
-
-/// Init the global default registry in distributed mode, use specified scheduler. Not thread-safe.
-template <ex::scheduler Scheduler>
-[[deprecated(
-    "Deprecated: use cluster_config-based initialization: `Init(uint32_t, const ClusterConfig&)` "
-    "or `ActorRegistry(Scheduler, const ClusterConfig&)`. This API will be removed in the future.")]]
-void Init(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info);
-/// Init the global default registry in distributed mode, use the default work-sharing thread pool as the scheduler. Not
-/// thread-safe.
-[[deprecated(
-    "Deprecated: use `Init(uint32_t, const ClusterConfig&)` instead. This API will be removed in the future.")]]
-void Init(uint32_t thread_pool_size, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info);
-
 }  // namespace ex_actor
 
 // -----------template function implementations(non-template funcs are written in .cc file)-------------
 
 namespace ex_actor {
-
-namespace internal {
-ClusterConfig BuildClusterConfigFromNodeList(uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info);
-void WaitForClusterNodes(uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info);
-}  // namespace internal
 
 template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler) {
@@ -202,21 +177,8 @@ void Init(Scheduler scheduler) {
 }
 
 template <ex::scheduler Scheduler>
-void Init(Scheduler scheduler, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info) {
-  internal::log::Info(
-      "Initializing ex_actor in distributed mode with custom scheduler. this_node_id={}, total_nodes={}", this_node_id,
-      cluster_node_info.size());
-  EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
-  auto cluster_config = internal::BuildClusterConfigFromNodeList(this_node_id, cluster_node_info);
-  AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler), cluster_config));
-  internal::SetupGlobalHandlers();
-  internal::WaitForClusterNodes(this_node_id, cluster_node_info);
-}
-
-template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler, const ClusterConfig& cluster_config) {
-  internal::log::Info("Initializing ex_actor in distributed mode with custom scheduler. this_node_id={}",
-                      cluster_config.this_node_id);
+  internal::log::Info("Initializing ex_actor in distributed mode with custom scheduler.");
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler), cluster_config));
   internal::SetupGlobalHandlers();

--- a/include/ex_actor/internal/message.h
+++ b/include/ex_actor/internal/message.h
@@ -104,18 +104,18 @@ struct NetworkReply {
 struct NodeState {
   bool alive = true;
   uint64_t last_seen_timestamp_ms = 0;
-  uint32_t node_id = 0;
+  uint64_t node_id = 0;
   std::string address;
 };
 
 struct BrokerGossipMessage {
-  uint32_t from_node_id;
+  uint64_t from_node_id;
   std::vector<NodeState> node_states;
 };
 
 struct BrokerTwoWayMessage {
-  uint32_t request_node_id;
-  uint32_t response_node_id;
+  uint64_t request_node_id;
+  uint64_t response_node_id;
   uint64_t request_id;  // the request id in the request node
   ByteBuffer payload;
 };

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -49,20 +49,40 @@ struct NetworkConfig {
 };
 
 struct ClusterConfig {
-  uint32_t this_node_id;
   std::string listen_address;
   std::string contact_node_address;
   NetworkConfig network_config;
 };
+
+struct NodeInfo {
+  uint64_t node_id = 0;
+  std::string address;
+};
+
+/// Thrown when a remote operation fails due to the target node being
+/// unreachable (dead, timed-out heartbeat, connection refused, etc.).
+struct ConnectionLost : public std::runtime_error {
+  uint64_t node_id;
+
+  explicit ConnectionLost(uint64_t node_id, const std::string& message)
+      : std::runtime_error(message), node_id(node_id) {}
+};
+
+struct WaitNodeConditionResult {
+  std::vector<NodeInfo> nodes;
+  bool condition_met;
+};
+
 }  // namespace ex_actor
 
 namespace ex_actor::internal {
 
-struct NodeAlivenessWaiter {
-  explicit NodeAlivenessWaiter(uint64_t deadline_ms) : sem(1), deadline_ms(deadline_ms) {}
+struct NodeConditionWaiter {
+  explicit NodeConditionWaiter(uint64_t deadline_ms) : sem(1), deadline_ms(deadline_ms) {}
   ex_actor::Semaphore sem;
   uint64_t deadline_ms;
-  bool arrived = false;
+  bool condition_met = false;
+  std::function<bool(const std::vector<NodeInfo>&)> predicate;
 };
 
 /**
@@ -125,7 +145,7 @@ class MessageBroker {
  public:
   using RequestHandler = std::function<exec::task<ByteBuffer>(ByteBuffer)>;
 
-  explicit MessageBroker(ClusterConfig cluster_config);
+  explicit MessageBroker(uint64_t this_node_id, ClusterConfig cluster_config);
   ~MessageBroker();
 
   /**
@@ -145,16 +165,17 @@ class MessageBroker {
   exec::task<void> Stop();
 
   /**
-   * @brief Wait for a node to be alive.
-   * @returns True if the node is alive before the timeout, false otherwise.
+   * @brief Wait until predicate(alive_nodes) returns true, or timeout.
+   * @return A pair of (alive nodes snapshot, whether the condition was met).
    */
-  exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms);
+  exec::task<WaitNodeConditionResult> WaitNodeCondition(std::function<bool(const std::vector<NodeInfo>&)> predicate,
+                                                        uint64_t timeout_ms);
 
   /**
    * @brief Send buffer to the remote node and get a response.
    * @return A task containing raw response buffer.
    */
-  exec::task<ByteBuffer> SendRequest(uint32_t to_node_id, ByteBuffer data);
+  exec::task<ByteBuffer> SendRequest(uint64_t to_node_id, ByteBuffer data);
 
   // Called by RecvSocketPuller
   exec::task<void> DispatchReceivedMessage(ByteBuffer raw);
@@ -162,54 +183,58 @@ class MessageBroker {
   // ------------- periodical tasks scheduled in PeriodicalTaskScheduler -------------
   void BroadcastGossip();
   void CheckHeartbeatTimeout();
-  void CheckNodeAlivenessWaiterTimeout();
+  void CheckNodeConditionWaiterTimeout();
 
  private:
   void StartRecvSocketPuller();
   void StartPeriodicalTaskScheduler();
 
-  std::vector<uint32_t> GetRandomPeers(size_t fanout);
+  std::vector<uint64_t> GetRandomPeers(size_t fanout);
 
   void HandleRepliedResponse(BrokerTwoWayMessage response_msg);
   exec::task<void> HandleIncomingRequest(BrokerTwoWayMessage request_msg);
   void HandleGossipMessage(const BrokerGossipMessage& gossip_message);
 
-  void OnNodeAlive(uint32_t node_id);
-  void OnNodeDead(uint32_t node_id);
+  void OnNodeAlive(uint64_t node_id);
+  void OnNodeDead(uint64_t node_id);
 
-  uint64_t SendTwoWayMessage(uint32_t node_id, ByteBuffer data);
-  void SendReply(uint32_t request_node_id, uint64_t request_id, ByteBuffer data);
+  std::vector<NodeInfo> BuildAliveNodeInfoList() const;
+  void EvaluateNodeConditionWaiters();
+
+  uint64_t SendTwoWayMessage(uint64_t node_id, ByteBuffer data);
+  void SendReply(uint64_t request_node_id, uint64_t request_id, ByteBuffer data);
 
   struct OutstandingRequest {
     Semaphore sem;
     ByteBuffer response_bytes;
     std::exception_ptr exception_ptr;
-    uint32_t response_node_id {};
+    uint64_t response_node_id {};
     OutstandingRequest() : sem(1) {}
   };
 
   struct ReplyOperation {
-    uint32_t request_node_id;
+    uint64_t request_node_id;
     uint64_t request_id;
     ByteBuffer data;
   };
 
+  uint64_t this_node_id_;
   ClusterConfig cluster_config_;
   uint64_t send_request_id_counter_ = 0;
 
-  std::unordered_map</*node_id*/ uint32_t, std::vector<ReplyOperation>> deferred_replies_;
+  std::unordered_map</*node_id*/ uint64_t, std::vector<ReplyOperation>> deferred_replies_;
   std::unordered_map</*request_id*/ uint64_t, OutstandingRequest> outstanding_requests_;
 
   bool stopped_ = false;
 
-  std::unordered_map<uint32_t, NodeState> node_id_to_state_;
-  std::unordered_map<uint32_t, std::list<NodeAlivenessWaiter>> node_id_to_waiters_;
-  std::mt19937 rng_ {std::random_device {}()};
+  std::unordered_map<uint64_t, NodeState> node_id_to_state_;
+  std::list<NodeConditionWaiter> node_condition_waiters_;
+  std::mt19937_64 rng_ {std::random_device {}()};
 
   zmq::context_t zmq_context_ {/*io_threads_=*/1};
   // connected at start, then moved to node_id_to_send_socket_ once got gossip from it
   std::optional<zmq::socket_t> contact_node_send_socket_;
-  std::unordered_map<uint32_t, zmq::socket_t> node_id_to_send_socket_;
+  std::unordered_map<uint64_t, zmq::socket_t> node_id_to_send_socket_;
 
   LocalActorRef<MessageBroker> self_actor_ref_;
   RequestHandler request_handler_;

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 #include <exception>
+#include <functional>
+#include <random>
 
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/network.h"
@@ -24,12 +26,9 @@
 namespace ex_actor::internal {
 
 // ----------------------ActorRegistryBackend--------------------------
-ActorRegistryBackend::ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler,
-                                           const ClusterConfig& cluster_config,
+ActorRegistryBackend::ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler, uint64_t this_node_id,
                                            LocalActorRef<MessageBroker> broker_actor_ref)
-    : scheduler_(std::move(scheduler)),
-      this_node_id_(cluster_config.this_node_id),
-      broker_actor_ref_(broker_actor_ref) {
+    : scheduler_(std::move(scheduler)), this_node_id_(this_node_id), broker_actor_ref_(broker_actor_ref) {
   InitRandomNumGenerator();
 }
 
@@ -153,11 +152,6 @@ exec::task<ByteBuffer> ActorRegistryBackend::HandleActorMethodCallRequest(ActorM
   }
 }
 
-exec::task<bool> ActorRegistryBackend::WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms) {
-  EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty()) << "Broker actor not set";
-  co_return co_await broker_actor_ref_.SendLocal<&MessageBroker::WaitNodeAlive>(node_id, timeout_ms);
-}
-
 // ----------------------ActorRegistry--------------------------
 ActorRegistry::~ActorRegistry() {
   log::Info("Start to shutdown actor registry");
@@ -175,17 +169,23 @@ ActorRegistry::~ActorRegistry() {
 
 ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler,
                              const ClusterConfig& cluster_config)
-    : this_node_id_(cluster_config.this_node_id),
+    : this_node_id_([] {
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
+        // Mask off the sign bit so the value is serializable by Cap'n Proto (which uses int64)
+        return gen() & 0x7FFF'FFFF'FFFF'FFFF;
+      }()),
       default_work_sharing_thread_pool_(thread_pool_size),
       scheduler_(scheduler != nullptr ? std::move(scheduler)
                                       : std::make_unique<AnyStdExecScheduler<WorkSharingThreadPool::Scheduler>>(
                                             default_work_sharing_thread_pool_.GetScheduler())),
       broker_actor_(cluster_config.listen_address.empty()
                         ? nullptr
-                        : std::make_unique<Actor<MessageBroker>>(scheduler_->Clone(), ActorConfig {}, cluster_config)),
+                        : std::make_unique<Actor<MessageBroker>>(scheduler_->Clone(), ActorConfig {}, this_node_id_,
+                                                                 cluster_config)),
       broker_actor_ref_(broker_actor_ ? LocalActorRef<MessageBroker>(/*actor_id=*/UINT64_MAX, broker_actor_.get())
                                       : LocalActorRef<MessageBroker> {}),
-      backend_actor_(scheduler_->Clone(), ActorConfig {}, scheduler_->Clone(), cluster_config, broker_actor_ref_),
+      backend_actor_(scheduler_->Clone(), ActorConfig {}, scheduler_->Clone(), this_node_id_, broker_actor_ref_),
       backend_actor_ref_(/*actor_id=*/UINT64_MAX, &backend_actor_) {
   if (!broker_actor_ref_.IsEmpty()) {
     NotifyOnSpawned<MessageBroker>(broker_actor_.get(), broker_actor_ref_);
@@ -196,13 +196,14 @@ ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeEras
     ex::sync_wait(broker_actor_ref_.SendLocal<&MessageBroker::Start>(std::move(request_handler)));
   }
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
+  log::Info("ActorRegistry created, node_id={}", this_node_id_);
 }
 
-exec::task<bool> ActorRegistry::WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms) {
-  if (node_id == this_node_id_) {
-    co_return true;
-  }
-  co_return co_await backend_actor_ref_.SendLocal<&ActorRegistryBackend::WaitNodeAlive>(node_id, timeout_ms);
+exec::task<WaitNodeConditionResult> ActorRegistry::WaitNodeCondition(
+    std::function<bool(const std::vector<NodeInfo>&)> predicate, uint64_t timeout_ms) {
+  EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty())
+      << "WaitNodeCondition requires distributed mode, add ClusterConfig to Init() to enable distributed mode";
+  co_return co_await broker_actor_ref_.SendLocal<&MessageBroker::WaitNodeCondition>(std::move(predicate), timeout_ms);
 }
 
 }  // namespace ex_actor::internal

--- a/src/ex_actor/internal/global_registry.cc
+++ b/src/ex_actor/internal/global_registry.cc
@@ -16,10 +16,10 @@
 
 #include <csignal>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <vector>
 
-#include "ex_actor/internal/constants.h"
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/network.h"
 #include "ex_actor/internal/util.h"
@@ -100,37 +100,6 @@ static void RegisterAtExitCleanup() {
 
 void SetupGlobalHandlers() { RegisterAtExitCleanup(); }
 
-ClusterConfig BuildClusterConfigFromNodeList(uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info) {
-  ClusterConfig cluster_config {.this_node_id = this_node_id};
-
-  uint32_t min_id = this_node_id;
-  std::string min_id_address;
-
-  for (const auto& node : cluster_node_info) {
-    if (node.node_id < min_id) {
-      min_id = node.node_id;
-      min_id_address = node.address;
-    }
-
-    if (node.node_id == this_node_id) {
-      cluster_config.listen_address = node.address;
-    }
-  }
-  if (min_id != this_node_id) {
-    cluster_config.contact_node_address = min_id_address;
-  }
-  return cluster_config;
-}
-
-void WaitForClusterNodes(uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info) {
-  for (const auto& node : cluster_node_info) {
-    if (node.node_id != this_node_id) {
-      auto [connected] =
-          stdexec::sync_wait(ex_actor::WaitNodeAlive(node.node_id, kDefaultWaitNodeAliveTimeoutMs)).value();
-      EXA_THROW_CHECK(connected) << "Cannot connect to the node " << node.node_id;
-    }
-  }
-}
 }  // namespace ex_actor::internal
 
 namespace ex_actor {
@@ -142,22 +111,9 @@ void Init(uint32_t thread_pool_size) {
   internal::SetupGlobalHandlers();
 }
 
-void Init(uint32_t thread_pool_size, uint32_t this_node_id, const std::vector<NodeInfo>& cluster_node_info) {
-  internal::log::Info(
-      "Initializing ex_actor in distributed mode with default scheduler, thread_pool_size={}, this_node_id={}, "
-      "total_nodes={}",
-      thread_pool_size, this_node_id, cluster_node_info.size());
-  EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
-  auto cluster_config = internal::BuildClusterConfigFromNodeList(this_node_id, cluster_node_info);
-  global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size, cluster_config);
-  internal::SetupGlobalHandlers();
-  internal::WaitForClusterNodes(this_node_id, cluster_node_info);
-}
-
 void Init(uint32_t thread_pool_size, const ClusterConfig& cluster_config) {
-  internal::log::Info(
-      "Initializing ex_actor in distributed mode with default scheduler, thread_pool_size={}, this_node_id={}, ",
-      thread_pool_size, cluster_config.this_node_id);
+  internal::log::Info("Initializing ex_actor in distributed mode with default scheduler, thread_pool_size={}",
+                      thread_pool_size);
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size, cluster_config);
   internal::SetupGlobalHandlers();
@@ -165,8 +121,9 @@ void Init(uint32_t thread_pool_size, const ClusterConfig& cluster_config) {
 
 void HoldResource(std::shared_ptr<void> resource) { resource_holder.push_back(std::move(resource)); }
 
-exec::task<bool> WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms) {
-  co_return co_await global_default_registry->WaitNodeAlive(node_id, timeout_ms);
+exec::task<WaitNodeConditionResult> WaitNodeCondition(std::function<bool(const std::vector<NodeInfo>&)> predicate,
+                                                      uint64_t timeout_ms) {
+  co_return co_await global_default_registry->WaitNodeCondition(std::move(predicate), timeout_ms);
 }
 
 exec::task<void> WaitOsExitSignal() {

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -145,12 +145,13 @@ void PeriodicalTaskScheduler::Loop(const std::stop_token& stop_token) {
 
 // ----------------------MessageBroker--------------------------
 
-MessageBroker::MessageBroker(ClusterConfig cluster_config) : cluster_config_(std::move(cluster_config)) {
+MessageBroker::MessageBroker(uint64_t this_node_id, ClusterConfig cluster_config)
+    : this_node_id_(this_node_id), cluster_config_(std::move(cluster_config)) {
   EXA_THROW_CHECK(!cluster_config_.listen_address.empty()) << "listen_address must not be empty";
-  node_id_to_state_[cluster_config_.this_node_id] = {.alive = true,
-                                                     .last_seen_timestamp_ms = GetTimeMs(),
-                                                     .node_id = cluster_config_.this_node_id,
-                                                     .address = cluster_config_.listen_address};
+  node_id_to_state_[this_node_id_] = {.alive = true,
+                                      .last_seen_timestamp_ms = GetTimeMs(),
+                                      .node_id = this_node_id_,
+                                      .address = cluster_config_.listen_address};
   if (!cluster_config_.contact_node_address.empty()) {
     EXA_THROW_CHECK_NE(cluster_config_.contact_node_address, cluster_config_.listen_address);
     // will be moved into node_id_to_send_socket_ once got gossip from it
@@ -162,7 +163,7 @@ MessageBroker::MessageBroker(ClusterConfig cluster_config) : cluster_config_(std
 
 MessageBroker::~MessageBroker() {
   if (!stopped_) {
-    log::Critical("MessageBroker destroyed without calling Stop() first, node_id={}", cluster_config_.this_node_id);
+    log::Critical("MessageBroker destroyed without calling Stop() first, node_id={}", this_node_id_);
   }
 }
 
@@ -177,16 +178,16 @@ void MessageBroker::Start(RequestHandler request_handler) {
 }
 
 exec::task<void> MessageBroker::Stop() {
-  log::Info("Node {} stopping message broker", cluster_config_.this_node_id);
+  log::Info("Node {} stopping message broker", this_node_id_);
   if (periodical_task_scheduler_ != nullptr) {
     periodical_task_scheduler_->Stop();
   }
   if (recv_socket_puller_ != nullptr) {
     recv_socket_puller_->Stop();
   }
-  log::Info("Node {}'s message broker stopped, waiting for in-flight tasks", cluster_config_.this_node_id);
+  log::Info("Node {}'s message broker stopped, waiting for in-flight tasks", this_node_id_);
   co_await async_scope_.on_empty();
-  log::Info("Node {}'s message broker fully stopped", cluster_config_.this_node_id);
+  log::Info("Node {}'s message broker fully stopped", this_node_id_);
   stopped_ = true;
 }
 
@@ -198,17 +199,17 @@ exec::task<void> MessageBroker::DispatchReceivedMessage(ByteBuffer raw) {
     co_return;
   }
   auto& two_way = std::get<BrokerTwoWayMessage>(broker_msg.variant);
-  if (two_way.request_node_id == cluster_config_.this_node_id) {
+  if (two_way.request_node_id == this_node_id_) {
     HandleRepliedResponse(std::move(two_way));
-  } else if (two_way.response_node_id == cluster_config_.this_node_id) {
+  } else if (two_way.response_node_id == this_node_id_) {
     co_await HandleIncomingRequest(std::move(two_way));
   } else {
     EXA_THROW << "Received two-way message not addressed to this node";
   }
 }
 
-exec::task<ByteBuffer> MessageBroker::SendRequest(uint32_t to_node_id, ByteBuffer data) {
-  EXA_THROW_CHECK_NE(to_node_id, cluster_config_.this_node_id) << "Cannot send message to current node";
+exec::task<ByteBuffer> MessageBroker::SendRequest(uint64_t to_node_id, ByteBuffer data) {
+  EXA_THROW_CHECK_NE(to_node_id, this_node_id_) << "Cannot send message to current node";
   uint64_t request_id = SendTwoWayMessage(to_node_id, std::move(data));
   auto [iter, inserted] = outstanding_requests_.try_emplace(request_id);
   EXA_THROW_CHECK(inserted);
@@ -227,30 +228,31 @@ exec::task<ByteBuffer> MessageBroker::SendRequest(uint32_t to_node_id, ByteBuffe
   co_return std::move(response_bytes);
 }
 
-exec::task<bool> MessageBroker::WaitNodeAlive(uint32_t node_id, uint64_t timeout_ms) {
-  if (auto iter = node_id_to_state_.find(node_id); iter != node_id_to_state_.end()) {
-    auto& [found_node_id, node_state] = *iter;
-    if (node_state.alive) {
-      co_return true;
-    }
+exec::task<WaitNodeConditionResult> MessageBroker::WaitNodeCondition(
+    std::function<bool(const std::vector<NodeInfo>&)> predicate, uint64_t timeout_ms) {
+  auto alive_nodes = BuildAliveNodeInfoList();
+  if (predicate(alive_nodes)) {
+    co_return WaitNodeConditionResult {.nodes = std::move(alive_nodes), .condition_met = true};
   }
-  auto& waiters = node_id_to_waiters_[node_id];
-  auto waiter = waiters.emplace(waiters.end(), GetTimeMs() + timeout_ms);
 
-  co_await waiter->sem.OnDrained();
-  bool arrived = waiter->arrived;
-  waiters.erase(waiter);
-  co_return arrived;
+  auto waiter_it = node_condition_waiters_.emplace(node_condition_waiters_.end(), GetTimeMs() + timeout_ms);
+  waiter_it->predicate = std::move(predicate);
+
+  co_await waiter_it->sem.OnDrained();
+  bool met = waiter_it->condition_met;
+  node_condition_waiters_.erase(waiter_it);
+
+  co_return WaitNodeConditionResult {.nodes = BuildAliveNodeInfoList(), .condition_met = met};
 }
 
-std::vector<uint32_t> MessageBroker::GetRandomPeers(size_t fanout) {
+std::vector<uint64_t> MessageBroker::GetRandomPeers(size_t fanout) {
   EXA_THROW_CHECK_GT(fanout, 0);
 
   // get all alive nodes except ourselves
-  std::vector<uint32_t> node_ids;
+  std::vector<uint64_t> node_ids;
   node_ids.reserve(node_id_to_state_.size());
   for (const auto& [node_id, node_state] : node_id_to_state_) {
-    if (node_id != cluster_config_.this_node_id && node_state.alive) {
+    if (node_id != this_node_id_ && node_state.alive) {
       node_ids.emplace_back(node_id);
     }
   }
@@ -265,12 +267,12 @@ std::vector<uint32_t> MessageBroker::GetRandomPeers(size_t fanout) {
 
 void MessageBroker::BroadcastGossip() {
   // update last seen timestamp for ourselves to current time
-  MapAt(node_id_to_state_, cluster_config_.this_node_id).last_seen_timestamp_ms = GetTimeMs();
+  MapAt(node_id_to_state_, this_node_id_).last_seen_timestamp_ms = GetTimeMs();
 
   // broadcast all known node states(include ourselves) to random peers
-  std::vector<uint32_t> node_ids = GetRandomPeers(cluster_config_.network_config.gossip_fanout);
+  std::vector<uint64_t> node_ids = GetRandomPeers(cluster_config_.network_config.gossip_fanout);
   BrokerGossipMessage gossip_message;
-  gossip_message.from_node_id = cluster_config_.this_node_id;
+  gossip_message.from_node_id = this_node_id_;
   gossip_message.node_states.reserve(node_id_to_state_.size());
   for (const auto& [node_id, node_state] : node_id_to_state_) {
     gossip_message.node_states.emplace_back(node_state);
@@ -278,7 +280,7 @@ void MessageBroker::BroadcastGossip() {
   BrokerMessage broker_msg {.variant = std::move(gossip_message)};
   auto serialized = Serialize(broker_msg);
 
-  for (uint32_t node_id : node_ids) {
+  for (uint64_t node_id : node_ids) {
     auto& node_state = MapAt(node_id_to_state_, node_id);
     auto& socket = MapAt(node_id_to_send_socket_, node_id);
     EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::none));
@@ -290,8 +292,8 @@ void MessageBroker::BroadcastGossip() {
 
 void MessageBroker::CheckHeartbeatTimeout() {
   for (auto& [node_id, state] : node_id_to_state_) {
-    if (!state.alive                                // already dead
-        || node_id == cluster_config_.this_node_id  // ourselves
+    if (!state.alive                 // already dead
+        || node_id == this_node_id_  // ourselves
         || GetTimeMs() - state.last_seen_timestamp_ms <
                cluster_config_.network_config.heartbeat_timeout_ms  // not timeout yet
     ) {
@@ -302,15 +304,13 @@ void MessageBroker::CheckHeartbeatTimeout() {
   }
 }
 
-void MessageBroker::CheckNodeAlivenessWaiterTimeout() {
+void MessageBroker::CheckNodeConditionWaiterTimeout() {
   auto now_ms = GetTimeMs();
-  for (auto& [node_id, waiters] : node_id_to_waiters_) {
-    for (auto it = waiters.begin(); it != waiters.end();) {
-      auto& waiter = *it;
-      ++it;  // advance before signaling -- the coroutine may erase this node on resume
-      if (!waiter.arrived && waiter.deadline_ms <= now_ms) {
-        waiter.sem.Acquire(1);
-      }
+  for (auto it = node_condition_waiters_.begin(); it != node_condition_waiters_.end();) {
+    auto& waiter = *it;
+    ++it;  // advance before signaling -- the coroutine may erase this entry on resume
+    if (!waiter.condition_met && waiter.deadline_ms <= now_ms) {
+      waiter.sem.Acquire(1);
     }
   }
 }
@@ -319,7 +319,7 @@ void MessageBroker::StartRecvSocketPuller() {
   zmq::socket_t recv_socket {zmq_context_, zmq::socket_type::dealer};
   recv_socket.bind(cluster_config_.listen_address);
   recv_socket.set(zmq::sockopt::linger, 0);
-  log::Info("Node {}'s recv socket bound to {}", cluster_config_.this_node_id, cluster_config_.listen_address);
+  log::Info("Node {}'s recv socket bound to {}", this_node_id_, cluster_config_.listen_address);
 
   recv_socket_puller_ = std::make_unique<RecvSocketPuller>(std::move(recv_socket), [this](ByteBuffer raw) {
     async_scope_.spawn(self_actor_ref_.SendLocal<&MessageBroker::DispatchReceivedMessage>(std::move(raw)));
@@ -335,7 +335,7 @@ void MessageBroker::StartPeriodicalTaskScheduler() {
       [this]() { async_scope_.spawn(self_actor_ref_.SendLocal<&MessageBroker::CheckHeartbeatTimeout>()); },
       kDefaultHeartbeatCheckIntervalMs);
   periodical_task_scheduler_->Register(
-      [this]() { async_scope_.spawn(self_actor_ref_.SendLocal<&MessageBroker::CheckNodeAlivenessWaiterTimeout>()); },
+      [this]() { async_scope_.spawn(self_actor_ref_.SendLocal<&MessageBroker::CheckNodeConditionWaiterTimeout>()); },
       kDefaultWaiterExpirationCheckIntervalMs);
 }
 
@@ -383,9 +383,9 @@ exec::task<void> MessageBroker::HandleIncomingRequest(BrokerTwoWayMessage reques
   SendReply(request_msg.request_node_id, request_msg.request_id, std::move(reply_data));
 }
 
-void MessageBroker::OnNodeAlive(uint32_t node_id) {
+void MessageBroker::OnNodeAlive(uint64_t node_id) {
   const auto& new_node = MapAt(node_id_to_state_, node_id);
-  log::Info("[Gossip] Node {} found node {}, connecting to it at {}", cluster_config_.this_node_id, new_node.node_id,
+  log::Info("[Gossip] Node {} found node {}, connecting to it at {}", this_node_id_, new_node.node_id,
             new_node.address);
 
   // Create send socket
@@ -399,17 +399,7 @@ void MessageBroker::OnNodeAlive(uint32_t node_id) {
     contact_node_send_socket_ = std::nullopt;
   }
 
-  // Notify waiters
-  auto waiter_iter = node_id_to_waiters_.find(node_id);
-  if (waiter_iter != node_id_to_waiters_.end()) {
-    auto& [waiter_node_id, waiters] = *waiter_iter;
-    for (auto waiter_iter = waiters.begin(); waiter_iter != waiters.end();) {
-      auto& waiter = *waiter_iter;
-      ++waiter_iter;  // advance before signaling -- the coroutine may erase this node on resume
-      waiter.arrived = true;
-      waiter.sem.Acquire(1);
-    }
-  }
+  EvaluateNodeConditionWaiters();
 
   // flush deferred replies
   auto node_handle = deferred_replies_.extract(new_node.node_id);
@@ -421,41 +411,43 @@ void MessageBroker::OnNodeAlive(uint32_t node_id) {
   }
 }
 
-void MessageBroker::OnNodeDead(uint32_t node_id) {
+void MessageBroker::OnNodeDead(uint64_t node_id) {
   log::Warn("Node {} detects that node {} is dead, all requests to this node will be failed, heartbeat timeout is {}ms",
-            cluster_config_.this_node_id, node_id, cluster_config_.network_config.heartbeat_timeout_ms);
+            this_node_id_, node_id, cluster_config_.network_config.heartbeat_timeout_ms);
   // Error out waiting outstanding requests
   for (auto it = outstanding_requests_.begin(); it != outstanding_requests_.end();) {
     auto& [request_id, request] = *it;
     ++it;  // advance before signaling -- the coroutine may erase this entry on resume
     if (request.response_node_id == node_id) {
       request.exception_ptr = std::make_exception_ptr(
-          ThrowStream() << fmt_lib::format("Node {} is dead, cannot complete request", node_id));
+          ConnectionLost(node_id, fmt_lib::format("Node {} is dead, cannot complete request", node_id)));
       request.sem.Acquire(1);
     }
   }
   deferred_replies_.erase(node_id);
+
+  EvaluateNodeConditionWaiters();
 }
 
-uint64_t MessageBroker::SendTwoWayMessage(uint32_t node_id, ByteBuffer data) {
+uint64_t MessageBroker::SendTwoWayMessage(uint64_t node_id, ByteBuffer data) {
   auto request_id = send_request_id_counter_++;
   BrokerMessage broker_msg {.variant = BrokerTwoWayMessage {
-                                .request_node_id = cluster_config_.this_node_id,
+                                .request_node_id = this_node_id_,
                                 .response_node_id = node_id,
                                 .request_id = request_id,
                                 .payload = std::move(data),
                             }};
   auto socket_it = node_id_to_send_socket_.find(node_id);
   if (socket_it == node_id_to_send_socket_.end()) {
-    EXA_THROW << fmt_lib::format("Node {} is trying to send request to an unconnected node {}",
-                                 cluster_config_.this_node_id, node_id);
+    throw ConnectionLost(node_id, fmt_lib::format("Node {} is trying to send request to an unconnected node {}",
+                                                  this_node_id_, node_id));
   }
   auto& [target_node_id, socket] = *socket_it;
   EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::none));
   return request_id;
 }
 
-void MessageBroker::SendReply(uint32_t request_node_id, uint64_t request_id, ByteBuffer data) {
+void MessageBroker::SendReply(uint64_t request_node_id, uint64_t request_id, ByteBuffer data) {
   auto socket_it = node_id_to_send_socket_.find(request_node_id);
   if (socket_it == node_id_to_send_socket_.end()) {
     // The requesting node connected to our recv socket and sent a request, but we haven't
@@ -476,11 +468,34 @@ void MessageBroker::SendReply(uint32_t request_node_id, uint64_t request_id, Byt
   auto& [target_node_id, socket] = *socket_it;
   BrokerMessage broker_msg {.variant = BrokerTwoWayMessage {
                                 .request_node_id = request_node_id,
-                                .response_node_id = cluster_config_.this_node_id,
+                                .response_node_id = this_node_id_,
                                 .request_id = request_id,
                                 .payload = std::move(data),
                             }};
   EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::none));
+}
+
+std::vector<NodeInfo> MessageBroker::BuildAliveNodeInfoList() const {
+  std::vector<NodeInfo> result;
+  result.reserve(node_id_to_state_.size());
+  for (const auto& [node_id, state] : node_id_to_state_) {
+    if (state.alive) {
+      result.push_back(NodeInfo {.node_id = node_id, .address = state.address});
+    }
+  }
+  return result;
+}
+
+void MessageBroker::EvaluateNodeConditionWaiters() {
+  auto alive_nodes = BuildAliveNodeInfoList();
+  for (auto it = node_condition_waiters_.begin(); it != node_condition_waiters_.end();) {
+    auto& waiter = *it;
+    ++it;  // advance before signaling -- the coroutine may erase this entry on resume
+    if (!waiter.condition_met && waiter.predicate(alive_nodes)) {
+      waiter.condition_met = true;
+      waiter.sem.Acquire(1);
+    }
+  }
 }
 
 }  // namespace ex_actor::internal

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <barrier>
 #include <exception>
 #include <memory>
@@ -111,18 +112,33 @@ EXA_REMOTE(&RetVoid::Create, &RetVoid::ReturnVoid, &RetVoid::CoroutineReturnVoid
 
 TEST(DistributedTest, ConstructionInDistributedModeWithDefaultScheduler) {
   std::barrier bar {2};
-  auto node_main = [&bar](uint32_t this_node_id) -> exec::task<void> {
+  auto node_main = [&bar](size_t index) -> exec::task<void> {
     std::vector<std::string> addresses = {"tcp://127.0.0.1:5301", "tcp://127.0.0.1:5302"};
     ex_actor::ClusterConfig cluster_config {
-        .this_node_id = this_node_id,
-        .listen_address = addresses.at(this_node_id),
-        .contact_node_address = (this_node_id == 0) ? "" : addresses.at(0),
+        .listen_address = addresses.at(index),
+        .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
     ex_actor::ActorRegistry registry(/*thread_pool_size=*/4, cluster_config);
 
-    uint32_t remote_node_id = (this_node_id + 1) % addresses.size();
-    bool connected = co_await registry.WaitNodeAlive(remote_node_id, 5000);
-    EXPECT_TRUE(connected);
+    auto [nodes, condition_met] =
+        co_await registry.WaitNodeCondition([](const auto& nodes) { return nodes.size() >= 2; },
+                                            /*timeout_ms=*/5000);
+    EXPECT_TRUE(condition_met);
+    EXPECT_GE(nodes.size(), 2U);
+    if (nodes.size() < 2U) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+
+    std::string remote_address = addresses.at(1 - index);
+    auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == remote_address; });
+    EXPECT_NE(it, nodes.end());
+    if (it == nodes.end()) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+    auto remote_node_id = it->node_id;
+
     auto ping_worker = co_await registry.Spawn<&PingWorker::Create>(/*name=*/"Alice").ToNode(remote_node_id);
     auto ping = ping_worker.Send<&PingWorker::Ping>("hello");
     auto ping_res = co_await std::move(ping);
@@ -135,27 +151,52 @@ TEST(DistributedTest, ConstructionInDistributedModeWithDefaultScheduler) {
 
 TEST(DistributedTest, ConstructionInDistributedMode) {
   std::barrier bar {2};
-  auto node_main = [&bar](uint32_t this_node_id) -> exec::task<void> {
+  auto node_main = [&bar](size_t index) -> exec::task<void> {
     ex_actor::WorkSharingThreadPool thread_pool(4);
     std::vector<std::string> addresses = {"tcp://127.0.0.1:5301", "tcp://127.0.0.1:5302"};
     ex_actor::ClusterConfig cluster_config {
-        .this_node_id = this_node_id,
-        .listen_address = addresses.at(this_node_id),
-        .contact_node_address = (this_node_id == 0) ? "" : addresses.at(0),
+        .listen_address = addresses.at(index),
+        .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler(), cluster_config);
 
     // test local creation
     auto local_a = co_await registry.Spawn<A>();
     auto local_b = co_await registry.Spawn<B>();
-    auto local_a2 = co_await registry.Spawn<A>().ToNode(this_node_id);
+    auto local_a2 = co_await registry.Spawn<A>();
 
     // test remote creation
-    uint32_t remote_node_id = (this_node_id + 1) % addresses.size();
-    bool connected = co_await registry.WaitNodeAlive(remote_node_id, 5000);
-    EXPECT_TRUE(connected);
+    auto [nodes, condition_met] =
+        co_await registry.WaitNodeCondition([](const auto& nodes) { return nodes.size() >= 2; },
+                                            /*timeout_ms=*/5000);
+    EXPECT_TRUE(condition_met);
+    EXPECT_GE(nodes.size(), 2U);
+    if (nodes.size() < 2U) {
+      bar.arrive_and_wait();
+      co_return;
+    }
 
-    logging::Info("node {} creating remote actor A", this_node_id);
+    std::string this_address = addresses.at(index);
+    std::string remote_address = addresses.at(1 - index);
+    auto self_it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == this_address; });
+    auto remote_it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == remote_address; });
+    EXPECT_NE(self_it, nodes.end());
+    EXPECT_NE(remote_it, nodes.end());
+    if (self_it == nodes.end() || remote_it == nodes.end()) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+    auto this_node_id = self_it->node_id;
+    auto remote_node_id = remote_it->node_id;
+
+    // test ToNode with this_node_id (spawn "remotely" on self)
+    logging::Info("node {} creating actor on self via ToNode", index);
+    auto self_a = co_await registry.Spawn<&A::Create>().ToNode(this_node_id);
+    auto self_ping = co_await registry.Spawn<&PingWorker::Create>(/*name=*/"Self").ToNode(this_node_id);
+    auto self_reply = co_await self_ping.Send<&PingWorker::Ping>("hi");
+    EXPECT_EQ(self_reply, "ack from Self, msg got: hi");
+
+    logging::Info("node {} creating remote actor A", index);
     /*
     before gcc 13, we can't use heap-allocated temp variable after co_await, or there will be a double free error.
     here actor_name is heap allocated. so when using ActorConfig with actor_name, we should define it explicitly.
@@ -172,7 +213,7 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
     ex_actor::ActorConfig a_config {.actor_name = "A"};
     auto remote_a = co_await registry.Spawn<&A::Create>().ToNode(remote_node_id).WithConfig(a_config);
 
-    logging::Info("node {} creating remote actor B", this_node_id);
+    logging::Info("node {} creating remote actor B", index);
     auto remote_b = co_await registry.Spawn<&B::Create>(1, "asd", std::make_unique<int>()).ToNode(remote_node_id);
 
     logging::Info("creating remote actor C without registering with EXA_REMOTE");
@@ -228,19 +269,33 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
 
 TEST(DistributedTest, ActorLookUpInDistributeMode) {
   std::barrier bar {2};
-  auto node_main = [&bar](uint32_t this_node_id) -> exec::task<void> {
+  auto node_main = [&bar](size_t index) -> exec::task<void> {
     ex_actor::WorkSharingThreadPool thread_pool(4);
     std::vector<std::string> addresses = {"tcp://127.0.0.1:5301", "tcp://127.0.0.1:5302"};
     ex_actor::ClusterConfig cluster_config {
-        .this_node_id = this_node_id,
-        .listen_address = addresses.at(this_node_id),
-        .contact_node_address = (this_node_id == 0) ? "" : addresses.at(0),
+        .listen_address = addresses.at(index),
+        .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler(), cluster_config);
 
-    uint32_t remote_node_id = (this_node_id + 1) % addresses.size();
-    bool connected = co_await registry.WaitNodeAlive(remote_node_id, 5000);
-    EXPECT_TRUE(connected);
+    auto [nodes, condition_met] =
+        co_await registry.WaitNodeCondition([](const auto& nodes) { return nodes.size() >= 2; },
+                                            /*timeout_ms=*/5000);
+    EXPECT_TRUE(condition_met);
+    EXPECT_GE(nodes.size(), 2U);
+    if (nodes.size() < 2U) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+
+    std::string remote_address = addresses.at(1 - index);
+    auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == remote_address; });
+    EXPECT_NE(it, nodes.end());
+    if (it == nodes.end()) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+    auto remote_node_id = it->node_id;
     ex_actor::ActorConfig echoer_config {.actor_name = "Alice"};
     auto remote_actor = co_await registry.Spawn<&Echoer::Create>().ToNode(remote_node_id).WithConfig(echoer_config);
     auto lookup_result = co_await registry.GetActorRefByName<Echoer>(remote_node_id, "Alice");
@@ -267,19 +322,33 @@ TEST(DistributedTest, ActorLookUpInDistributeMode) {
 
 TEST(DistributedTest, ActorRefSerializationTest) {
   std::barrier bar {2};
-  auto node_main = [&bar](uint32_t this_node_id) -> exec::task<void> {
+  auto node_main = [&bar](size_t index) -> exec::task<void> {
     ex_actor::WorkSharingThreadPool thread_pool(4);
     std::vector<std::string> addresses = {"tcp://127.0.0.1:5301", "tcp://127.0.0.1:5302"};
     ex_actor::ClusterConfig cluster_config {
-        .this_node_id = this_node_id,
-        .listen_address = addresses.at(this_node_id),
-        .contact_node_address = (this_node_id == 0) ? "" : addresses.at(0),
+        .listen_address = addresses.at(index),
+        .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler(), cluster_config);
 
-    uint32_t remote_node_id = (this_node_id + 1) % addresses.size();
-    bool connected = co_await registry.WaitNodeAlive(remote_node_id, 5000);
-    EXPECT_TRUE(connected);
+    auto [nodes, condition_met] =
+        co_await registry.WaitNodeCondition([](const auto& nodes) { return nodes.size() >= 2; },
+                                            /*timeout_ms=*/5000);
+    EXPECT_TRUE(condition_met);
+    EXPECT_GE(nodes.size(), 2U);
+    if (nodes.size() < 2U) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+
+    std::string remote_address = addresses.at(1 - index);
+    auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == remote_address; });
+    EXPECT_NE(it, nodes.end());
+    if (it == nodes.end()) {
+      bar.arrive_and_wait();
+      co_return;
+    }
+    auto remote_node_id = it->node_id;
 
     auto local_actor_a = co_await registry.Spawn<Echoer>();
     auto local_actor_b = co_await registry.Spawn<Echoer>();

--- a/test/dynamic_connectivity_test.cc
+++ b/test/dynamic_connectivity_test.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -42,73 +43,91 @@ enum class TestType : uint8_t {
 
 class DynamicConnectivityTest {
  public:
-  DynamicConnectivityTest(uint32_t this_node_id, uint32_t cluster_size, TestType type)
-      : this_node_id_(this_node_id), cluster_size_(cluster_size), type_(type) {}
+  DynamicConnectivityTest(uint32_t this_index, uint32_t cluster_size, TestType type)
+      : this_index_(this_index), cluster_size_(cluster_size), type_(type) {}
 
   void Test() {
     auto config = BuildConfig();
-    ex_actor::Init(1, config);
-    CheckConnectivityAndCallMethod();
+    ex_actor::Init(/*thread_pool_size=*/1, config);
+
+    auto coroutine = [this]() -> exec::task<void> {
+      // Wait for all other nodes to be discovered
+      auto [nodes, condition_met] =
+          co_await ex_actor::WaitNodeCondition([this](const auto& nodes) { return nodes.size() >= cluster_size_; },
+                                               /*timeout_ms=*/6000);
+      EXA_THROW_CHECK(condition_met) << ex_actor::fmt_lib::format(
+          "Error: node index {} can't discover all {} nodes, only found {}", this_index_, cluster_size_, nodes.size());
+
+      // Pick a target node by address
+      uint32_t target_index = PickTargetIndex();
+      std::string target_address = GetAddress(target_index);
+      auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == target_address; });
+      EXA_THROW_CHECK(it != nodes.end()) << "Cannot find target node at " << target_address;
+      auto target_node_id = it->node_id;
+
+      std::string str {"Hello"};
+      auto actor_creation_sender = ex_actor::Spawn<Echoer>();
+      auto [actor_ref] = stdexec::sync_wait(actor_creation_sender).value();
+      auto actor_method_calling_sender = actor_ref.Send<&Echoer::Echo>(str);
+      auto [method_calling_return_val] = stdexec::sync_wait(std::move(actor_method_calling_sender)).value();
+      EXA_THROW_CHECK(method_calling_return_val == str)
+          << ex_actor::fmt_lib::format("Error: local method calling error");
+
+      auto remote_actor_creation_sender = ex_actor::Spawn<&Echoer::Create>().ToNode(target_node_id);
+      auto [remote_actor_ref] = stdexec::sync_wait(std::move(remote_actor_creation_sender)).value();
+      auto remote_actor_calling_sender = remote_actor_ref.Send<&Echoer::Echo>(str);
+      auto [remote_method_calling_return_val] = stdexec::sync_wait(std::move(remote_actor_calling_sender)).value();
+      EXA_THROW_CHECK(remote_method_calling_return_val == str)
+          << ex_actor::fmt_lib::format("Error: remote method calling error");
+    };
+
+    stdexec::sync_wait(coroutine());
     std::this_thread::sleep_for(std::chrono::milliseconds {1500});
     ex_actor::Shutdown();
   }
 
  private:
-  ex_actor::ClusterConfig BuildConfig() const {
+  static std::string GetAddress(uint32_t index) {
     constexpr uint32_t kBasePort = 5000;
+    return ex_actor::fmt_lib::format("tcp://127.0.0.1:{}", kBasePort + index);
+  }
+
+  ex_actor::ClusterConfig BuildConfig() const {
     ex_actor::ClusterConfig config;
-    config.this_node_id = this_node_id_;
-    config.listen_address = ex_actor::fmt_lib::format("tcp://127.0.0.1:{}", kBasePort + this_node_id_);
+    config.listen_address = GetAddress(this_index_);
     config.network_config = {
         .heartbeat_timeout_ms = 1000,
         .gossip_interval_ms = 100,
         .gossip_fanout = cluster_size_ > 1 ? cluster_size_ / 2 : 1,
     };
 
-    if (this_node_id_ != 0) {
-      uint32_t contact_port = kBasePort;
+    if (this_index_ != 0) {
+      uint32_t contact_index = 0;
       if (type_ == TestType::kChain) {
-        contact_port = kBasePort + this_node_id_ - 1;
+        contact_index = this_index_ - 1;
       }
-      config.contact_node_address = ex_actor::fmt_lib::format("tcp://127.0.0.1:{}", contact_port);
+      config.contact_node_address = GetAddress(contact_index);
     }
     return config;
   }
 
-  void CheckConnectivityAndCallMethod() const {
-    uint32_t target_node_id;
+  uint32_t PickTargetIndex() const {
+    uint32_t target_index;
     if (type_ == TestType::kStar) {
       std::random_device device;
       std::mt19937 random_generator(device());
       std::uniform_int_distribution<uint32_t> dist(0, cluster_size_ - 1);
-      target_node_id = dist(random_generator);
+      target_index = dist(random_generator);
     } else {
-      target_node_id = cluster_size_ - 1 - this_node_id_;
-      if (target_node_id == this_node_id_) {
-        target_node_id = (this_node_id_ + 1) % cluster_size_;
+      target_index = cluster_size_ - 1 - this_index_;
+      if (target_index == this_index_) {
+        target_index = (this_index_ + 1) % cluster_size_;
       }
     }
-
-    auto [connected] = stdexec::sync_wait(ex_actor::WaitNodeAlive(target_node_id, 6000)).value();
-    EXA_THROW_CHECK(connected) << ex_actor::fmt_lib::format("Error: node {} can't connected to node {}", this_node_id_,
-                                                            target_node_id);
-
-    std::string str {"Hello"};
-    auto actor_creation_sender = ex_actor::Spawn<Echoer>();
-    auto [actor_ref] = stdexec::sync_wait(actor_creation_sender).value();
-    auto actor_method_calling_sender = actor_ref.Send<&Echoer::Echo>(str);
-    auto [method_calling_return_val] = stdexec::sync_wait(std::move(actor_method_calling_sender)).value();
-    EXA_THROW_CHECK(method_calling_return_val == str) << ex_actor::fmt_lib::format("Error: local method calling error");
-
-    auto remote_actor_creation_sender = ex_actor::Spawn<&Echoer::Create>().ToNode(target_node_id);
-    auto [remote_actor_ref] = stdexec::sync_wait(std::move(remote_actor_creation_sender)).value();
-    auto remote_actor_calling_sender = remote_actor_ref.Send<&Echoer::Echo>(str);
-    auto [remote_method_calling_return_val] = stdexec::sync_wait(std::move(remote_actor_calling_sender)).value();
-    EXA_THROW_CHECK(remote_method_calling_return_val == str)
-        << ex_actor::fmt_lib::format("Error: remote method calling error");
+    return target_index;
   }
 
-  uint32_t this_node_id_;
+  uint32_t this_index_;
   uint32_t cluster_size_;
   TestType type_;
 };
@@ -119,8 +138,8 @@ int main(int argc, char* argv[]) {
   }
 
   uint32_t cluster_size = std::atoi(argv[1]);
-  uint32_t this_node_id = std::atoi(argv[2]);
-  if (cluster_size == 0 || this_node_id >= cluster_size) {
+  uint32_t this_index = std::atoi(argv[2]);
+  if (cluster_size == 0 || this_index >= cluster_size) {
     return 1;
   }
 
@@ -134,7 +153,7 @@ int main(int argc, char* argv[]) {
     return -1;
   }
 
-  DynamicConnectivityTest dynamic_connectivity_test(this_node_id, cluster_size, type);
+  DynamicConnectivityTest dynamic_connectivity_test(this_index, cluster_size, type);
   dynamic_connectivity_test.Test();
 
   return 0;

--- a/test/heartbeat_test.cc
+++ b/test/heartbeat_test.cc
@@ -1,5 +1,6 @@
+#include <algorithm>
 #include <chrono>
-#include <exception>
+#include <string>
 #include <thread>
 
 #include "ex_actor/api.h"
@@ -21,17 +22,15 @@ class PingWorker {
 
 EXA_REMOTE(&PingWorker::Create, &PingWorker::Ping);
 
-// Usage: <binary> <node_id> <listen_address> <remote_node_id> [contact_address]
+// Usage: <binary> <listen_address> <remote_address> [contact_address]
 int main(int argc, char** argv) {
   ex_actor::internal::InstallFallbackExceptionHandler();
-  uint32_t this_node_id = std::atoi(argv[1]);
-  std::string listen_address = argv[2];
-  uint32_t remote_node_id = std::atoi(argv[3]);
-  std::string contact_address = (argc > 4) ? argv[4] : "";
-  auto coroutine = [](uint32_t this_node_id, std::string listen_address, uint32_t remote_node_id,
+  std::string listen_address = argv[1];
+  std::string remote_address = argv[2];
+  std::string contact_address = (argc > 3) ? argv[3] : "";
+  auto coroutine = [](std::string listen_address, std::string remote_address,
                       std::string contact_address) -> exec::task<void> {
     ex_actor::ClusterConfig cluster_config {
-        .this_node_id = this_node_id,
         .listen_address = listen_address,
         .contact_node_address = contact_address,
         .network_config =
@@ -41,23 +40,30 @@ int main(int argc, char** argv) {
             },
     };
     ex_actor::Init(/*thread_pool_size=*/2, cluster_config);
-    bool connected = co_await ex_actor::WaitNodeAlive(remote_node_id, 5000);
-    EXA_THROW_CHECK(connected) << "Cannot connect to node " << remote_node_id;
+
+    auto [nodes, condition_met] =
+        co_await ex_actor::WaitNodeCondition([](const auto& nodes) { return nodes.size() >= 2; },
+                                             /*timeout_ms=*/5000);
+    EXA_THROW_CHECK(condition_met) << "Cannot connect to any remote node";
+
+    auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address == remote_address; });
+    EXA_THROW_CHECK(it != nodes.end()) << "Cannot find remote node at " << remote_address;
+    auto remote_node_id = it->node_id;
+
     auto ping_worker = co_await ex_actor::Spawn<&PingWorker::Create>(/*name=*/"Alice").ToNode(remote_node_id);
-    logging::Info("Node {} connected to node {}, remote actor created, now start to ping it", this_node_id,
-                  remote_node_id);
+    logging::Info("Connected to remote node, remote actor created, now start to ping it");
     while (true) {
       try {
         auto ping = ping_worker.Send<&PingWorker::Ping>("hello");
         std::ignore = co_await std::move(ping);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      } catch (const std::exception& e) {
-        logging::Error("Node {} caught exception during ping: {}", this_node_id, e.what());
+      } catch (const ex_actor::ConnectionLost& e) {
+        logging::Error("connection lost to node {}: {}", e.node_id, e.what());
         break;
       }
     }
     co_await ex_actor::WaitOsExitSignal();
     ex_actor::Shutdown();
   };
-  stdexec::sync_wait(coroutine(this_node_id, std::move(listen_address), remote_node_id, std::move(contact_address)));
+  stdexec::sync_wait(coroutine(std::move(listen_address), std::move(remote_address), std::move(contact_address)));
 }

--- a/test/heartbeat_test.py
+++ b/test/heartbeat_test.py
@@ -24,36 +24,37 @@ ADDR1 = "tcp://127.0.0.1:5302"
 
 # Step 1: Launch both nodes, capturing their logs to temp files.
 log_file0 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")
-node0 = subprocess.Popen([argv[1], "0", ADDR0, "1"], stdout=log_file0, stderr=subprocess.STDOUT)
+node0 = subprocess.Popen([argv[1], ADDR0, ADDR1], stdout=log_file0, stderr=subprocess.STDOUT)
 log_file0.close()
 
 log_file = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")
-node1 = subprocess.Popen([argv[1], "1", ADDR1, "0", ADDR0], stdout=log_file, stderr=subprocess.STDOUT)
+node1 = subprocess.Popen([argv[1], ADDR1, ADDR0, ADDR0], stdout=log_file, stderr=subprocess.STDOUT)
 log_file.close()
 
 # Step 2: Wait for bidirectional gossip discovery (up to 5 s).
+# Node IDs are auto-generated, so we look for the generic gossip pattern.
 deadline = time.monotonic() + 5
-node0_found_node1 = False
-node1_found_node0 = False
+node0_found_peer = False
+node1_found_peer = False
 while time.monotonic() < deadline:
-    if not node0_found_node1:
+    if not node0_found_peer:
         with open(log_file0.name, "r") as f:
-            if "[Gossip] Node 0 found node 1" in f.read():
-                node0_found_node1 = True
-    if not node1_found_node0:
+            if "[Gossip]" in f.read() and "found node" in open(log_file0.name).read():
+                node0_found_peer = True
+    if not node1_found_peer:
         with open(log_file.name, "r") as f:
-            if "[Gossip] Node 1 found node 0" in f.read():
-                node1_found_node0 = True
-    if node0_found_node1 and node1_found_node0:
+            if "[Gossip]" in f.read() and "found node" in open(log_file.name).read():
+                node1_found_peer = True
+    if node0_found_peer and node1_found_peer:
         break
     time.sleep(0.1)
 
-if not node0_found_node1 or not node1_found_node0:
+if not node0_found_peer or not node1_found_peer:
     missing = []
-    if not node0_found_node1:
-        missing.append("node0 -> node1")
-    if not node1_found_node0:
-        missing.append("node1 -> node0")
+    if not node0_found_peer:
+        missing.append("node0 -> peer")
+    if not node1_found_peer:
+        missing.append("node1 -> peer")
     print(f"FAIL: connection not established: {', '.join(missing)}")
     with open(log_file0.name, "r") as f:
         print("=== node0 log ===", flush=True)
@@ -108,7 +109,7 @@ while time.monotonic() < deadline:
         content = f.read()
     if "detects that node" in content and "is dead" in content:
         death_detected = True
-    if "caught exception during ping" in content:
+    if "connection lost to node" in content:
         exception_caught = True
     if death_detected and exception_caught:
         print(content, end="", flush=True)
@@ -120,7 +121,7 @@ if not death_detected or not exception_caught:
     if not death_detected:
         missing.append("death detection")
     if not exception_caught:
-        missing.append("caught exception during ping")
+        missing.append("connection lost to node")
     print(f"FAIL: node1 did not log: {', '.join(missing)}")
     with open(log_file.name, "r") as f:
         print(f.read(), end="", flush=True)
@@ -129,7 +130,7 @@ if not death_detected or not exception_caught:
     os.unlink(log_file.name)
     sys.exit(1)
 
-print("SUCCESS: node1 detected node0's death and caught ping exception", flush=True)
+print("SUCCESS: node1 detected node0's death and caught ConnectionLost", flush=True)
 node1.kill()
 node1.wait()
 os.unlink(log_file.name)

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -1,5 +1,6 @@
+#include <algorithm>
 #include <cassert>
-#include <cstdlib>
+#include <string>
 
 #include "ex_actor/api.h"
 #include "ex_actor/internal/logging.h"
@@ -19,31 +20,33 @@ class PingWorker {
 };
 EXA_REMOTE(&PingWorker::CreateFn, &PingWorker::Ping);
 
-// Usage: <binary> <node_id> <listen_address> <remote_node_id> [contact_address]
+// Usage: <binary> <listen_address> [contact_address]
 exec::task<void> MainCoroutine(int argc, char** argv) {
   auto shared_pool = std::make_shared<ex_actor::WorkSharingThreadPool>(4);
-  uint32_t this_node_id = std::atoi(argv[1]);
-  std::string listen_address = argv[2];
-  uint32_t remote_node_id = std::atoi(argv[3]);
-  std::string contact_address = (argc > 4) ? argv[4] : "";
+  std::string listen_address = argv[1];
+  std::string contact_address = (argc > 2) ? argv[2] : "";
   ex_actor::ClusterConfig cluster_config {
-      .this_node_id = this_node_id,
       .listen_address = listen_address,
       .contact_node_address = contact_address,
   };
   ex_actor::Init(shared_pool->GetScheduler(), cluster_config);
   ex_actor::HoldResource(shared_pool);
 
-  bool connected = co_await ex_actor::WaitNodeAlive(remote_node_id, 5000);
-  EXA_THROW_CHECK(connected) << "Cannot connected to node " << remote_node_id;
+  auto [nodes, condition_met] =
+      co_await ex_actor::WaitNodeCondition([](const auto& nodes) { return nodes.size() >= 2; },
+                                           /*timeout_ms=*/5000);
+  EXA_THROW_CHECK(condition_met) << "Cannot connect to any remote node";
 
-  // 2. Specify the create function in Spawn
+  auto it = std::ranges::find_if(nodes, [&](const auto& n) { return n.address != listen_address; });
+  EXA_THROW_CHECK(it != nodes.end()) << "Cannot find any remote node";
+  auto remote_node_id = it->node_id;
+
   auto ping_worker = co_await ex_actor::Spawn<&PingWorker::CreateFn>(/*name=*/"Alice").ToNode(remote_node_id);
   std::string ping_res = co_await ping_worker.Send<&PingWorker::Ping>("hello");
   assert(ping_res == "ack from Alice, msg got: hello");
   (void)ping_res;
 
-  logging::Info("All work done, node id: {}", this_node_id);
+  logging::Info("All work done");
   co_await ex_actor::WaitOsExitSignal();
   ex_actor::Shutdown();
 }

--- a/test/multi_process_test.py
+++ b/test/multi_process_test.py
@@ -15,11 +15,11 @@ ADDR0 = "tcp://127.0.0.1:5301"
 ADDR1 = "tcp://127.0.0.1:5302"
 
 log_file0 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")
-node0 = subprocess.Popen([argv[1], "0", ADDR0, "1"], stdout=log_file0, stderr=subprocess.STDOUT)
+node0 = subprocess.Popen([argv[1], ADDR0], stdout=log_file0, stderr=subprocess.STDOUT)
 log_file0.close()
 
 log_file1 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")
-node1 = subprocess.Popen([argv[1], "1", ADDR1, "0", ADDR0], stdout=log_file1, stderr=subprocess.STDOUT)
+node1 = subprocess.Popen([argv[1], ADDR1, ADDR0], stdout=log_file1, stderr=subprocess.STDOUT)
 log_file1.close()
 
 

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -1,9 +1,11 @@
 #include "ex_actor/internal/network.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <ranges>
 #include <string>
 #include <thread>
 
@@ -27,11 +29,9 @@ std::string BytesToString(const ByteBuffer& buf) {
   return std::string(reinterpret_cast<const char*>(buf.data()), buf.size());
 }
 
-ex_actor::ClusterConfig MakeConfig(uint32_t node_id, const std::string& address,
-                                   const std::string& contact_address = "", uint64_t heartbeat_timeout_ms = 5000,
-                                   uint64_t gossip_interval_ms = 500) {
+ex_actor::ClusterConfig MakeConfig(const std::string& address, const std::string& contact_address = "",
+                                   uint64_t heartbeat_timeout_ms = 5000, uint64_t gossip_interval_ms = 500) {
   ex_actor::ClusterConfig config;
-  config.this_node_id = node_id;
   config.listen_address = address;
   config.contact_node_address = contact_address;
   config.network_config.heartbeat_timeout_ms = heartbeat_timeout_ms;
@@ -41,7 +41,7 @@ ex_actor::ClusterConfig MakeConfig(uint32_t node_id, const std::string& address,
 
 void DispatchGossip(ex_actor::internal::MessageBroker& broker,
                     const std::vector<ex_actor::internal::NodeState>& node_states) {
-  uint32_t sender_node_id = node_states.empty() ? 0 : node_states.front().node_id;
+  uint64_t sender_node_id = node_states.empty() ? 0 : node_states.front().node_id;
   ex_actor::internal::BrokerMessage broker_msg {.variant = ex_actor::internal::BrokerGossipMessage {
                                                     .from_node_id = sender_node_id,
                                                     .node_states = node_states,
@@ -57,15 +57,15 @@ void DispatchGossip(ex_actor::internal::MessageBroker& broker,
 // ============================================================
 
 TEST(MessageBrokerTest, ConstructorSucceedsWithNoContactNode) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7203");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7203");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
   stdexec::sync_wait(broker.Stop());
 }
 
 TEST(MessageBrokerTest, ConstructorSucceedsWithValidContactNode) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7204",
+  auto config = MakeConfig("tcp://127.0.0.1:7204",
                            /*contact_address=*/"tcp://127.0.0.1:7205");
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
   stdexec::sync_wait(broker.Stop());
 }
 
@@ -74,19 +74,19 @@ TEST(MessageBrokerTest, ConstructorSucceedsWithValidContactNode) {
 // ============================================================
 
 TEST(MessageBrokerTest, SendRequestToUnconnectedNodeThrows) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7210");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7210");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   EXPECT_THAT([&]() { stdexec::sync_wait(broker.SendRequest(/*to_node_id=*/99, {})); },
-              testing::Throws<std::exception>(testing::Property(
+              testing::Throws<ex_actor::ConnectionLost>(testing::Property(
                   &std::exception::what, testing::HasSubstr("trying to send request to an unconnected node"))));
 
   stdexec::sync_wait(broker.Stop());
 }
 
 TEST(MessageBrokerTest, SendRequestToSelfThrows) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7211");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7211");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   EXPECT_THAT([&]() { stdexec::sync_wait(broker.SendRequest(/*to_node_id=*/0, {})); },
               testing::Throws<std::exception>(
@@ -96,74 +96,96 @@ TEST(MessageBrokerTest, SendRequestToSelfThrows) {
 }
 
 // ============================================================
-// WaitNodeAlive: immediate return for already-connected contact node
+// WaitNodeCondition: immediate return for already-connected contact node
 // ============================================================
 
-TEST(MessageBrokerTest, WaitNodeAliveReturnsTrueForGossipDiscoveredNode) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7220");
-  ex_actor::internal::MessageBroker broker(config);
+TEST(MessageBrokerTest, WaitNodeConditionReturnsTrueForGossipDiscoveredNode) {
+  auto config = MakeConfig("tcp://127.0.0.1:7220");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
                  {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7221"}});
 
-  auto [alive] = stdexec::sync_wait(broker.WaitNodeAlive(/*node_id=*/1, /*timeout_ms=*/10)).value();
-  EXPECT_TRUE(alive);
+  auto [result] = stdexec::sync_wait(broker.WaitNodeCondition(
+                                         [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                                           return std::ranges::any_of(
+                                               nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+                                         },
+                                         /*timeout_ms=*/10))
+                      .value();
+  EXPECT_TRUE(result.condition_met);
 
   stdexec::sync_wait(broker.Stop());
 }
 
-TEST(MessageBrokerTest, WaitNodeAliveReturnsTrueForSelfNode) {
-  auto config = MakeConfig(/*node_id=*/5, "tcp://127.0.0.1:7222");
-  ex_actor::internal::MessageBroker broker(config);
+TEST(MessageBrokerTest, WaitNodeConditionWithAlwaysTruePredicateReturnsImmediately) {
+  auto config = MakeConfig("tcp://127.0.0.1:7222");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/5, config);
 
-  auto [alive] = stdexec::sync_wait(broker.WaitNodeAlive(/*node_id=*/5, /*timeout_ms=*/10)).value();
-  EXPECT_TRUE(alive);
+  // An always-true predicate returns immediately (self node is always in the list).
+  auto [result] =
+      stdexec::sync_wait(broker.WaitNodeCondition([](const std::vector<ex_actor::NodeInfo>& /*nodes*/) { return true; },
+                                                  /*timeout_ms=*/10))
+          .value();
+  EXPECT_TRUE(result.condition_met);
 
   stdexec::sync_wait(broker.Stop());
 }
 
 // ============================================================
-// WaitNodeAlive + CheckNodeAlivenessWaiterTimeout: waiter times out
+// WaitNodeCondition + CheckNodeConditionWaiterTimeout: waiter times out
 // ============================================================
 
-TEST(MessageBrokerTest, WaitNodeAliveTimesOutForUnknownNode) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7230");
-  ex_actor::internal::MessageBroker broker(config);
+TEST(MessageBrokerTest, WaitNodeConditionTimesOutForUnknownNode) {
+  auto config = MakeConfig("tcp://127.0.0.1:7230");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   exec::async_scope scope;
-  std::atomic<bool> result = true;
+  std::atomic<bool> condition_met = true;
 
-  scope.spawn(broker.WaitNodeAlive(/*node_id=*/99, /*timeout_ms=*/0) |
-              stdexec::then([&result](bool alive) { result.store(alive, std::memory_order_relaxed); }));
+  scope.spawn(broker.WaitNodeCondition(
+                  [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                    return std::ranges::any_of(nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 99; });
+                  },
+                  /*timeout_ms=*/0) |
+              stdexec::then([&condition_met](const ex_actor::WaitNodeConditionResult& res) {
+                condition_met.store(res.condition_met, std::memory_order_relaxed);
+              }));
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  broker.CheckNodeAlivenessWaiterTimeout();
+  broker.CheckNodeConditionWaiterTimeout();
 
   stdexec::sync_wait(scope.on_empty());
-  EXPECT_FALSE(result.load(std::memory_order_relaxed));
+  EXPECT_FALSE(condition_met.load(std::memory_order_relaxed));
 
   stdexec::sync_wait(broker.Stop());
 }
 
 // ============================================================
-// WaitNodeAlive resolves when gossip brings a new node
+// WaitNodeCondition resolves when gossip brings a new node
 // ============================================================
 
-TEST(MessageBrokerTest, WaitNodeAliveResolvesOnGossipDiscovery) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7240");
-  ex_actor::internal::MessageBroker broker(config);
+TEST(MessageBrokerTest, WaitNodeConditionResolvesOnGossipDiscovery) {
+  auto config = MakeConfig("tcp://127.0.0.1:7240");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   exec::async_scope scope;
-  std::atomic<bool> result = false;
+  std::atomic<bool> condition_met = false;
 
-  scope.spawn(broker.WaitNodeAlive(/*node_id=*/1, /*timeout_ms=*/5000) |
-              stdexec::then([&result](bool alive) { result.store(alive, std::memory_order_relaxed); }));
+  scope.spawn(broker.WaitNodeCondition(
+                  [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                    return std::ranges::any_of(nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+                  },
+                  /*timeout_ms=*/5000) |
+              stdexec::then([&condition_met](const ex_actor::WaitNodeConditionResult& res) {
+                condition_met.store(res.condition_met, std::memory_order_relaxed);
+              }));
 
   DispatchGossip(broker,
                  {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7241"}});
 
   stdexec::sync_wait(scope.on_empty());
-  EXPECT_TRUE(result.load(std::memory_order_relaxed));
+  EXPECT_TRUE(condition_met.load(std::memory_order_relaxed));
 
   stdexec::sync_wait(broker.Stop());
 }
@@ -173,8 +195,8 @@ TEST(MessageBrokerTest, WaitNodeAliveResolvesOnGossipDiscovery) {
 // ============================================================
 
 TEST(MessageBrokerTest, DuplicateGossipForSameNodeDoesNotThrow) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7250");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7250");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
                  {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7251"}});
@@ -189,8 +211,8 @@ TEST(MessageBrokerTest, DuplicateGossipForSameNodeDoesNotThrow) {
 // ============================================================
 
 TEST(MessageBrokerTest, GossipWithConflictingAddressThrows) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7260");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7260");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
                  {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7261"}});
@@ -211,10 +233,10 @@ TEST(MessageBrokerTest, GossipWithConflictingAddressThrows) {
 // ============================================================
 
 TEST(MessageBrokerTest, CheckHeartbeatTimeoutDeactivatesTimedOutNodes) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7270",
+  auto config = MakeConfig("tcp://127.0.0.1:7270",
                            /*contact_address=*/"tcp://127.0.0.1:7271",
                            /*heartbeat_timeout_ms=*/1);
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   // Discover node 1 via gossip so it gets added to node_id_to_state_
   DispatchGossip(broker,
@@ -225,16 +247,21 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutDeactivatesTimedOutNodes) {
   broker.CheckHeartbeatTimeout();
 
   exec::async_scope scope;
-  std::atomic<bool> wait_result = true;
+  std::atomic<bool> condition_met = true;
   scope.spawn(ex_actor::internal::WrapSenderWithInlineScheduler(
-      broker.WaitNodeAlive(/*node_id=*/1, /*timeout_ms=*/0) |
-      stdexec::then([&wait_result](bool alive) { wait_result = alive; })));
+      broker.WaitNodeCondition(
+          [](const std::vector<ex_actor::NodeInfo>& nodes) {
+            return std::ranges::any_of(nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+          },
+          /*timeout_ms=*/0) |
+      stdexec::then(
+          [&condition_met](const ex_actor::WaitNodeConditionResult& res) { condition_met = res.condition_met; })));
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  broker.CheckNodeAlivenessWaiterTimeout();
+  broker.CheckNodeConditionWaiterTimeout();
 
   stdexec::sync_wait(scope.on_empty());
-  EXPECT_FALSE(wait_result);
+  EXPECT_FALSE(condition_met);
 
   stdexec::sync_wait(broker.Stop());
 }
@@ -244,10 +271,10 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutDeactivatesTimedOutNodes) {
 // ============================================================
 
 TEST(MessageBrokerTest, CheckHeartbeatTimeoutErrorsOutstandingRequests) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7280",
+  auto config = MakeConfig("tcp://127.0.0.1:7280",
                            /*contact_address=*/"tcp://127.0.0.1:7281",
                            /*heartbeat_timeout_ms=*/1);
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   // Discover node 1 via gossip so it gets added to node_id_to_state_ and a send socket is created
   DispatchGossip(broker,
@@ -273,9 +300,9 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutErrorsOutstandingRequests) {
 // ============================================================
 
 TEST(MessageBrokerTest, HandleRepliedResponseResolvesOutstandingRequest) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7290",
+  auto config = MakeConfig("tcp://127.0.0.1:7290",
                            /*contact_address=*/"tcp://127.0.0.1:7291");
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   // Discover node 1 via gossip so we can send requests to it
   DispatchGossip(broker,
@@ -312,9 +339,9 @@ TEST(MessageBrokerTest, HandleRepliedResponseResolvesOutstandingRequest) {
 // ============================================================
 
 TEST(MessageBrokerTest, DispatchReceivedMessageRejectsMisdirectedTwoWay) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7310",
+  auto config = MakeConfig("tcp://127.0.0.1:7310",
                            /*contact_address=*/"tcp://127.0.0.1:7311");
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   ex_actor::internal::BrokerMessage bad_msg {.variant = ex_actor::internal::BrokerTwoWayMessage {
                                                  .request_node_id = 5,
@@ -332,8 +359,8 @@ TEST(MessageBrokerTest, DispatchReceivedMessageRejectsMisdirectedTwoWay) {
 }
 
 TEST(MessageBrokerTest, DispatchReceivedMessageRejectsCorruptData) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7312");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7312");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   auto corrupt = MakeBytes("abc");
   EXPECT_THROW(stdexec::sync_wait(broker.DispatchReceivedMessage(std::move(corrupt))), std::exception);
@@ -346,15 +373,20 @@ TEST(MessageBrokerTest, DispatchReceivedMessageRejectsCorruptData) {
 // ============================================================
 
 TEST(MessageBrokerTest, MultipleWaitersNotifiedOnGossipDiscovery) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7320");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7320");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   exec::async_scope scope;
   std::atomic<int> success_count = 0;
 
   for (int i = 0; i < 3; ++i) {
-    scope.spawn(broker.WaitNodeAlive(/*node_id=*/2, /*timeout_ms=*/5000) | stdexec::then([&success_count](bool alive) {
-                  if (alive) {
+    scope.spawn(broker.WaitNodeCondition(
+                    [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                      return std::ranges::any_of(nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 2; });
+                    },
+                    /*timeout_ms=*/5000) |
+                stdexec::then([&success_count](const ex_actor::WaitNodeConditionResult& res) {
+                  if (res.condition_met) {
                     success_count.fetch_add(1, std::memory_order_relaxed);
                   }
                 }));
@@ -374,18 +406,32 @@ TEST(MessageBrokerTest, MultipleWaitersNotifiedOnGossipDiscovery) {
 // ============================================================
 
 TEST(MessageBrokerTest, GossipIntroducesMultipleNodesAtOnce) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7330");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7330");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   exec::async_scope scope;
   std::atomic<int> success_count = 0;
 
-  scope.spawn(broker.WaitNodeAlive(/*node_id=*/1, /*timeout_ms=*/5000) | stdexec::then([&success_count](bool alive) {
-                if (alive) success_count.fetch_add(1, std::memory_order_relaxed);
+  scope.spawn(broker.WaitNodeCondition(
+                  [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                    return std::ranges::any_of(nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+                  },
+                  /*timeout_ms=*/5000) |
+              stdexec::then([&success_count](const ex_actor::WaitNodeConditionResult& res) {
+                if (res.condition_met) {
+                  success_count.fetch_add(1, std::memory_order_relaxed);
+                }
               }));
 
-  scope.spawn(broker.WaitNodeAlive(/*node_id=*/2, /*timeout_ms=*/5000) | stdexec::then([&success_count](bool alive) {
-                if (alive) success_count.fetch_add(1, std::memory_order_relaxed);
+  scope.spawn(broker.WaitNodeCondition(
+                  [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                    return std::ranges::any_of(nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 2; });
+                  },
+                  /*timeout_ms=*/5000) |
+              stdexec::then([&success_count](const ex_actor::WaitNodeConditionResult& res) {
+                if (res.condition_met) {
+                  success_count.fetch_add(1, std::memory_order_relaxed);
+                }
               }));
 
   DispatchGossip(broker,
@@ -406,8 +452,8 @@ TEST(MessageBrokerTest, GossipIntroducesMultipleNodesAtOnce) {
 // ============================================================
 
 TEST(MessageBrokerTest, BroadcastGossipNoPeersNoCrash) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7340");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7340");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   EXPECT_NO_THROW(broker.BroadcastGossip());
 
@@ -415,9 +461,9 @@ TEST(MessageBrokerTest, BroadcastGossipNoPeersNoCrash) {
 }
 
 TEST(MessageBrokerTest, BroadcastGossipWithPeersNoCrash) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7350",
+  auto config = MakeConfig("tcp://127.0.0.1:7350",
                            /*contact_address=*/"tcp://127.0.0.1:7351");
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   EXPECT_NO_THROW(broker.BroadcastGossip());
 
@@ -429,10 +475,10 @@ TEST(MessageBrokerTest, BroadcastGossipWithPeersNoCrash) {
 // ============================================================
 
 TEST(MessageBrokerTest, GossipUpdatesLastSeenToMax) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7360",
+  auto config = MakeConfig("tcp://127.0.0.1:7360",
                            /*contact_address=*/"tcp://127.0.0.1:7361",
                            /*heartbeat_timeout_ms=*/200);
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   // Discover node 1 via gossip first
   DispatchGossip(broker,
@@ -451,8 +497,14 @@ TEST(MessageBrokerTest, GossipUpdatesLastSeenToMax) {
   // The node should NOT be timed out since we just refreshed it
   broker.CheckHeartbeatTimeout();
 
-  auto [alive] = stdexec::sync_wait(broker.WaitNodeAlive(/*node_id=*/1, /*timeout_ms=*/10)).value();
-  EXPECT_TRUE(alive);
+  auto [result] = stdexec::sync_wait(broker.WaitNodeCondition(
+                                         [](const std::vector<ex_actor::NodeInfo>& nodes) {
+                                           return std::ranges::any_of(
+                                               nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+                                         },
+                                         /*timeout_ms=*/10))
+                      .value();
+  EXPECT_TRUE(result.condition_met);
 
   stdexec::sync_wait(broker.Stop());
 }
@@ -462,16 +514,20 @@ TEST(MessageBrokerTest, GossipUpdatesLastSeenToMax) {
 // ============================================================
 
 TEST(MessageBrokerTest, CheckHeartbeatTimeoutDoesNotDeactivateSelf) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7370",
+  auto config = MakeConfig("tcp://127.0.0.1:7370",
                            /*contact_address=*/"",
                            /*heartbeat_timeout_ms=*/1);
-  ex_actor::internal::MessageBroker broker(config);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
   broker.CheckHeartbeatTimeout();
 
-  auto [alive] = stdexec::sync_wait(broker.WaitNodeAlive(/*node_id=*/0, /*timeout_ms=*/10)).value();
-  EXPECT_TRUE(alive);
+  // Self node is never deactivated. An always-true predicate returns immediately.
+  auto [result] =
+      stdexec::sync_wait(broker.WaitNodeCondition([](const std::vector<ex_actor::NodeInfo>& /*nodes*/) { return true; },
+                                                  /*timeout_ms=*/10))
+          .value();
+  EXPECT_TRUE(result.condition_met);
 
   stdexec::sync_wait(broker.Stop());
 }
@@ -481,8 +537,8 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutDoesNotDeactivateSelf) {
 // ============================================================
 
 TEST(MessageBrokerTest, BroadcastGossipAfterDiscovery) {
-  auto config = MakeConfig(/*node_id=*/0, "tcp://127.0.0.1:7380");
-  ex_actor::internal::MessageBroker broker(config);
+  auto config = MakeConfig("tcp://127.0.0.1:7380");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
                  {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7381"},


### PR DESCRIPTION
1. remove node_id from Init(), make API simpler, now we generate random node_id automatically. closes https://github.com/ex-actor/ex-actor/issues/186
2. add `ex_actor::WaitNodeCondition` API to allow user to discover new nodes. `ex_actor::WaitNodeAlive` is removed.
3. add `ex_actor::ConnectionLost` exception. allow user to discover failure

with these functionalities user can handle the node failure now. closes https://github.com/ex-actor/ex-actor/issues/122