### PR TITLE
[fix] Only broadcast alive nodes in gossip

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -99,7 +99,7 @@ The process will block on `ex_actor::WaitOsExitSignal()`. You should kill them m
 
 ## Fault tolerance
 
-When a remote node becomes unreachable (dead, heartbeat timeout, connection refused, etc.), in-flight remote calls will throw `ex_actor::ConnectionLost`, by catching this exception you can handle the failure gracefully.
+When a node can't be reached by any node in the cluster, it's considered dead, all in-flight remote calls will throw `ex_actor::ConnectionLost`, by catching this exception you can handle the failure gracefully.
 
 ```cpp
 try {

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -274,6 +274,11 @@ void MessageBroker::BroadcastGossip() {
   gossip_message.from_node_id = this_node_id_;
   gossip_message.node_states.reserve(node_id_to_state_.size());
   for (const auto& [node_id, node_state] : node_id_to_state_) {
+    if (!node_state.alive) {
+      // Only broadcast alive nodes. Each node determines the liveness of its peers independently by heartbeat timeout.
+      // As a result, a node will only be considered dead when no one can see it.
+      continue;
+    }
     gossip_message.node_states.emplace_back(node_state);
   }
   BrokerMessage broker_msg {.variant = std::move(gossip_message)};
@@ -360,17 +365,10 @@ void MessageBroker::HandleGossipMessage(const BrokerGossipMessage& gossip_messag
     EXA_THROW_CHECK_EQ(cur_node_state.address, incoming_node_state.address)
         << fmt_lib::format("Node {:#x} has conflicting address, {} vs {}.", cur_node_state.node_id,
                            cur_node_state.address, incoming_node_state.address);
-    bool new_node_dead = cur_node_state.alive && !incoming_node_state.alive;
-    if (!incoming_node_state.alive) {
-      // now if a node dead, it never comes back alive
-      // TODO: support re-activation of dead nodes
-      cur_node_state.alive = false;
-    }
+    EXA_THROW_CHECK(incoming_node_state.alive)
+        << fmt_lib::format("Invalid gossip message: node {:#x} is dead", incoming_node_state.node_id);
     cur_node_state.last_seen_timestamp_ms =
         std::max(cur_node_state.last_seen_timestamp_ms, incoming_node_state.last_seen_timestamp_ms);
-    if (new_node_dead) {
-      OnNodeConnectionLost(incoming_node_state.node_id);
-    }
   }
 }
 

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -674,6 +674,138 @@ TEST(MessageBrokerTest, ContactNodeRestartWithSameAddressDifferentNodeId) {
 }
 
 // ============================================================
+// Death is not propagated via gossip: a bad connection between 2 nodes
+// must not cause other nodes to consider them dead
+// ============================================================
+
+TEST(MessageBrokerTest, DeadNodeIsNotBroadcastViaGossip) {
+  // Node 0 knows about node 1 and node 2.
+  // Node 1 times out from node 0's perspective, but node 2 should NOT learn
+  // about node 1's death through gossip — each node decides independently.
+  //
+  // To exercise the real BroadcastGossip path, broker0 sends gossip over ZMQ
+  // to a recv socket that feeds into broker2's DispatchReceivedMessage.
+  auto config0 = MakeConfig("tcp://127.0.0.1:7400",
+                            /*contact_address=*/"tcp://127.0.0.1:7402",
+                            /*heartbeat_timeout_ms=*/1);
+  ex_actor::internal::MessageBroker broker0(/*this_node_id=*/0, config0);
+
+  auto config2 = MakeConfig("tcp://127.0.0.1:7402",
+                            /*contact_address=*/"",
+                            /*heartbeat_timeout_ms=*/60000);
+  ex_actor::internal::MessageBroker broker2(/*this_node_id=*/2, config2);
+
+  // Set up a ZMQ recv socket on broker2's address to capture what broker0 sends
+  zmq::context_t capture_ctx {1};
+  zmq::socket_t capture_socket {capture_ctx, zmq::socket_type::dealer};
+  capture_socket.bind("tcp://127.0.0.1:7402");
+  capture_socket.set(zmq::sockopt::rcvtimeo, 2000);
+  capture_socket.set(zmq::sockopt::linger, 0);
+
+  // Both brokers discover node 1
+  DispatchGossip(broker0,
+                 {{.alive = true, .last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7401"},
+                  {.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7402"}});
+  DispatchGossip(broker2,
+                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 0, .address = "tcp://127.0.0.1:7400"},
+                  {.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7401"}});
+
+  // Node 1 times out from broker0's perspective
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  broker0.CheckHeartbeatTimeout();
+
+  // broker0 broadcasts gossip over ZMQ (contact node socket points to 7402)
+  broker0.BroadcastGossip();
+
+  // Receive the gossip message that broker0 actually sent
+  zmq::message_t captured_msg;
+  auto recv_result = capture_socket.recv(captured_msg);
+  ASSERT_TRUE(recv_result.has_value()) << "Expected to receive a gossip message from broker0";
+
+  // Feed the captured raw gossip into broker2
+  ex_actor::internal::ByteBuffer raw(static_cast<const std::byte*>(captured_msg.data()),
+                                     static_cast<const std::byte*>(captured_msg.data()) + captured_msg.size());
+  stdexec::sync_wait(broker2.DispatchReceivedMessage(std::move(raw)));
+
+  // broker2 should still see node 1 as alive — the death was not propagated.
+  // Use async_scope + manual timeout check to avoid blocking forever if the
+  // bug is present (node 1 would be dead and the predicate never satisfied).
+  exec::async_scope scope;
+  std::atomic<bool> node1_alive = false;
+  scope.spawn(ex_actor::internal::WrapSenderWithInlineScheduler(
+      broker2.WaitClusterState(
+          [](const ex_actor::ClusterState& state) {
+            return std::ranges::any_of(state.nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 1; });
+          },
+          /*timeout_ms=*/0) |
+      stdexec::then([&node1_alive](const ex_actor::WaitClusterStateResult& res) {
+        node1_alive.store(res.condition_met, std::memory_order_relaxed);
+      })));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  broker2.CheckClusterStateWaiterTimeout();
+  stdexec::sync_wait(scope.on_empty());
+
+  EXPECT_TRUE(node1_alive.load(std::memory_order_relaxed))
+      << "Node 2 should still see node 1 as alive; "
+         "only the node-0-to-node-1 connection was bad";
+
+  capture_socket.close();
+  stdexec::sync_wait(broker0.Stop());
+  stdexec::sync_wait(broker2.Stop());
+}
+
+TEST(MessageBrokerTest, HandleGossipMessageRejectsDeadNodeState) {
+  auto config = MakeConfig("tcp://127.0.0.1:7410");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  // Discover node 1 first so it exists in the state map
+  DispatchGossip(broker,
+                 {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7411"}});
+
+  // A gossip message claiming node 1 is dead should be rejected
+  EXPECT_THAT(
+      [&]() {
+        DispatchGossip(
+            broker,
+            {{.alive = false, .last_seen_timestamp_ms = 200, .node_id = 1, .address = "tcp://127.0.0.1:7411"}});
+      },
+      testing::Throws<std::exception>(
+          testing::Property(&std::exception::what, testing::HasSubstr("Invalid gossip message"))));
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+TEST(MessageBrokerTest, HandleGossipMessageIgnoresNewDeadNode) {
+  auto config = MakeConfig("tcp://127.0.0.1:7420");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  // A gossip message about a previously unknown dead node should be silently ignored
+  DispatchGossip(broker,
+                 {{.alive = false, .last_seen_timestamp_ms = 100, .node_id = 5, .address = "tcp://127.0.0.1:7425"}});
+
+  // Node 5 should not appear in the cluster state
+  exec::async_scope scope;
+  std::atomic<bool> condition_met = true;
+  scope.spawn(ex_actor::internal::WrapSenderWithInlineScheduler(
+      broker.WaitClusterState(
+          [](const ex_actor::ClusterState& state) {
+            return std::ranges::any_of(state.nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 5; });
+          },
+          /*timeout_ms=*/0) |
+      stdexec::then(
+          [&condition_met](const ex_actor::WaitClusterStateResult& res) { condition_met = res.condition_met; })));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  broker.CheckClusterStateWaiterTimeout();
+
+  stdexec::sync_wait(scope.on_empty());
+  EXPECT_FALSE(condition_met) << "A previously unknown dead node should not appear in the cluster state";
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
 // BroadcastGossip after gossip discovery sends to all discovered peers
 // ============================================================
 


### PR DESCRIPTION
## Summary

- **Bug**: When 2 nodes had a bad connection, all nodes in the cluster would consider them dead because the death was broadcast via gossip. A localized connectivity issue cascaded into a cluster-wide outage.
- **Fix**: `BroadcastGossip` now only includes alive nodes, and `HandleGossipMessage` rejects incoming dead node states. Each node independently decides whether a peer is dead based on its own heartbeat timeout.
- **Docs**: Updated distributed mode documentation to clarify the new behavior.

## Test plan

- [x] `DeadNodeIsNotBroadcastViaGossip` — End-to-end test using real ZMQ sockets: broker0 marks node 1 dead, broadcasts gossip to broker2, verifies broker2 still sees node 1 as alive
- [x] `HandleGossipMessageRejectsDeadNodeState` — Verifies that a gossip message claiming a known node is dead is rejected with an exception
- [x] `HandleGossipMessageIgnoresNewDeadNode` — Verifies that a gossip message about a previously unknown dead node is silently ignored
- [x] Verified tests fail when the fix is reverted (2 of 3 fail), confirming they cover the bug
- [x] All 28 network tests pass with the fix applied