### PR TITLE
[API] Introduce Async Start()/Stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ struct Counter {
 };
 
 exec::task<void> MainCoroutine() {
-  ex_actor::Init(/*thread_pool_size=*/1);
+  co_await ex_actor::Start(/*thread_pool_size=*/1);
 
   // 1. Create the actor.
   ex_actor::ActorRef actor = co_await ex_actor::Spawn<Counter>();
@@ -56,7 +56,7 @@ exec::task<void> MainCoroutine() {
   int res = co_await actor.Send<&Counter::Add>(1);
   assert(res == 1);
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -96,13 +96,13 @@ private:
 exec::task<void> MainCoroutine() {
   // Here we have only one thread in scheduler, but it still can finish the entire work
   // because we use coroutine, there is no blocking wait in actor's method.
-  ex_actor::Init(/*thread_pool_size=*/1);
+  co_await ex_actor::Start(/*thread_pool_size=*/1);
 
   ex_actor::ActorRef<Father> father = co_await ex_actor::Spawn<Father>();
   std::string res = co_await father.Send<&Father::SpawnChildAndPing>();
   assert(res == "Where is my child? Dad, I'm here!");
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }

--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -35,8 +35,8 @@ EXA_REMOTE(&PingWorker::Create, &PingWorker::Ping); // (1)
 exec::task<void> MainCoroutine(int argc, char** argv) {
   std::string listen_address = argv[1];
   std::string contact_address = (argc > 2) ? argv[2] : "";
-  // 2. Init the framework, then start or join a cluster.
-  ex_actor::Init(/*thread_pool_size=*/4);
+  // 2. Start the framework, then start or join a cluster.
+  co_await ex_actor::Start(/*thread_pool_size=*/4);
   co_await ex_actor::StartOrJoinCluster(ex_actor::ClusterConfig {
       // The public address other nodes use to connect to you,
       // we'll open a listening port at this address.
@@ -70,7 +70,7 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
   // will exit immediately, which might be earlier than the other node finishes its work,
   // causing error in the other node.
   co_await ex_actor::WaitOsExitSignal();
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main(int argc, char** argv) { stdexec::sync_wait(MainCoroutine(argc, argv)); }

--- a/docs/contents/schedulers.md
+++ b/docs/contents/schedulers.md
@@ -3,46 +3,51 @@
 
 ## Using a custom scheduler
 
-You can use any std::execution scheduler as ex_actor's underlying scheduler, just pass it to the `ex_actor::Init` function.
-When you pass a scheduler to the `ex_actor::Init` function, we'll use it as the underlying scheduler, instead of using our
+You can use any std::execution scheduler as ex_actor's underlying scheduler, just pass it to the `ex_actor::Start` function.
+When you pass a scheduler to the `ex_actor::Start` function, we'll use it as the underlying scheduler, instead of using our
 default scheduler.
 
 
-Be cautious that you should shutdown the runtime before your execution resource is destroyed, or the program will crash or hang forever, because we are still using your execution resource.
+
+Be cautious that you should stop the runtime before your execution resource is destroyed, or the program will crash or hang forever, because we are still using your execution resource.
 
 <!-- doc test start -->
 ```cpp
 #include "ex_actor/api.h"
 
-int main() {
+exec::task<void> MainCoroutine() {
   ex_actor::WorkSharingThreadPool thread_pool(/*thread_count=*/10);
 
-  // pass the scheduler to the ex_actor::Init function
-  ex_actor::Init(thread_pool.GetScheduler());
+  // pass the scheduler to the ex_actor::Start function
+  co_await ex_actor::Start(thread_pool.GetScheduler());
   
-  // caution: shutdown the runtime before your execution resource is destroyed
+  // caution: stop the runtime before your execution resource is destroyed
   // or the program will crash or hang forever, because we are still using your execution resource.
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
+
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
-If you want ex_actor to control the lifecycle of your execution resource, you can use `ex_actor::HoldResource` to hold it, the resource will be released when calling `ex_actor::Shutdown()`.
+If you want ex_actor to control the lifecycle of your execution resource, you can use `ex_actor::HoldResource` to hold it, the resource will be released when calling `ex_actor::Stop()`.
 
 <!-- doc test start -->
 ```cpp
 #include "ex_actor/api.h"
 
-int main() {
+exec::task<void> MainCoroutine() {
   // can also be a `shared_ptr` if you want to use it elsewhere.
   auto thread_pool = std::make_unique<ex_actor::WorkSharingThreadPool>(/*thread_count=*/10);
-  ex_actor::Init(thread_pool->GetScheduler());
+  co_await ex_actor::Start(thread_pool->GetScheduler());
   ex_actor::HoldResource(std::move(thread_pool));
 
   // do some work...
 
-  ex_actor::Shutdown(); // the thread_pool will be destroyed here
+  co_await ex_actor::Stop(); // the thread_pool will be destroyed here
 }
+
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
@@ -58,17 +63,19 @@ We provide some handy schedulers out-of-box.
 ```cpp
 #include "ex_actor/api.h"
 
-int main() {
+exec::task<void> MainCoroutine() {
   ex_actor::WorkSharingThreadPool thread_pool(/*thread_count=*/10);
-  ex_actor::Init(thread_pool.GetScheduler());
-  ex_actor::Shutdown();
+  co_await ex_actor::Start(thread_pool.GetScheduler());
+  co_await ex_actor::Stop();
 }
+
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
 This scheduler is suitable for most cases. It's a classic thread pool with a globally shared lock-free task queue.
 
-It's also the default scheduler we use when you don't pass a scheduler to the `ex_actor::Init`.
+It's also the default scheduler we use when you don't pass a scheduler to the `ex_actor::Start`.
 
 
 ### Work-Stealing Thread Pool
@@ -77,11 +84,13 @@ It's also the default scheduler we use when you don't pass a scheduler to the `e
 ```cpp
 #include "ex_actor/api.h"
 
-int main() {
+exec::task<void> MainCoroutine() {
   ex_actor::WorkStealingThreadPool thread_pool(/*thread_count=*/10);
-  ex_actor::Init(thread_pool.GetScheduler());
-  ex_actor::Shutdown();
+  co_await ex_actor::Start(thread_pool.GetScheduler());
+  co_await ex_actor::Stop();
 }
+
+int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
@@ -103,11 +112,11 @@ struct TestActor {
 
 exec::task<void> MainCoroutine() {
   ex_actor::PriorityThreadPool thread_pool(1);
-  ex_actor::Init(thread_pool.GetScheduler());
+  co_await ex_actor::Start(thread_pool.GetScheduler());
   auto actor = co_await ex_actor::Spawn<TestActor>().WithConfig({
     .priority = 1 // smaller number means higher priority
   });
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -143,7 +152,7 @@ exec::task<void> MainCoroutine() {
     thread_pool1.GetScheduler(), thread_pool2.GetScheduler()
   });
   // 3. initialize the runtime with the scheduler union
-  ex_actor::Init(scheduler_union.GetScheduler());
+  co_await ex_actor::Start(scheduler_union.GetScheduler());
   // 4. create two actors, specify the scheduler index using .WithConfig().
   auto actor1 = co_await ex_actor::Spawn<TestActor>().WithConfig({.scheduler_index = 0});
   auto actor2 = co_await ex_actor::Spawn<TestActor>().WithConfig({.scheduler_index = 1});
@@ -152,7 +161,7 @@ exec::task<void> MainCoroutine() {
   uint64_t thread_id2 = co_await actor2.Send<&TestActor::GetThreadId>();
   // the two actors should run on different thread pool
   assert(thread_id1 != thread_id2);
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }

--- a/docs/contents/tutorial.md
+++ b/docs/contents/tutorial.md
@@ -30,9 +30,9 @@ struct Counter {
 
 exec::task<void> MainCoroutine() {
   /*
-  1. First, initialize ex_actor runtime.
+  1. First, start the ex_actor runtime.
   */
-  ex_actor::Init(/*thread_pool_size=*/1);
+  co_await ex_actor::Start(/*thread_pool_size=*/1);
 
   /*
   2. Create an actor, returns an `ActorRef` object.
@@ -63,7 +63,7 @@ exec::task<void> MainCoroutine() {
   res = co_await actor.Send<&Counter::Add>(1);
   assert(res == 2);
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 
@@ -117,7 +117,7 @@ private:
 exec::task<void> MainCoroutine() {
   // Here we have only one thread in scheduler, but it still can finish the entire work,
   // because we use coroutine, there is no blocking wait in actor's method.
-  ex_actor::Init(/*thread_pool_size=*/1);
+  co_await ex_actor::Start(/*thread_pool_size=*/1);
 
   ex_actor::ActorRef<Father> father = co_await ex_actor::Spawn<Father>();
   // When the return type of your method is a std::execution sender, we'll automatically
@@ -125,7 +125,7 @@ exec::task<void> MainCoroutine() {
   std::string res = co_await father.Send<&Father::SpawnChildAndPing>();
   assert(res == "Where is my child? Dad, I'm here!");
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -164,7 +164,7 @@ class Proxy {
 
 
 exec::task<void> MainCoroutine() {
-  ex_actor::Init(/*thread_pool_size=*/1);
+  co_await ex_actor::Start(/*thread_pool_size=*/1);
 
   ex_actor::ActorRef ping_worker = co_await ex_actor::Spawn<PingWorker>();
 
@@ -175,7 +175,7 @@ exec::task<void> MainCoroutine() {
   std::string res = co_await proxy.Send<&Proxy::ProxyPing>();
   assert(res == "Hi from Proxy");
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -199,7 +199,7 @@ struct Counter {
 };
 
 exec::task<void> MainCoroutine() {
-  ex_actor::Init(/*thread_pool_size=*/1);
+  co_await ex_actor::Start(/*thread_pool_size=*/1);
   ex_actor::ActorRef actor = co_await ex_actor::Spawn<Counter>();
   exec::async_scope scope;
 
@@ -225,7 +225,7 @@ exec::task<void> MainCoroutine() {
   // or an exception will be thrown.
   co_await scope.on_empty();
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -250,7 +250,7 @@ struct Counter {
 };
 
 exec::task<void> MainCoroutine() {
-  ex_actor::Init(/*thread_pool_size=*/3);
+  co_await ex_actor::Start(/*thread_pool_size=*/3);
 
   // create multiple counters, you want to increase them in parallel
   std::vector<ex_actor::ActorRef<Counter>> counters;
@@ -302,7 +302,7 @@ exec::task<void> MainCoroutine() {
     assert(value == 3);
   }
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }
@@ -327,7 +327,7 @@ struct Counter {
 };
 
 int main() {
-  ex_actor::Init(/*thread_pool_size=*/2);
+  stdexec::sync_wait(ex_actor::Start(/*thread_pool_size=*/2));
   auto [actor] = stdexec::sync_wait(ex_actor::Spawn<Counter>()).value();
 
   // Sender adapter style
@@ -345,7 +345,7 @@ int main() {
   auto [res1] = stdexec::sync_wait(std::move(task1)).value();
   assert(res1 == 2);
 
-  ex_actor::Shutdown();
+  stdexec::sync_wait(ex_actor::Stop());
 }
 ```
 <!-- doc test end -->
@@ -388,7 +388,7 @@ class Proxy {
 };
 
 exec::task<void> MainCoroutine() {
-  ex_actor::Init(/*thread_pool_size=*/2);
+  co_await ex_actor::Start(/*thread_pool_size=*/2);
   ex_actor::ActorRef dummy_actor = co_await ex_actor::Spawn<DummyActor>();
 
   // 2. create a proxy actor, who has a reference to the dummy actor
@@ -400,7 +400,7 @@ exec::task<void> MainCoroutine() {
   scope.spawn(proxy.Send<&Proxy::AnotherMethod>());
   co_await scope.on_empty();
 
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 
 int main() { stdexec::sync_wait(MainCoroutine()); }

--- a/include/ex_actor/internal/global_registry.h
+++ b/include/ex_actor/internal/global_registry.h
@@ -42,28 +42,47 @@ using ex_actor::internal::SenderOf;
 using ex_actor::internal::FnReturnType;
 
 /**
- * @brief Init the global default registry in single-node mode, use the default thread pool as the scheduler.
+ * @brief Start the ex_actor runtime, use the default thread pool as the scheduler.
  * @note Not thread-safe.
  */
-void Init(uint32_t thread_pool_size);
+exec::task<void> Start(uint32_t thread_pool_size);
 
 /**
- * @brief Init the global default registry in single-node mode, use user-specified scheduler.
+ * @brief Start the ex_actor runtime, use user-specified scheduler.
  * @note Not thread-safe.
  */
 template <ex::scheduler Scheduler>
-void Init(Scheduler scheduler);
+exec::task<void> Start(Scheduler scheduler);
 
 /**
  * @brief [Experimental] Switch to distributed mode by starting or joining a cluster.
- * @note Not thread-safe. Should be called after Init() and before Shutdown(). Can't be called twice.
+ * @note Not thread-safe. Should be called after Start() and before Stop(). Can't be called twice.
  */
 exec::task<void> StartOrJoinCluster(const ClusterConfig& cluster_config);
 
 /**
- * @brief Shutdown the global default registry. Must be called explicitly before `main` exits.
+ * @brief Stop the ex_actor runtime. Must be called explicitly before `main` exits.
  * @note Not thread-safe
  */
+exec::task<void> Stop();
+
+/**
+ * @brief Deprecated. Use `sync_wait(Start())` or `co_await Start()` instead.
+ */
+[[deprecated("Use sync_wait(Start(...)) or co_await Start() instead.")]]
+void Init(uint32_t thread_pool_size);
+
+/**
+ * @brief Deprecated. Use `sync_wait(Start())` or `co_await Start()` instead.
+ */
+template <ex::scheduler Scheduler>
+[[deprecated("Use sync_wait(Start(...)) or co_await Start() instead.")]]
+void Init(Scheduler scheduler);
+
+/**
+ * @brief Deprecated. Use `sync_wait(Stop())` or `co_await Stop()` instead.
+ */
+[[deprecated("Use sync_wait(Stop()) or co_await Stop() instead.")]]
 void Shutdown();
 
 /**
@@ -161,11 +180,17 @@ void ConfigureLogging(const LogConfig& config = {});
 namespace ex_actor {
 
 template <ex::scheduler Scheduler>
-void Init(Scheduler scheduler) {
+exec::task<void> Start(Scheduler scheduler) {
   internal::log::Info("Initializing ex_actor with custom scheduler.");
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   AssignGlobalDefaultRegistry(std::make_unique<ActorRegistry>(std::move(scheduler)));
   internal::SetupGlobalHandlers();
+  co_return;
+}
+
+template <ex::scheduler Scheduler>
+void Init(Scheduler scheduler) {
+  ex::sync_wait(Start(std::move(scheduler)));
 }
 
 }  // namespace ex_actor

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -216,7 +216,7 @@ exec::task<void> ActorRegistry::StartOrJoinCluster(const ClusterConfig& cluster_
 exec::task<WaitClusterStateResult> ActorRegistry::WaitClusterState(std::function<bool(const ClusterState&)> predicate,
                                                                    uint64_t timeout_ms) {
   EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty())
-      << "WaitClusterState requires distributed mode, call StartOrJoinCluster() after Init() to enable it.";
+      << "WaitClusterState requires distributed mode, call StartOrJoinCluster() after Start() to enable it.";
   co_return co_await broker_actor_ref_.SendLocal<&MessageBroker::WaitClusterState>(std::move(predicate), timeout_ms);
 }
 

--- a/src/ex_actor/internal/global_registry.cc
+++ b/src/ex_actor/internal/global_registry.cc
@@ -79,13 +79,13 @@ static void RegisterAtExitCleanup() {
   }
   at_exit_cleanup_registered = true;
 
-  // Because Init() is called after main starts, this handler will be called before static object destruction.
-  // Once we enter static object destruction without calling Shutdown(), the program will crash due to static object
+  // Because Start() is called after main starts, this handler will be called before static object destruction.
+  // Once we enter static object destruction without calling Stop(), the program will crash due to static object
   // destruction order fiasco. So we print an error message here and force exit the program.
   //
-  // We can't call Shutdown() here for user, because thread_local objects are already destroyed, shutting down
+  // We can't call Stop() here for user, because thread_local objects are already destroyed, shutting down
   // ActorRegistry needs to use the mailbox, which has some thread_local objects, the program will crash if we call
-  // Shutdown() here. Printing an error message is the best we can do here. User need to call Shutdown() explicitly
+  // Stop() here. Printing an error message is the best we can do here. User need to call Stop() explicitly
   // before main() exits.
   std::atexit([] {
     if (!IsGlobalDefaultRegistryInitialized()) {
@@ -93,7 +93,8 @@ static void RegisterAtExitCleanup() {
     }
     log::Error(
         "ex_actor is not shutdown when exiting main(), calling std::quick_exit(1) to force exit, resources may not be "
-        "cleaned properly. To fix this error, call ex_actor::Shutdown() before main() exits.");
+        "cleaned properly. To fix this error, call co_await ex_actor::Stop() or sync_wait(ex_actor::Stop()) before "
+        "main() exits.");
     std::quick_exit(1);
   });
 }
@@ -103,15 +104,18 @@ void SetupGlobalHandlers() { RegisterAtExitCleanup(); }
 }  // namespace ex_actor::internal
 
 namespace ex_actor {
-void Init(uint32_t thread_pool_size) {
+exec::task<void> Start(uint32_t thread_pool_size) {
   internal::log::Info("Initializing ex_actor with default scheduler, thread_pool_size={}", thread_pool_size);
   EXA_THROW_CHECK(!internal::IsGlobalDefaultRegistryInitialized()) << "Already initialized.";
   global_default_registry = std::make_unique<ActorRegistry>(thread_pool_size);
   internal::SetupGlobalHandlers();
+  co_return;
 }
 
+void Init(uint32_t thread_pool_size) { ex::sync_wait(Start(thread_pool_size)); }
+
 exec::task<void> StartOrJoinCluster(const ClusterConfig& cluster_config) {
-  EXA_THROW_CHECK(internal::IsGlobalDefaultRegistryInitialized()) << "Not initialized. Call Init() first.";
+  EXA_THROW_CHECK(internal::IsGlobalDefaultRegistryInitialized()) << "Not initialized. Call Start() first.";
   co_await internal::GetGlobalDefaultRegistry().StartOrJoinCluster(cluster_config);
 }
 
@@ -136,12 +140,15 @@ exec::task<void> WaitOsExitSignal() {
   signal_semaphore = nullptr;
 }
 
-void Shutdown() {
+exec::task<void> Stop() {
   EXA_THROW_CHECK(internal::IsGlobalDefaultRegistryInitialized()) << "Not initialized.";
   internal::log::Info("Shutting down ex_actor.");
   global_default_registry.reset();
   resource_holder.clear();
+  co_return;
 }
+
+void Shutdown() { ex::sync_wait(Stop()); }
 
 void ConfigureLogging(const LogConfig& config) { internal::GlobalLogger() = internal::CreateLoggerUsingConfig(config); }
 

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -51,19 +51,19 @@ class Proxy {
 
 TEST(BasicApiTest, ActorRegistryCreationWithDefaultScheduler) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto counter = co_await ex_actor::Spawn<Counter>();
     auto getvalue_sender = counter.Send<&Counter::GetValue>();
     auto getvalue_reply = co_await std::move(getvalue_sender);
     EXPECT_EQ(getvalue_reply, 0);
-    co_return;
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(BasicApiTest, ShouldWorkWithAsyncSpawn) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto counter = co_await ex_actor::Spawn<Counter>();
     exec::async_scope scope;
     scope.spawn(counter.SendLocal<&Counter::Add>(1));
@@ -72,26 +72,28 @@ TEST(BasicApiTest, ShouldWorkWithAsyncSpawn) {
     EXPECT_EQ(res, 1);
     // Wait for all spawned work to complete before destroying the scope
     co_await scope.on_empty();
-    co_return;
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(BasicApiTest, ExceptionInActorMethodShouldBePropagatedToCaller) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto counter = co_await ex_actor::Spawn<Counter>();
     co_await counter.Send<&Counter::Error>();
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ASSERT_THAT([&coroutine] { ex::sync_wait(coroutine()); },
               Throws<std::exception>(Property(&std::exception::what, HasSubstr("error0"))));
-  ex_actor::Shutdown();
+  // The exception above causes the coroutine to unwind before reaching Stop(),
+  // so we must explicitly shut down to avoid leaving stale global state for subsequent tests.
+  ex::sync_wait(ex_actor::Stop());
 }
 
 TEST(BasicApiTest, NestActorRefCase) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     ex_actor::ActorRef counter = co_await ex_actor::Spawn<Counter>();
     exec::async_scope scope;
     for (int i = 0; i < 100; ++i) {
@@ -105,15 +107,14 @@ TEST(BasicApiTest, NestActorRefCase) {
     auto res3 = co_await proxy.Send<&Proxy::GetValue2>();
     EXPECT_EQ(res2, 100);
     EXPECT_EQ(res3, 100);
-    co_return;
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(BasicApiTest, SpawnWithFullConfig) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     /*
     before gcc 13, we can't use heap-allocated temp variable after co_await, or there will be a double free error.
     here actor_name is heap allocated. so when using ActorConfig with actor_name, we should define it explicitly.
@@ -141,10 +142,9 @@ TEST(BasicApiTest, SpawnWithFullConfig) {
     ex_actor::ActorConfig config = {.max_message_executed_per_activation = 10};
     co_await ex_actor::Spawn<Proxy>(counter).WithConfig(config);
     co_await ex_actor::DestroyActor(counter);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 class TestActorWithNamedLookup {
@@ -156,6 +156,7 @@ class TestActorWithNamedLookup {
 
 TEST(BasicApiTest, LookUpNamedActor) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     ex_actor::ActorConfig config {.actor_name = "counter"};
     co_await ex_actor::Spawn<Counter>().WithConfig(config);
     auto test_retriever_actor = co_await ex_actor::Spawn<TestActorWithNamedLookup>();
@@ -167,10 +168,9 @@ TEST(BasicApiTest, LookUpNamedActor) {
     auto getvalue_sender = actor.Send<&Counter::GetValue>();
     auto getvalue_reply = co_await std::move(getvalue_sender);
     EXPECT_EQ(getvalue_reply, 0);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(BasicApiTest, RemoteActorRefSlicedToLocalActorRefShouldThrowOnUse) {
@@ -194,11 +194,11 @@ struct Derived : Base {
 
 TEST(BasicApiTest, ActorCanBePolymorphic) {
   auto coroutine = []() -> exec::task<void> {
-    ex_actor::Init(/*thread_pool_size=*/10);
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     ex_actor::ActorRef<Base> base = co_await ex_actor::Spawn<Derived>();
     std::string foo_reply = co_await base.Send<&Base::Foo>();
     EXPECT_EQ(foo_reply, "Derived::Foo");
-    ex_actor::Shutdown();
+    co_await ex_actor::Stop();
   };
   ex::sync_wait(coroutine());
 }

--- a/test/complex_api_test_constructors.cc
+++ b/test/complex_api_test_constructors.cc
@@ -140,6 +140,7 @@ class ComplexContainerActor {
 
 TEST(ComplexApiTest, EmptyConstructorActor) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<EmptyActor>();
 
     int initial = co_await actor.template Send<&EmptyActor::GetCounter>();
@@ -155,14 +156,14 @@ TEST(ComplexApiTest, EmptyConstructorActor) {
 
     int final_count = co_await actor.template Send<&EmptyActor::GetCounter>();
     EXPECT_EQ(final_count, 7);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, SingleParameterConstructor) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<SingleParamActor>("TestActor");
 
     std::string name = co_await actor.template Send<&SingleParamActor::GetName>();
@@ -175,14 +176,14 @@ TEST(ComplexApiTest, SingleParameterConstructor) {
     co_await actor.template Send<&SingleParamActor::AppendToName>("_Suffix");
     std::string new_name = co_await actor.template Send<&SingleParamActor::GetName>();
     EXPECT_EQ(new_name, "TestActor_Suffix");
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, MultipleParametersConstructor) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<MultiParamActor>(123, "MultiActor", 2.5, true);
 
     int id = co_await actor.template Send<&MultiParamActor::GetId>();
@@ -207,14 +208,14 @@ TEST(ComplexApiTest, MultipleParametersConstructor) {
 
     bool new_enabled = co_await actor.template Send<&MultiParamActor::IsEnabled>();
     EXPECT_FALSE(new_enabled);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, MoveOnlyConstructorParameters) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto initial_data = std::make_unique<std::string>("Initial");
     auto actor = co_await ex_actor::Spawn<MoveOnlyConstructorActor>(std::move(initial_data));
 
@@ -227,14 +228,14 @@ TEST(ComplexApiTest, MoveOnlyConstructorParameters) {
 
     std::string updated_data = co_await actor.template Send<&MoveOnlyConstructorActor::GetData>();
     EXPECT_EQ(updated_data, "Updated");
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, ComplexContainerConstructor) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     std::vector<int> ids = {1, 2, 3, 4, 5};
     std::map<std::string, int> lookup = {{"a", 10}, {"b", 20}, {"c", 30}};
     std::optional<std::string> description = "Test Actor";
@@ -272,8 +273,7 @@ TEST(ComplexApiTest, ComplexContainerConstructor) {
     EXPECT_EQ(new_size, 6);
     int last_id = co_await actor.template Send<&ComplexContainerActor::GetIdAt>(5);
     EXPECT_EQ(last_id, 6);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }

--- a/test/complex_api_test_methods.cc
+++ b/test/complex_api_test_methods.cc
@@ -252,6 +252,7 @@ class Distributor {
 
 TEST(ComplexApiTest, VariousArgumentTypes) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<VariousArgsActor>();
     // No arguments
     int state = co_await actor.template Send<&VariousArgsActor::GetState>();
@@ -304,14 +305,14 @@ TEST(ComplexApiTest, VariousArgumentTypes) {
     co_await actor.template Send<&VariousArgsActor::ProcessNestedData>(std::move(nested), std::move(mapped));
     size_t nested_size = co_await actor.template Send<&VariousArgsActor::GetNestedDataSize>();
     EXPECT_EQ(nested_size, 6);  // 2 + 3 + 1
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, MoveOnlyArguments) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<MoveOnlyArgsActor>();
     // unique_ptr<int>
     auto int_ptr = std::make_unique<int>(42);
@@ -346,14 +347,14 @@ TEST(ComplexApiTest, MoveOnlyArguments) {
     co_await actor.template Send<&MoveOnlyArgsActor::StoreMap>(std::move(map_ptr));
     size_t map_size = co_await actor.template Send<&MoveOnlyArgsActor::GetMapSize>();
     EXPECT_EQ(map_size, 3);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, ReferenceReturnTypes) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<ReferenceReturnActor>("Initial");
     std::string data = co_await actor.template Send<&ReferenceReturnActor::GetDataCopy>();
     EXPECT_EQ(data, "Initial");
@@ -368,14 +369,14 @@ TEST(ComplexApiTest, ReferenceReturnTypes) {
 
     size_t size = co_await actor.template Send<&ReferenceReturnActor::GetDataSize>();
     EXPECT_EQ(size, 8);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, ActorWithActorRefMember) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto child = co_await ex_actor::Spawn<ChildActor>();
     auto parent = co_await ex_actor::Spawn<ParentActor>(child);
     // Direct access to child
@@ -391,14 +392,14 @@ TEST(ComplexApiTest, ActorWithActorRefMember) {
     co_await parent.template Send<&ParentActor::AddToChild>(10);
     count = co_await parent.template Send<&ParentActor::GetChildCounter>();
     EXPECT_EQ(count, 12);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, ActorWithMultipleActorRefMembers) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto acc1 = co_await ex_actor::Spawn<Accumulator>();
     auto acc2 = co_await ex_actor::Spawn<Accumulator>();
     auto acc3 = co_await ex_actor::Spawn<Accumulator>();
@@ -426,14 +427,14 @@ TEST(ComplexApiTest, ActorWithMultipleActorRefMembers) {
     EXPECT_EQ(sum1, 60);
     EXPECT_EQ(sum2, 60);
     EXPECT_EQ(sum3, 60);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, MixedComplexScenario) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     // Test combining multiple complex features
     // Create a complex hierarchy
     auto acc1 = co_await ex_actor::Spawn<Accumulator>();
@@ -462,8 +463,7 @@ TEST(ComplexApiTest, MixedComplexScenario) {
     co_await move_actor.template Send<&MoveOnlyArgsActor::StoreString>(std::move(str));
     std::string stored = co_await move_actor.template Send<&MoveOnlyArgsActor::GetStoredString>();
     EXPECT_EQ(stored, "Complex Test");
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }

--- a/test/complex_api_test_structs.cc
+++ b/test/complex_api_test_structs.cc
@@ -244,6 +244,7 @@ class NestedStructActor {
 
 TEST(ComplexApiTest, StructArguments) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<StructActor>();
     // Test Point struct
     Point pt {.x = 3.0, .y = 4.0};
@@ -285,14 +286,14 @@ TEST(ComplexApiTest, StructArguments) {
 
     double sum = co_await actor.template Send<&StructActor::SumPacketValues>();
     EXPECT_DOUBLE_EQ(sum, 11.0);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, StructInConstructor) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     Configuration config;
     config.app_name = "TestApp";
     config.version = 2;
@@ -337,14 +338,14 @@ TEST(ComplexApiTest, StructInConstructor) {
 
     bool is_prod_after = co_await actor.template Send<&StructConstructorActor::IsProduction>();
     EXPECT_FALSE(is_prod_after);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, MultipleStructArguments) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<MultiStructActor>();
     // Test with Point and Person
     Point pt {.x = 10.0, .y = 20.0};
@@ -377,14 +378,14 @@ TEST(ComplexApiTest, MultipleStructArguments) {
 
     bool has_data = co_await actor.template Send<&MultiStructActor::HasData>();
     EXPECT_TRUE(has_data);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, MoveOnlyStructArgument) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<MoveOnlyStructActor>();
     // Create move-only data
     auto content = std::make_unique<std::string>("Test Content");
@@ -408,14 +409,14 @@ TEST(ComplexApiTest, MoveOnlyStructArgument) {
 
     bool has_data = co_await actor.template Send<&MoveOnlyStructActor::HasData>();
     EXPECT_TRUE(has_data);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ComplexApiTest, NestedStructArgument) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     auto actor = co_await ex_actor::Spawn<NestedStructActor>();
     // Create nested struct
     Employee emp;
@@ -448,8 +449,7 @@ TEST(ComplexApiTest, NestedStructArgument) {
 
     int age = co_await actor.template Send<&NestedStructActor::GetAge>();
     EXPECT_EQ(age, 35);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }

--- a/test/dynamic_connectivity_test.cc
+++ b/test/dynamic_connectivity_test.cc
@@ -1,15 +1,12 @@
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <iostream>
 #include <random>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "ex_actor/api.h"
-
-using std::chrono::milliseconds;
 
 class Echoer {
  public:
@@ -48,10 +45,10 @@ class DynamicConnectivityTest {
 
   void Test() {
     auto config = BuildConfig();
-    ex_actor::Init(/*thread_pool_size=*/1);
-    stdexec::sync_wait(ex_actor::StartOrJoinCluster(config));
+    auto coroutine = [this, config]() -> exec::task<void> {
+      co_await ex_actor::Start(/*thread_pool_size=*/1);
+      co_await ex_actor::StartOrJoinCluster(config);
 
-    auto coroutine = [this]() -> exec::task<void> {
       // Wait for all other nodes to be discovered
       auto [cluster_state, condition_met] =
           co_await ex_actor::WaitClusterState([this](const auto& state) { return state.nodes.size() >= cluster_size_; },
@@ -68,24 +65,21 @@ class DynamicConnectivityTest {
       auto target_node_id = it->node_id;
 
       std::string str {"Hello"};
-      auto actor_creation_sender = ex_actor::Spawn<Echoer>();
-      auto [actor_ref] = stdexec::sync_wait(actor_creation_sender).value();
-      auto actor_method_calling_sender = actor_ref.Send<&Echoer::Echo>(str);
-      auto [method_calling_return_val] = stdexec::sync_wait(std::move(actor_method_calling_sender)).value();
+      auto actor_ref = co_await ex_actor::Spawn<Echoer>();
+      auto method_calling_return_val = co_await actor_ref.Send<&Echoer::Echo>(str);
       EXA_THROW_CHECK(method_calling_return_val == str)
           << ex_actor::fmt_lib::format("Error: local method calling error");
 
-      auto remote_actor_creation_sender = ex_actor::Spawn<&Echoer::Create>().ToNode(target_node_id);
-      auto [remote_actor_ref] = stdexec::sync_wait(std::move(remote_actor_creation_sender)).value();
-      auto remote_actor_calling_sender = remote_actor_ref.Send<&Echoer::Echo>(str);
-      auto [remote_method_calling_return_val] = stdexec::sync_wait(std::move(remote_actor_calling_sender)).value();
+      auto remote_actor_ref = co_await ex_actor::Spawn<&Echoer::Create>().ToNode(target_node_id);
+      auto remote_method_calling_return_val = co_await remote_actor_ref.Send<&Echoer::Echo>(str);
       EXA_THROW_CHECK(remote_method_calling_return_val == str)
           << ex_actor::fmt_lib::format("Error: remote method calling error");
+      std::cout << "All work done" << std::endl;
+      co_await ex_actor::WaitOsExitSignal();
+      co_await ex_actor::Stop();
     };
 
     stdexec::sync_wait(coroutine());
-    std::this_thread::sleep_for(std::chrono::milliseconds {1500});
-    ex_actor::Shutdown();
   }
 
  private:

--- a/test/dynamic_connectivity_test.py
+++ b/test/dynamic_connectivity_test.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 
+import os
+import signal
 import subprocess
 import sys
+import tempfile
 import time
 
+IS_WINDOWS = sys.platform == "win32"
 CLUSTER_SIZE = 8
+WORK_TIMEOUT = 15
+SUCCESS_LOG = "All work done"
 
 
-def clear_nodes(node_list):
+def kill_nodes(node_list):
     for node in node_list:
         if node.poll() is None:
             node.kill()
@@ -15,29 +21,95 @@ def clear_nodes(node_list):
         node.wait()
 
 
-def check_nodes(node_list, timeout=15):
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if all(node.poll() is not None for node in node_list):
-            break
-        time.sleep(0.5)
-    for node in node_list:
-        if node.poll() is None:
-            clear_nodes(node_list)
-            raise RuntimeError("There is a node in the cluster hangs")
-    for node in node_list:
-        if node.returncode != 0:
-            clear_nodes(node_list)
-            raise RuntimeError("There are some nodes in the cluster exit with non-zero return code")
-
-
 def run_test(bin, test_type):
+    log_files = []
     node_list = []
     for node_id in range(CLUSTER_SIZE):
-        node_list.append(
-            subprocess.Popen([bin, str(CLUSTER_SIZE), str(node_id), test_type])
+        log_file = tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".log"
         )
-    check_nodes(node_list)
+        log_files.append(log_file)
+        node_list.append(
+            subprocess.Popen(
+                [bin, str(CLUSTER_SIZE), str(node_id), test_type],
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+            )
+        )
+        log_file.close()
+
+    def cleanup(kill=True):
+        for node in node_list:
+            if kill and node.poll() is None:
+                node.kill()
+            node.wait()
+        for log_file in log_files:
+            os.unlink(log_file.name)
+
+    def print_all_logs():
+        for i, log_file in enumerate(log_files):
+            print(f"--- node{i} log ---", flush=True)
+            with open(log_file.name, "r") as f:
+                print(f.read(), end="", flush=True)
+
+    # Wait until all nodes print the success log, or timeout.
+    done = [False] * CLUSTER_SIZE
+    deadline = time.monotonic() + WORK_TIMEOUT
+    while time.monotonic() < deadline:
+        for i, node in enumerate(node_list):
+            code = node.poll()
+            if code is not None and code != 0:
+                print(f"FAIL: node{i} exited prematurely with code {code}", flush=True)
+                print_all_logs()
+                cleanup(kill=True)
+                sys.exit(1)
+
+        for i, log_file in enumerate(log_files):
+            if not done[i]:
+                with open(log_file.name, "r") as f:
+                    if SUCCESS_LOG in f.read():
+                        done[i] = True
+
+        if all(done):
+            break
+        time.sleep(0.5)
+
+    if not all(done):
+        missing = [i for i, d in enumerate(done) if not d]
+        print(f"FAIL: node(s) {missing} did not print '{SUCCESS_LOG}' within {WORK_TIMEOUT}s", flush=True)
+        print_all_logs()
+        cleanup(kill=True)
+        sys.exit(1)
+
+    # All nodes finished work; terminate them.
+    # On Linux, terminate() sends SIGTERM which the C++ signal handler catches for graceful shutdown.
+    # On Windows, terminate() calls TerminateProcess(pid, 1) — no signal handler is invoked.
+    for node in node_list:
+        if node.poll() is None:
+            node.terminate()
+
+    for node in node_list:
+        try:
+            node.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            node.kill()
+            node.wait()
+
+    if IS_WINDOWS:
+        # TerminateProcess sets exit code to 1
+        acceptable_codes = {0, 1}
+    else:
+        acceptable_codes = {0, -signal.SIGTERM}
+    for i, node in enumerate(node_list):
+        if node.returncode not in acceptable_codes:
+            print(f"FAIL: node{i} exited with unexpected code {node.returncode}", flush=True)
+            print_all_logs()
+            cleanup(kill=False)
+            sys.exit(1)
+
+    print(f"SUCCESS: all {CLUSTER_SIZE} nodes completed work", flush=True)
+    for log_file in log_files:
+        os.unlink(log_file.name)
 
 
 if __name__ == "__main__":

--- a/test/heartbeat_test.cc
+++ b/test/heartbeat_test.cc
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
                 .gossip_interval_ms = 50,
             },
     };
-    ex_actor::Init(/*thread_pool_size=*/2);
+    co_await ex_actor::Start(/*thread_pool_size=*/2);
     co_await ex_actor::StartOrJoinCluster(cluster_config);
 
     auto [cluster_state, condition_met] =
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
       }
     }
     co_await ex_actor::WaitOsExitSignal();
-    ex_actor::Shutdown();
+    co_await ex_actor::Stop();
   };
   stdexec::sync_wait(coroutine(std::move(listen_address), std::move(remote_address), std::move(contact_address)));
 }

--- a/test/logging_test.cc
+++ b/test/logging_test.cc
@@ -38,8 +38,8 @@ void CleanupLogFile(const std::string& log_file) {
 
 }  // namespace
 
-// Test 1: Init() and Shutdown() without configure logging, should see all logs
-TEST(LoggingTest, InitShutdownWithoutConfigureLogging) {
+// Test 1: Start() and Stop() without configure logging, should see all logs
+TEST(LoggingTest, StartStopWithoutConfigureLogging) {
   std::string log_file = "test_log_1.txt";
 
   // Clean up any existing log file
@@ -50,19 +50,19 @@ TEST(LoggingTest, InitShutdownWithoutConfigureLogging) {
       .log_file_path = log_file,
   });
 
-  // Init and Shutdown
-  ex_actor::Init(4);
-  ex_actor::Shutdown();
+  // Start and Stop
+  stdexec::sync_wait(ex_actor::Start(4));
+  stdexec::sync_wait(ex_actor::Stop());
 
   // flush log
   ex_actor::internal::GlobalLogger()->flush();
 
-  // Read log file and verify both Init and Shutdown logs are present
+  // Read log file and verify both Start and Stop logs are present
   std::string log_contents = ReadFile(log_file);
   EXPECT_FALSE(log_contents.empty()) << "Log file should not be empty";
-  EXPECT_TRUE(Contains(log_contents, "Initializing ex_actor")) << "Should see Init log. Log contents:\n"
+  EXPECT_TRUE(Contains(log_contents, "Initializing ex_actor")) << "Should see Start log. Log contents:\n"
                                                                << log_contents;
-  EXPECT_TRUE(Contains(log_contents, "Shutting down ex_actor")) << "Should see Shutdown log. Log contents:\n"
+  EXPECT_TRUE(Contains(log_contents, "Shutting down ex_actor")) << "Should see Stop log. Log contents:\n"
                                                                 << log_contents;
 
   // Clean up
@@ -82,9 +82,9 @@ TEST(LoggingTest, ConfigureLoggingWithErrorLevel) {
       .log_file_path = log_file,
   });
 
-  // Init and Shutdown - these produce Info level logs
-  ex_actor::Init(4);
-  ex_actor::Shutdown();
+  // Start and Stop - these produce Info level logs
+  stdexec::sync_wait(ex_actor::Start(4));
+  stdexec::sync_wait(ex_actor::Stop());
 
   // flush log
   ex_actor::internal::GlobalLogger()->flush();
@@ -92,18 +92,18 @@ TEST(LoggingTest, ConfigureLoggingWithErrorLevel) {
   // Read log file - should be empty or not contain Info logs
   std::string log_contents = ReadFile(log_file);
   EXPECT_FALSE(Contains(log_contents, "Initializing ex_actor"))
-      << "Should NOT see Init log at Error level. Log contents:\n"
+      << "Should NOT see Start log at Error level. Log contents:\n"
       << log_contents;
   EXPECT_FALSE(Contains(log_contents, "Shutting down ex_actor"))
-      << "Should NOT see Shutdown log at Error level. Log contents:\n"
+      << "Should NOT see Stop log at Error level. Log contents:\n"
       << log_contents;
 
   // Clean up
   CleanupLogFile(log_file);
 }
 
-// Test 3: Init() first with Info level, then ConfigureLogging() with Error level in the middle,
-// and Shutdown(). Should only see Init log, not Shutdown log
+// Test 3: Start() first with Info level, then ConfigureLogging() with Error level in the middle,
+// and Stop(). Should only see Start log, not Stop log
 TEST(LoggingTest, ConfigureLoggingInMiddle) {
   std::string log_file = "test_log_3.txt";
 
@@ -116,8 +116,8 @@ TEST(LoggingTest, ConfigureLoggingInMiddle) {
       .log_file_path = log_file,
   });
 
-  // Init - should be logged
-  ex_actor::Init(4);
+  // Start - should be logged
+  stdexec::sync_wait(ex_actor::Start(4));
 
   // Change log level to Error in the middle
   ex_actor::ConfigureLogging({
@@ -125,8 +125,8 @@ TEST(LoggingTest, ConfigureLoggingInMiddle) {
       .log_file_path = log_file,
   });
 
-  // Shutdown - should NOT be logged because level is now Error
-  ex_actor::Shutdown();
+  // Stop - should NOT be logged because level is now Error
+  stdexec::sync_wait(ex_actor::Stop());
 
   // flush log
   ex_actor::internal::GlobalLogger()->flush();
@@ -135,10 +135,10 @@ TEST(LoggingTest, ConfigureLoggingInMiddle) {
   std::string log_contents = ReadFile(log_file);
   EXPECT_FALSE(log_contents.empty()) << "Log file should not be empty";
   EXPECT_TRUE(Contains(log_contents, "Initializing ex_actor"))
-      << "Should see Init log (before level change). Log contents:\n"
+      << "Should see Start log (before level change). Log contents:\n"
       << log_contents;
   EXPECT_FALSE(Contains(log_contents, "Shutting down ex_actor"))
-      << "Should NOT see Shutdown log (after level change to Error). Log contents:\n"
+      << "Should NOT see Stop log (after level change to Error). Log contents:\n"
       << log_contents;
 
   // Clean up

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -29,7 +29,7 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
       .listen_address = listen_address,
       .contact_node_address = contact_address,
   };
-  ex_actor::Init(shared_pool->GetScheduler());
+  co_await ex_actor::Start(shared_pool->GetScheduler());
   co_await ex_actor::StartOrJoinCluster(cluster_config);
   ex_actor::HoldResource(shared_pool);
 
@@ -49,7 +49,7 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
 
   logging::Info("All work done");
   co_await ex_actor::WaitOsExitSignal();
-  ex_actor::Shutdown();
+  co_await ex_actor::Stop();
 }
 }  // namespace
 

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -87,6 +87,7 @@ TEST(SchedulerTest, SchedulerUnionTest) {
   ASSERT_NE(thread_id1, thread_id2);
 
   auto coroutine = [&]() -> exec::task<void> {
+    co_await ex_actor::Start(scheduler_union.GetScheduler());
     // create two actors, specify the scheduler index in ActorConfig.
     auto actor1 = co_await ex_actor::Spawn<TestActor2>().WithConfig({.scheduler_index = 0});
     auto actor2 = co_await ex_actor::Spawn<TestActor2>().WithConfig({.scheduler_index = 1});
@@ -95,10 +96,9 @@ TEST(SchedulerTest, SchedulerUnionTest) {
     uint64_t thread_id2 = co_await actor2.Send<&TestActor2::GetThreadId>();
     // the two actors should run on different thread pool
     EXPECT_NE(thread_id1, thread_id2);
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(scheduler_union.GetScheduler());
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(SchedulerTest, TestResourceHolder) {
@@ -107,11 +107,11 @@ TEST(SchedulerTest, TestResourceHolder) {
   auto union_pool = std::make_unique<ex_actor::SchedulerUnion<ex_actor::WorkSharingThreadPool::Scheduler>>(
       std::vector<ex_actor::WorkSharingThreadPool::Scheduler> {shared_pool1->GetScheduler(),
                                                                shared_pool2->GetScheduler()});
-  ex_actor::Init(union_pool->GetScheduler());
-  ex_actor::HoldResource(std::move(shared_pool1));
-  ex_actor::HoldResource(std::move(shared_pool2));
-  ex_actor::HoldResource(std::move(union_pool));
   auto coroutine = [&]() -> exec::task<void> {
+    co_await ex_actor::Start(union_pool->GetScheduler());
+    ex_actor::HoldResource(std::move(shared_pool1));
+    ex_actor::HoldResource(std::move(shared_pool2));
+    ex_actor::HoldResource(std::move(union_pool));
     // create two actors, specify the scheduler index in ActorConfig.
     auto actor1 = co_await ex_actor::Spawn<TestActor2>().WithConfig({.scheduler_index = 0});
     auto actor2 = co_await ex_actor::Spawn<TestActor2>().WithConfig({.scheduler_index = 1});
@@ -120,7 +120,7 @@ TEST(SchedulerTest, TestResourceHolder) {
     uint64_t thread_id2 = co_await actor2.Send<&TestActor2::GetThreadId>();
     // the two actors should run on different thread pool
     EXPECT_NE(thread_id1, thread_id2);
+    co_await ex_actor::Stop();
   };
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }

--- a/test/shuffle_merge_test.cc
+++ b/test/shuffle_merge_test.cc
@@ -148,6 +148,7 @@ class Coordinator {
 
 TEST(ShuffleMergeTest, BasicShuffleMergeWorkflow) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     constexpr int kNumReducers = 4;
     constexpr int kNumWorkers = 16;
     constexpr int kNumSources = 8;
@@ -196,14 +197,14 @@ TEST(ShuffleMergeTest, BasicShuffleMergeWorkflow) {
     int64_t expected_sum = total_items * (total_items + 1) * (2 * total_items + 1) / 6;
 
     EXPECT_EQ(total_sum, expected_sum) << "Total sum should match formula for sum of squares from 1 to " << total_items;
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ShuffleMergeTest, LargeScaleShuffleMerge) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     constexpr int kNumReducers = 8;
     constexpr int kNumWorkers = 64;
     constexpr int kNumSources = 32;
@@ -264,14 +265,14 @@ TEST(ShuffleMergeTest, LargeScaleShuffleMerge) {
     // load should be reasonably balanced
     double load_balance_ratio = static_cast<double>(max_sum) / min_sum;
     EXPECT_LT(load_balance_ratio, 2.0) << "Load imbalance too high: " << load_balance_ratio;
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ShuffleMergeTest, MultiStageShuffleMerge) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     // Test with multiple stages of shuffle-merge (like multi-level MapReduce)
     constexpr int kNumStage1Reducers = 16;
     constexpr int kNumStage2Reducers = 4;
@@ -369,14 +370,14 @@ TEST(ShuffleMergeTest, MultiStageShuffleMerge) {
     }
 
     EXPECT_EQ(final_sum, expected_final_sum) << "Stage 2 final sum should be sum of squares of stage 1 results";
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }
 
 TEST(ShuffleMergeTest, ComplexDependencyGraph) {
   auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/10);
     // Test with complex dependency graph where workers communicate with multiple reducers
     constexpr int kNumReducers = 8;
     constexpr int kNumValues = 10000;
@@ -428,8 +429,7 @@ TEST(ShuffleMergeTest, ComplexDependencyGraph) {
     // Verify total: sum of squares from 1 to N = N(N+1)(2N+1)/6
     int64_t expected_sum = static_cast<int64_t>(kNumValues) * (kNumValues + 1) * (2 * kNumValues + 1) / 6;
     EXPECT_EQ(total_sum, expected_sum) << "Total sum should match mathematical formula for sum of squares";
+    co_await ex_actor::Stop();
   };
-  ex_actor::Init(/*thread_pool_size=*/10);
   ex::sync_wait(coroutine());
-  ex_actor::Shutdown();
 }

--- a/test/skynet_test.cc
+++ b/test/skynet_test.cc
@@ -80,22 +80,24 @@ exec::task<uint64_t> SkynetActor::Process(int level, bool verbose) {
 }
 
 TEST(SkynetTest, ActorRegistryCanBeInvokeInsideActorMethods) {
-  ex_actor::Init(/*thread_pool_size=*/2);
-  auto [root] = stdexec::sync_wait(ex_actor::Spawn<SkynetActor>()).value();
+  auto coroutine = []() -> exec::task<void> {
+    co_await ex_actor::Start(/*thread_pool_size=*/2);
+    auto root = co_await ex_actor::Spawn<SkynetActor>();
 
-  int depth = 4;
+    int depth = 4;
 
-  logging::Info("Starting Skynet (Depth {}, Width 10)...", depth);
-  auto start = std::chrono::high_resolution_clock::now();
+    logging::Info("Starting Skynet (Depth {}, Width 10)...", depth);
+    auto start = std::chrono::high_resolution_clock::now();
 
-  auto task = root.SendLocal<&SkynetActor::Process>(depth, true);
-  auto [result] = ex::sync_wait(std::move(task)).value();
-  ASSERT_EQ(result, std::pow(10, depth));
+    auto result = co_await root.SendLocal<&SkynetActor::Process>(depth, true);
+    EXPECT_EQ(result, std::pow(10, depth));
 
-  auto end = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
-  logging::Info("Result: {} ms", result);
-  logging::Info("Time: {} ms", duration);
-  ex_actor::Shutdown();
+    logging::Info("Result: {} ms", result);
+    logging::Info("Time: {} ms", duration);
+    co_await ex_actor::Stop();
+  };
+  ex::sync_wait(coroutine());
 }


### PR DESCRIPTION
There are blocking operations in Init() and Shutdown(), which will block scheduler threads, causing potential deadlock.
This PR introduce new async Start()/Stop() API to replace them. The original API is still working, marked as deprecated.