### PR TITLE
[API] Move ClusterConfig to a separate interface

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -35,8 +35,9 @@ EXA_REMOTE(&PingWorker::Create, &PingWorker::Ping); // (1)
 exec::task<void> MainCoroutine(int argc, char** argv) {
   std::string listen_address = argv[1];
   std::string contact_address = (argc > 2) ? argv[2] : "";
-  // 2. Start or join a cluster.
-  ex_actor::Init(/*thread_pool_size=*/4, ex_actor::ClusterConfig {
+  // 2. Init the framework, then start or join a cluster.
+  ex_actor::Init(/*thread_pool_size=*/4);
+  co_await ex_actor::StartOrJoinCluster(ex_actor::ClusterConfig {
       // The public address other nodes use to connect to you,
       // we'll open a listening port at this address.
       .listen_address = listen_address,

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -141,6 +141,11 @@ class ActorRegistryBackend {
   }
 
   /**
+   * @brief Update the broker actor ref. Called when switching to distributed mode after init.
+   */
+  void SetBrokerActorRef(LocalActorRef<MessageBroker> broker_actor_ref);
+
+  /**
    * @brief Handle a network request. Returns the serialized reply data.
    */
   exec::task<ByteBuffer> HandleNetworkRequest(ByteBuffer request_buffer);
@@ -268,32 +273,16 @@ class SpawnBuilder : public ex::sender_t {
 class ActorRegistry {
  public:
   /**
-   * @brief Construct in single-node mode, use the default work-sharing thread pool as the scheduler.
+   * @brief Construct with the default work-sharing thread pool as the scheduler.
    */
-  explicit ActorRegistry(uint32_t thread_pool_size)
-      : ActorRegistry(thread_pool_size, /*scheduler=*/nullptr, /*cluster_config=*/ {}) {}
+  explicit ActorRegistry(uint32_t thread_pool_size) : ActorRegistry(thread_pool_size, /*scheduler=*/nullptr) {}
 
   /**
-   * @brief Construct in single-node mode, use specified scheduler.
+   * @brief Construct with a user-specified scheduler.
    */
   template <ex::scheduler Scheduler>
   explicit ActorRegistry(Scheduler scheduler)
-      : ActorRegistry(/*thread_pool_size=*/0, std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler),
-                      /*cluster_config*/ {}) {}
-
-  /**
-   * @brief Construct in distributed mode, use the default work-sharing thread pool as the scheduler.
-   */
-  explicit ActorRegistry(uint32_t thread_pool_size, const ClusterConfig& cluster_config)
-      : ActorRegistry(thread_pool_size, /*scheduler=*/nullptr, cluster_config) {}
-
-  /**
-   * @brief Construct in distributed mode, use specified scheduler.
-   */
-  template <ex::scheduler Scheduler>
-  explicit ActorRegistry(Scheduler scheduler, const ClusterConfig& cluster_config)
-      : ActorRegistry(/*thread_pool_size=*/0, std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler),
-                      cluster_config) {}
+      : ActorRegistry(/*thread_pool_size=*/0, std::make_unique<AnyStdExecScheduler<Scheduler>>(scheduler)) {}
 
   ~ActorRegistry();
 
@@ -351,6 +340,13 @@ class ActorRegistry {
   exec::task<WaitClusterStateResult> WaitClusterState(std::function<bool(const ClusterState&)> predicate,
                                                       uint64_t timeout_ms);
 
+  /**
+   * @brief [Experimental] Switch to distributed mode by creating and starting the MessageBroker.
+   * Can be called after Init() with non-distributed mode to join or start a cluster.
+   * @note Not thread-safe. Must not be called if already in distributed mode.
+   */
+  exec::task<void> StartOrJoinCluster(const ClusterConfig& cluster_config);
+
  private:
   uint64_t this_node_id_;
   WorkSharingThreadPool default_work_sharing_thread_pool_;
@@ -360,8 +356,7 @@ class ActorRegistry {
   Actor<ActorRegistryBackend> backend_actor_;
   LocalActorRef<ActorRegistryBackend> backend_actor_ref_;
 
-  explicit ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler,
-                         const ClusterConfig& cluster_config);
+  explicit ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler);
 };
 
 }  // namespace ex_actor::internal

--- a/include/ex_actor/internal/global_registry.h
+++ b/include/ex_actor/internal/global_registry.h
@@ -55,17 +55,10 @@ template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler);
 
 /**
- * @brief Init the global default registry in distributed mode, use the default thread pool as the scheduler.
- * @note Not thread-safe.
+ * @brief [Experimental] Switch to distributed mode by starting or joining a cluster.
+ * @note Not thread-safe. Should be called after Init() and before Shutdown(). Can't be called twice.
  */
-void Init(uint32_t thread_pool_size, const ClusterConfig& cluster_config);
-
-/**
- * @brief Init the global default registry in distributed mode, use user-specified scheduler.
- * @note Not thread-safe.
- */
-template <ex::scheduler Scheduler>
-void Init(Scheduler scheduler, const ClusterConfig& cluster_config);
+exec::task<void> StartOrJoinCluster(const ClusterConfig& cluster_config);
 
 /**
  * @brief Shutdown the global default registry. Must be called explicitly before `main` exits.
@@ -169,17 +162,9 @@ namespace ex_actor {
 
 template <ex::scheduler Scheduler>
 void Init(Scheduler scheduler) {
-  internal::log::Info("Initializing ex_actor in single-node mode with custom scheduler.");
+  internal::log::Info("Initializing ex_actor with custom scheduler.");
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler)));
-  internal::SetupGlobalHandlers();
-}
-
-template <ex::scheduler Scheduler>
-void Init(Scheduler scheduler, const ClusterConfig& cluster_config) {
-  internal::log::Info("Initializing ex_actor in distributed mode with custom scheduler.");
-  EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
-  AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler), cluster_config));
   internal::SetupGlobalHandlers();
 }
 

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -32,6 +32,10 @@ ActorRegistryBackend::ActorRegistryBackend(std::unique_ptr<TypeErasedActorSchedu
   InitRandomNumGenerator();
 }
 
+void ActorRegistryBackend::SetBrokerActorRef(LocalActorRef<MessageBroker> broker_actor_ref) {
+  broker_actor_ref_ = broker_actor_ref;
+}
+
 exec::task<void> ActorRegistryBackend::AsyncDestroyAllActors() {
   exec::async_scope async_scope;
   log::Info("Sending destroy messages to actors");
@@ -167,8 +171,7 @@ ActorRegistry::~ActorRegistry() {
   log::Info("Actor registry shutdown completed");
 }
 
-ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler,
-                             const ClusterConfig& cluster_config)
+ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler)
     : this_node_id_([] {
         std::random_device rd;
         std::mt19937_64 gen(rd());
@@ -179,30 +182,41 @@ ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeEras
       scheduler_(scheduler != nullptr ? std::move(scheduler)
                                       : std::make_unique<AnyStdExecScheduler<WorkSharingThreadPool::Scheduler>>(
                                             default_work_sharing_thread_pool_.GetScheduler())),
-      broker_actor_(cluster_config.listen_address.empty()
-                        ? nullptr
-                        : std::make_unique<Actor<MessageBroker>>(scheduler_->Clone(), ActorConfig {}, this_node_id_,
-                                                                 cluster_config)),
-      broker_actor_ref_(broker_actor_ ? LocalActorRef<MessageBroker>(/*actor_id=*/UINT64_MAX, broker_actor_.get())
-                                      : LocalActorRef<MessageBroker> {}),
       backend_actor_(scheduler_->Clone(), ActorConfig {}, scheduler_->Clone(), this_node_id_, broker_actor_ref_),
       backend_actor_ref_(/*actor_id=*/UINT64_MAX, &backend_actor_) {
-  if (!broker_actor_ref_.IsEmpty()) {
-    NotifyOnSpawned<MessageBroker>(broker_actor_.get(), broker_actor_ref_);
-    MessageBroker::RequestHandler request_handler =
-        [ref = backend_actor_ref_](ByteBuffer data) -> exec::task<ByteBuffer> {
-      co_return co_await ref.SendLocal<&ActorRegistryBackend::HandleNetworkRequest>(std::move(data));
-    };
-    ex::sync_wait(broker_actor_ref_.SendLocal<&MessageBroker::Start>(std::move(request_handler)));
-  }
-  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
   log::Info("ActorRegistry created, node_id={}", this_node_id_);
+}
+
+exec::task<void> ActorRegistry::StartOrJoinCluster(const ClusterConfig& cluster_config) {
+  log::Info("Starting distributed mode...");
+  EXA_THROW_CHECK(broker_actor_ref_.IsEmpty()) << "Already in distributed mode.";
+  EXA_THROW_CHECK(!cluster_config.listen_address.empty()) << "listen_address must not be empty";
+
+  broker_actor_ =
+      std::make_unique<Actor<MessageBroker>>(scheduler_->Clone(), ActorConfig {}, this_node_id_, cluster_config);
+  broker_actor_ref_ = LocalActorRef<MessageBroker>(/*actor_id=*/UINT64_MAX, broker_actor_.get());
+  NotifyOnSpawned<MessageBroker>(broker_actor_.get(), broker_actor_ref_);
+
+  // Update the backend actor's broker ref so it can forward network requests
+  co_await backend_actor_ref_.SendLocal<&ActorRegistryBackend::SetBrokerActorRef>(broker_actor_ref_);
+
+  auto request_handler = [ref = backend_actor_ref_](ByteBuffer data) -> exec::task<ByteBuffer> {
+    co_return co_await ref.SendLocal<&ActorRegistryBackend::HandleNetworkRequest>(std::move(data));
+  };
+  co_await broker_actor_ref_.SendLocal<&MessageBroker::Start>(std::move(request_handler));
+
+  if (cluster_config.contact_node_address.empty()) {
+    log::Info("Successfully started distributed mode, listen_address={}", cluster_config.listen_address);
+  } else {
+    log::Info("Successfully started distributed mode, listen_address={}, contact_node_address={}",
+              cluster_config.listen_address, cluster_config.contact_node_address);
+  }
 }
 
 exec::task<WaitClusterStateResult> ActorRegistry::WaitClusterState(std::function<bool(const ClusterState&)> predicate,
                                                                    uint64_t timeout_ms) {
   EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty())
-      << "WaitClusterState requires distributed mode, add ClusterConfig to Init() to enable distributed mode";
+      << "WaitClusterState requires distributed mode, call StartOrJoinCluster() after Init() to enable it.";
   co_return co_await broker_actor_ref_.SendLocal<&MessageBroker::WaitClusterState>(std::move(predicate), timeout_ms);
 }
 

--- a/src/ex_actor/internal/global_registry.cc
+++ b/src/ex_actor/internal/global_registry.cc
@@ -104,19 +104,15 @@ void SetupGlobalHandlers() { RegisterAtExitCleanup(); }
 
 namespace ex_actor {
 void Init(uint32_t thread_pool_size) {
-  internal::log::Info("Initializing ex_actor in single-node mode with default scheduler, thread_pool_size={}",
-                      thread_pool_size);
+  internal::log::Info("Initializing ex_actor with default scheduler, thread_pool_size={}", thread_pool_size);
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size);
   internal::SetupGlobalHandlers();
 }
 
-void Init(uint32_t thread_pool_size, const ClusterConfig& cluster_config) {
-  internal::log::Info("Initializing ex_actor in distributed mode with default scheduler, thread_pool_size={}",
-                      thread_pool_size);
-  EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
-  global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size, cluster_config);
-  internal::SetupGlobalHandlers();
+exec::task<void> StartOrJoinCluster(const ClusterConfig& cluster_config) {
+  EXA_THROW_CHECK(internal::IsGlobalDefaultRegistryInitialized()) << "Not initialized. Call Init() first.";
+  co_await internal::GetGlobalDefaultRegistry().StartOrJoinCluster(cluster_config);
 }
 
 void HoldResource(std::shared_ptr<void> resource) { resource_holder.push_back(std::move(resource)); }

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -135,7 +135,8 @@ TEST(DistributedTest, ConstructionInDistributedModeWithDefaultScheduler) {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
-    ex_actor::ActorRegistry registry(/*thread_pool_size=*/4, cluster_config);
+    ex_actor::ActorRegistry registry(/*thread_pool_size=*/4);
+    co_await registry.StartOrJoinCluster(cluster_config);
 
     auto [cluster_state, condition_met] =
         co_await registry.WaitClusterState([](const auto& state) { return state.nodes.size() >= 2; },
@@ -175,7 +176,8 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
-    ex_actor::ActorRegistry registry(thread_pool.GetScheduler(), cluster_config);
+    ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
+    co_await registry.StartOrJoinCluster(cluster_config);
 
     // test local creation
     auto local_a = co_await registry.Spawn<A>();
@@ -294,7 +296,8 @@ TEST(DistributedTest, ActorLookUpInDistributeMode) {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
-    ex_actor::ActorRegistry registry(thread_pool.GetScheduler(), cluster_config);
+    ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
+    co_await registry.StartOrJoinCluster(cluster_config);
 
     auto [cluster_state, condition_met] =
         co_await registry.WaitClusterState([](const auto& state) { return state.nodes.size() >= 2; },
@@ -347,7 +350,8 @@ TEST(DistributedTest, ActorRefSerializationTest) {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
     };
-    ex_actor::ActorRegistry registry(thread_pool.GetScheduler(), cluster_config);
+    ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
+    co_await registry.StartOrJoinCluster(cluster_config);
 
     auto [cluster_state, condition_met] =
         co_await registry.WaitClusterState([](const auto& state) { return state.nodes.size() >= 2; },

--- a/test/dynamic_connectivity_test.cc
+++ b/test/dynamic_connectivity_test.cc
@@ -48,7 +48,8 @@ class DynamicConnectivityTest {
 
   void Test() {
     auto config = BuildConfig();
-    ex_actor::Init(/*thread_pool_size=*/1, config);
+    ex_actor::Init(/*thread_pool_size=*/1);
+    stdexec::sync_wait(ex_actor::StartOrJoinCluster(config));
 
     auto coroutine = [this]() -> exec::task<void> {
       // Wait for all other nodes to be discovered

--- a/test/heartbeat_test.cc
+++ b/test/heartbeat_test.cc
@@ -39,7 +39,8 @@ int main(int argc, char** argv) {
                 .gossip_interval_ms = 50,
             },
     };
-    ex_actor::Init(/*thread_pool_size=*/2, cluster_config);
+    ex_actor::Init(/*thread_pool_size=*/2);
+    co_await ex_actor::StartOrJoinCluster(cluster_config);
 
     auto [cluster_state, condition_met] =
         co_await ex_actor::WaitClusterState([](const auto& state) { return state.nodes.size() >= 2; },

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -29,7 +29,8 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
       .listen_address = listen_address,
       .contact_node_address = contact_address,
   };
-  ex_actor::Init(shared_pool->GetScheduler(), cluster_config);
+  ex_actor::Init(shared_pool->GetScheduler());
+  co_await ex_actor::StartOrJoinCluster(cluster_config);
   ex_actor::HoldResource(shared_pool);
 
   auto [cluster_state, condition_met] =


### PR DESCRIPTION
before: `Init(..., ClusterConfig{...})`
after: `Init(...);  StartOrJoinCluster({...})` 