### PR TITLE
[fix] Handle future-timestamp due to clock skew

### DIFF
--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -291,11 +291,15 @@ void MessageBroker::BroadcastGossip() {
 }
 
 void MessageBroker::CheckHeartbeatTimeout() {
+  auto now_ms = GetTimeMs();
   for (auto& [node_id, state] : node_id_to_state_) {
-    if (!state.alive                 // already dead
-        || node_id == this_node_id_  // ourselves
-        || GetTimeMs() - state.last_seen_timestamp_ms <
-               cluster_config_.network_config.heartbeat_timeout_ms  // not timeout yet
+    // When using system_clock, remote timestamps may be slightly ahead of local clock due to
+    // clock skew across machines. Treat future timestamps as "just seen" to avoid unsigned
+    // underflow in the subtraction, which would falsely trigger a heartbeat timeout.
+    if (!state.alive ||                            // already dead
+        node_id == this_node_id_ ||                // ourselves
+        state.last_seen_timestamp_ms >= now_ms ||  // timestamp in the future due to clock skew
+        now_ms - state.last_seen_timestamp_ms < cluster_config_.network_config.heartbeat_timeout_ms  // not timeout yet
     ) {
       continue;
     }

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -564,6 +564,49 @@ TEST(MessageBrokerTest, HeartbeatTimeoutUsesWallClockEpoch) {
 }
 
 // ============================================================
+// CheckHeartbeatTimeout: clock skew (future timestamp) must not kill node
+// ============================================================
+
+TEST(MessageBrokerTest, CheckHeartbeatTimeoutToleratesClockSkew) {
+  auto config = MakeConfig("tcp://127.0.0.1:7367",
+                           /*contact_address=*/"tcp://127.0.0.1:7368",
+                           /*heartbeat_timeout_ms=*/100);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  // Simulate a remote node whose clock is slightly ahead of the local clock.
+  // Its last_seen_timestamp_ms will be in the future relative to our GetTimeMs().
+  // Without the clock-skew guard, the unsigned subtraction
+  //   (now_ms - last_seen_timestamp_ms) would underflow to a huge value,
+  // exceeding heartbeat_timeout_ms and falsely declaring the node dead.
+  uint64_t future_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+          .count() +
+      5000;
+
+  DispatchGossip(broker, {{.alive = true,
+                           .last_seen_timestamp_ms = future_ms,
+                           .node_id = 1,
+                           .address = "tcp://127.0.0.1:7368"}});
+
+  // Even after sleeping past the heartbeat timeout, the future timestamp must
+  // not cause an unsigned-underflow false positive.
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  broker.CheckHeartbeatTimeout();
+
+  // Node 1 should still be alive.
+  auto [result] = stdexec::sync_wait(broker.WaitClusterState(
+                                         [](const ex_actor::ClusterState& state) {
+                                           return std::ranges::any_of(
+                                               state.nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+                                         },
+                                         /*timeout_ms=*/10))
+                      .value();
+  EXPECT_TRUE(result.condition_met) << "Node with future timestamp should not be killed by heartbeat check";
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
 // CheckHeartbeatTimeout: self node is never deactivated
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Fix unsigned integer underflow in `CheckHeartbeatTimeout()` when a remote node's `system_clock` is slightly ahead of the local clock, causing `now_ms - last_seen_timestamp_ms` to wrap and falsely kill healthy nodes.
- Add a `last_seen_timestamp_ms >= now_ms` guard to treat future timestamps as "just seen" instead of triggering the subtraction.
- Add regression test `CheckHeartbeatTimeoutToleratesClockSkew` that simulates a 5-second clock skew and verifies the node stays alive.

## Test plan
- [x] New test `CheckHeartbeatTimeoutToleratesClockSkew` passes with the fix
- [x] New test hangs/fails without the fix (verified by reverting)
- [x] Full `network_test` suite (24 tests) passes