### PR TITLE
[fix] make compile error shorter

### DIFF
--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -86,7 +86,9 @@ class ActorRef : public LocalActorRef<UserClass> {
    * @note The returned coroutine is not copyable. please use `co_await std::move(coroutine)`.
    */
   template <auto kMethod, class... Args>
-  [[nodiscard]] auto Send(Args... args) const {
+  [[nodiscard]] auto Send(Args... args) const
+    requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
+  {
     // Add a fallback inline_scheduler for it.
     return WrapSenderWithInlineScheduler(SendInternal<kMethod>(std::move(args)...));
   }
@@ -95,7 +97,9 @@ class ActorRef : public LocalActorRef<UserClass> {
    * @brief Send message to a local actor. Has better performance than the generic Send(). No heap allocation.
    */
   template <auto kMethod, class... Args>
-  [[nodiscard]] ex::sender auto SendLocal(Args... args) const {
+  [[nodiscard]] ex::sender auto SendLocal(Args... args) const
+    requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
+  {
     EXA_THROW_CHECK_EQ(node_id_, this_node_id_) << "Cannot call remote actor using SendLocal, use Send instead.";
     return LocalActorRef<UserClass>::template SendLocal<kMethod>(std::move(args)...);
   }
@@ -109,9 +113,9 @@ class ActorRef : public LocalActorRef<UserClass> {
 
   template <auto kMethod, class... Args>
   [[nodiscard]] auto SendInternal(Args... args) const
-      -> exec::task<typename decltype(UnwrapReturnSenderIfNested<kMethod>())::type> {
-    static_assert(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>,
-                  "method is not invocable with the provided arguments");
+      -> exec::task<typename decltype(UnwrapReturnSenderIfNested<kMethod>())::type>
+    requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
+  {
     if (this->IsEmpty()) [[unlikely]] {
       throw std::runtime_error("Empty ActorRef, cannot call method on it.");
     }

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -65,9 +65,6 @@ class ActorRegistryBackend {
   template <auto kCreateFn, class... Args>
   exec::task<ActorRef<FnReturnType<kCreateFn>>> SpawnWithCreateFn(uint64_t node_id, ActorConfig config, Args... args) {
     using UserClass = FnReturnType<kCreateFn>;
-    static_assert(std::is_invocable_v<decltype(kCreateFn), Args...>,
-                  "Class can't be created by given args and create function");
-
     if (node_id == this_node_id_) {
       co_return co_await SpawnLocal<UserClass, kCreateFn>(node_id, std::move(config), std::move(args)...);
     }
@@ -300,14 +297,18 @@ class ActorRegistry {
 
   /** @copydoc ex_actor::Spawn */
   template <class UserClass, class... Args>
-  SenderOf<ActorRef<UserClass>> auto Spawn(Args... args) {
+  SenderOf<ActorRef<UserClass>> auto Spawn(Args... args)
+    requires(std::is_constructible_v<UserClass, Args...>)
+  {
     return SpawnBuilder<UserClass, /*kCreateFn=*/nullptr, Args...>(backend_actor_ref_, std::move(args)...)
         .ToNode(this_node_id_);
   }
 
   /** @copydoc ex_actor::Spawn */
   template <auto kCreateFn, class... Args>
-  SenderOf<ActorRef<FnReturnType<kCreateFn>>> auto Spawn(Args... args) {
+  SenderOf<ActorRef<FnReturnType<kCreateFn>>> auto Spawn(Args... args)
+    requires(std::is_invocable_v<decltype(kCreateFn), Args...>)
+  {
     return SpawnBuilder<FnReturnType<kCreateFn>, kCreateFn, Args...>(backend_actor_ref_, std::move(args)...)
         .ToNode(this_node_id_);
   }

--- a/include/ex_actor/internal/global_registry.h
+++ b/include/ex_actor/internal/global_registry.h
@@ -103,7 +103,9 @@ void HoldResource(std::shared_ptr<void> resource);
  * @endcode
  */
 template <class UserClass, class... Args>
-SenderOf<ActorRef<UserClass>> auto Spawn(Args... args) {
+SenderOf<ActorRef<UserClass>> auto Spawn(Args... args)
+  requires(std::is_constructible_v<UserClass, Args...>)
+{
   return internal::GetGlobalDefaultRegistry().Spawn<UserClass, Args...>(std::move(args)...);
 }
 
@@ -120,7 +122,9 @@ SenderOf<ActorRef<UserClass>> auto Spawn(Args... args) {
  * @endcode
  */
 template <auto kCreateFn, class... Args>
-SenderOf<ActorRef<FnReturnType<kCreateFn>>> auto Spawn(Args... args) {
+SenderOf<ActorRef<FnReturnType<kCreateFn>>> auto Spawn(Args... args)
+  requires(std::is_invocable_v<decltype(kCreateFn), Args...>)
+{
   return internal::GetGlobalDefaultRegistry().Spawn<kCreateFn, Args...>(std::move(args)...);
 }
 

--- a/include/ex_actor/internal/local_actor_ref.h
+++ b/include/ex_actor/internal/local_actor_ref.h
@@ -63,9 +63,9 @@ class LocalActorRef {
    * @brief Send message to a local actor. No heap allocation.
    */
   template <auto kMethod, class... Args>
-  [[nodiscard]] ex::sender auto SendLocal(Args... args) const {
-    static_assert(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>,
-                  "method is not invocable with the provided arguments");
+  [[nodiscard]] ex::sender auto SendLocal(Args... args) const
+    requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
+  {
     EXA_THROW_CHECK(!IsEmpty()) << "Empty LocalActorRef, cannot call method on it.";
     EXA_THROW_CHECK(type_erased_actor_ != nullptr)
         << "Local actor instance not set, it's typically because you converted a remote ActorRef to LocalActorRef.";


### PR DESCRIPTION
Add `requires` closure to Send()/Spawn() to make compiler error more readable.