### PR TITLE
[fix] Preserve empty ActorRef state through serialization round-trip

### DIFF
--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -204,6 +204,9 @@ struct Reflector<ex_actor::internal::ActorRef<U>> {
   };
 
   static ex_actor::internal::ActorRef<U> to(const ReflType& rfl_type) noexcept {
+    if (rfl_type.is_empty) {
+      return ex_actor::internal::ActorRef<U>();
+    }
     // this_node_id(0) and TypeErasedActor*(nullptr) are placeholders;
     // filled later in the Parser::read below.
     ex_actor::internal::ActorRef<U> actor(/*this_node_id=*/0, rfl_type.node_id, rfl_type.actor_id, /*actor=*/nullptr,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ function(ex_actor_test NAME)
 endfunction()
 
 ex_actor_test(basic_api_test)
+ex_actor_test(serialization_test)
 ex_actor_test(util_test)
 ex_actor_test(scheduler_test)
 ex_actor_test(stress_test)

--- a/test/serialization_test.cc
+++ b/test/serialization_test.cc
@@ -1,0 +1,45 @@
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "ex_actor/api.h"
+#include "ex_actor/internal/serialization.h"
+
+namespace {
+
+class Counter {
+ public:
+  void Add(int x) { count_ += x; }
+  int GetValue() const { return count_; }
+
+ private:
+  int count_ = 0;
+};
+
+struct ActorRefWrapper {
+  ex_actor::ActorRef<Counter> ref;
+};
+
+}  // namespace
+
+TEST(SerializationTest, EmptyActorRefRemainsEmptyAfterSerializeRoundTrip) {
+  ActorRefWrapper wrapper {.ref = {}};
+  ASSERT_TRUE(wrapper.ref.IsEmpty());
+
+  auto serialized = ex_actor::internal::Serialize(wrapper);
+  auto deserialized = ex_actor::internal::Deserialize<ActorRefWrapper>(serialized);
+  EXPECT_TRUE(deserialized.ref.IsEmpty());
+}
+
+TEST(SerializationTest, NonEmptyActorRefRemainsNonEmptyAfterSerializeRoundTrip) {
+  ex_actor::ActorRef<Counter> ref(
+      /*this_node_id=*/1, /*node_id=*/2, /*actor_id=*/42, /*actor=*/nullptr, /*broker_actor_ref=*/ {});
+  ActorRefWrapper wrapper {.ref = ref};
+  ASSERT_FALSE(wrapper.ref.IsEmpty());
+
+  auto serialized = ex_actor::internal::Serialize(wrapper);
+  auto deserialized = ex_actor::internal::Deserialize<ActorRefWrapper>(serialized);
+  EXPECT_FALSE(deserialized.ref.IsEmpty());
+  EXPECT_EQ(deserialized.ref.GetNodeId(), 2);
+  EXPECT_EQ(deserialized.ref.GetActorId(), 42);
+}


### PR DESCRIPTION
## Summary
- Fix a bug where an empty `ActorRef` becomes non-empty after being serialized and sent over the network, because `Reflector::to()` always used the non-default constructor (which sets `is_empty_ = false`).
- Add `serialization_test.cc` with round-trip tests for both empty and non-empty `ActorRef` to prevent regression.

## Test plan
- [x] `serialization_test` passes with the fix
- [x] `EmptyActorRefRemainsEmptyAfterSerializeRoundTrip` fails without the fix (verified by temporarily reverting)
- [x] All existing `basic_api_test` tests still pass
