### PR TITLE
[fix] Support non-movable actor classes with factory functions

### DIFF
--- a/include/ex_actor/internal/actor.h
+++ b/include/ex_actor/internal/actor.h
@@ -160,7 +160,10 @@ class Actor : public TypeErasedActor {
   explicit Actor(std::unique_ptr<TypeErasedActorScheduler> scheduler, ActorConfig actor_config, Args... args)
       : TypeErasedActor(std::move(actor_config)), scheduler_(std::move(scheduler)) {
     if constexpr (kCreateFn != nullptr) {
-      user_class_instance_ = std::make_unique<UserClass>(kCreateFn(std::move(args)...));
+      // Use `new` directly so the prvalue returned by kCreateFn is used to
+      // initialize the heap object, benefiting from guaranteed copy elision
+      // (C++17 [dcl.init]/17.6.1) and not requiring UserClass to be movable.
+      user_class_instance_.reset(new UserClass(kCreateFn(std::move(args)...)));
     } else {
       user_class_instance_ = std::make_unique<UserClass>(std::move(args)...);
     }

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -110,6 +110,23 @@ struct RetVoid {
 };
 EXA_REMOTE(&RetVoid::Create, &RetVoid::ReturnVoid, &RetVoid::CoroutineReturnVoid);
 
+class NonMovableActor {
+ public:
+  NonMovableActor(const NonMovableActor&) = delete;
+  NonMovableActor& operator=(const NonMovableActor&) = delete;
+  NonMovableActor(NonMovableActor&&) = delete;
+  NonMovableActor& operator=(NonMovableActor&&) = delete;
+
+  static NonMovableActor Create(std::string name) { return NonMovableActor(std::move(name)); }
+
+  std::string GetName() const { return name_; }
+
+ private:
+  explicit NonMovableActor(std::string name) : name_(std::move(name)) {}
+  std::string name_;
+};
+EXA_REMOTE(&NonMovableActor::Create, &NonMovableActor::GetName);
+
 TEST(DistributedTest, ConstructionInDistributedModeWithDefaultScheduler) {
   std::barrier bar {2};
   auto node_main = [&bar](size_t index) -> exec::task<void> {
@@ -389,4 +406,13 @@ TEST(DistributedTest, ActorRefSerializationTest) {
 
   node_0.join();
   node_1.join();
+}
+
+// Verifies that a non-movable actor can be spawned via a factory function.
+// The lambda is never invoked; it only needs to compile, which forces the
+// full Spawn -> Actor template chain to be instantiated for NonMovableActor.
+TEST(DistributedTest, NonMovableActorCompiles) {
+  [[maybe_unused]] auto unused = [](ex_actor::ActorRegistry& registry) {
+    return registry.Spawn<&NonMovableActor::Create>(/*name=*/"Bob").ToNode(0);
+  };
 }


### PR DESCRIPTION
## Summary
- Use `new` + `reset()` instead of `std::make_unique` in the `kCreateFn` branch of `Actor`'s constructor, so the prvalue returned by the factory function directly initializes the heap object via C++17 guaranteed copy elision. This removes the requirement for actor classes to be movable when using a factory function.
- Add a compile-only test (`NonMovableActorCompiles`) that instantiates the full `Spawn` → `Actor` template chain for a non-movable class, ensuring this stays supported.

## Test plan
- [x] All 16 existing tests pass
- [x] New `NonMovableActorCompiles` test compiles and passes
