### PR TITLE
[fix] Fix crash when contact node restarts with same address but different node ID

### DIFF
--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -142,7 +142,7 @@ class ActorRef : public LocalActorRef<UserClass> {
 
     auto& ret = std::get<ActorMethodCallReply>(reply.variant);
     if (!ret.success) {
-      EXA_THROW << ret.error;
+      EXA_THROW << "Got error from remote actor on node " << node_id_ << ": " << ret.error;
     }
     if constexpr (std::is_void_v<UnwrappedType>) {
       co_return;

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -234,8 +234,8 @@ class MessageBroker {
   std::mt19937_64 rng_ {std::random_device {}()};
 
   zmq::context_t zmq_context_ {/*io_threads_=*/1};
-  // connected at start, then moved to node_id_to_send_socket_ once got gossip from it
-  std::optional<zmq::socket_t> contact_node_send_socket_;
+  // connected at start, used for bootstrapping the network
+  zmq::socket_t contact_node_send_socket_;
   std::unordered_map<uint64_t, zmq::socket_t> node_id_to_send_socket_;
 
   LocalActorRef<MessageBroker> self_actor_ref_;

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -154,10 +154,9 @@ MessageBroker::MessageBroker(uint64_t this_node_id, ClusterConfig cluster_config
                                       .address = cluster_config_.listen_address};
   if (!cluster_config_.contact_node_address.empty()) {
     EXA_THROW_CHECK_NE(cluster_config_.contact_node_address, cluster_config_.listen_address);
-    // will be moved into node_id_to_send_socket_ once got gossip from it
     contact_node_send_socket_ = zmq::socket_t(zmq_context_, zmq::socket_type::dealer);
-    contact_node_send_socket_->set(zmq::sockopt::linger, 0);
-    contact_node_send_socket_->connect(cluster_config_.contact_node_address);
+    contact_node_send_socket_.set(zmq::sockopt::linger, 0);
+    contact_node_send_socket_.connect(cluster_config_.contact_node_address);
   }
 }
 
@@ -285,8 +284,9 @@ void MessageBroker::BroadcastGossip() {
     auto& socket = MapAt(node_id_to_send_socket_, node_id);
     EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::none));
   }
-  if (contact_node_send_socket_.has_value()) {
-    EXA_THROW_CHECK(contact_node_send_socket_->send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::none));
+  // no matter the contact node is in `node_id_to_state_` or not, we always send a copy to it
+  if (contact_node_send_socket_.handle() != nullptr) {
+    EXA_THROW_CHECK(contact_node_send_socket_.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::none));
   }
 }
 
@@ -397,15 +397,9 @@ void MessageBroker::OnNodeAlive(uint64_t node_id) {
             new_node.address);
 
   // Create send socket
-  if (new_node.address != cluster_config_.contact_node_address) {
-    auto& socket = (node_id_to_send_socket_[new_node.node_id] = zmq::socket_t(zmq_context_, zmq::socket_type::dealer));
-    socket.set(zmq::sockopt::linger, 0);
-    socket.connect(new_node.address);
-  } else if (contact_node_send_socket_.has_value()) {
-    // contact node is already connected at start, just move it to node_id_to_send_socket_
-    node_id_to_send_socket_[new_node.node_id] = std::move(contact_node_send_socket_.value());
-    contact_node_send_socket_ = std::nullopt;
-  }
+  auto& socket = (node_id_to_send_socket_[new_node.node_id] = zmq::socket_t(zmq_context_, zmq::socket_type::dealer));
+  socket.set(zmq::sockopt::linger, 0);
+  socket.connect(new_node.address);
 
   EvaluateClusterStateWaiters();
 

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -630,6 +630,50 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutDoesNotDeactivateSelf) {
 }
 
 // ============================================================
+// Contact node dies and restarts with same address but different node ID
+// ============================================================
+
+TEST(MessageBrokerTest, ContactNodeRestartWithSameAddressDifferentNodeId) {
+  auto config = MakeConfig("tcp://127.0.0.1:7390",
+                           /*contact_address=*/"tcp://127.0.0.1:7391",
+                           /*heartbeat_timeout_ms=*/1);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  // Discover the contact node (node 1) via gossip
+  DispatchGossip(broker, {{.alive = true,
+                           .last_seen_timestamp_ms = 1,
+                           .node_id = 1,
+                           .address = "tcp://127.0.0.1:7391"}});
+
+  // Wait for the heartbeat to expire, then declare node 1 dead
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  broker.CheckHeartbeatTimeout();
+
+  // The contact node restarts with the same address but a new node ID (node 2).
+  // Before the fix, OnNodeAlive would crash here because the contact_node_send_socket_
+  // had already been moved into node_id_to_send_socket_ for node 1.
+  EXPECT_NO_THROW(DispatchGossip(broker, {{.alive = true,
+                                           .last_seen_timestamp_ms = 99999,
+                                           .node_id = 2,
+                                           .address = "tcp://127.0.0.1:7391"}}));
+
+  // The restarted node should be visible in the cluster state
+  auto [result] = stdexec::sync_wait(broker.WaitClusterState(
+                                         [](const ex_actor::ClusterState& state) {
+                                           return std::ranges::any_of(
+                                               state.nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 2; });
+                                         },
+                                         /*timeout_ms=*/10))
+                      .value();
+  EXPECT_TRUE(result.condition_met);
+
+  // BroadcastGossip should also work without crashing
+  EXPECT_NO_THROW(broker.BroadcastGossip());
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
 // BroadcastGossip after gossip discovery sends to all discovered peers
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Fix crash in `OnNodeAlive` when a contact node dies and restarts at the same address with a different node ID. The root cause was that `contact_node_send_socket_` (an `std::optional`) was moved into `node_id_to_send_socket_` on first discovery, leaving it empty for any subsequent node appearing at the same address.
- Change `contact_node_send_socket_` from `std::optional<zmq::socket_t>` to a plain `zmq::socket_t` that stays connected for the lifetime of the broker, used solely for bootstrap gossip. `OnNodeAlive` now always creates a fresh socket in `node_id_to_send_socket_`.
- Add regression test `ContactNodeRestartWithSameAddressDifferentNodeId` that reproduces the exact crash scenario.

## Test plan

- [x] New test `ContactNodeRestartWithSameAddressDifferentNodeId` fails without the fix and passes with it
- [x] All 25 existing `network_test` tests pass
