### PR TITLE
[feat] make network constants configurable via environment variables

### DIFF
--- a/include/ex_actor/internal/constants.h
+++ b/include/ex_actor/internal/constants.h
@@ -14,15 +14,44 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <type_traits>
+
 namespace ex_actor {
 namespace internal {
 
+/// Read an environment variable as type T, returning `default_val` when the
+/// variable is unset or empty.
+/// Supported types: std::string, double/float, and integral types.
+template <typename T>
+inline T GetEnv(const char* name, T default_val) {
+  const char* val = std::getenv(name);
+  if (val == nullptr || val[0] == '\0') {
+    return default_val;
+  }
+  if constexpr (std::is_same_v<T, std::string>) {
+    return std::string(val);
+  } else if constexpr (std::is_same_v<T, double>) {
+    return std::strtod(val, nullptr);
+  } else if constexpr (std::is_same_v<T, float>) {
+    return std::strtof(val, nullptr);
+  } else if constexpr (std::is_signed_v<T>) {
+    return static_cast<T>(std::strtoll(val, nullptr, 10));
+  } else {
+    return static_cast<T>(std::strtoull(val, nullptr, 10));
+  }
+}
+
 constexpr size_t kEmptyActorRefHashVal = 10086;
-constexpr uint64_t kDefaultHeartbeatTimeoutMs = 5000;
-constexpr uint64_t kDefaultGossipIntervalMs = 500;
-constexpr size_t kDefaultGossipFanout = 3;
-constexpr uint64_t kDefaultHeartbeatCheckIntervalMs = 100;
-constexpr uint64_t kDefaultWaiterExpirationCheckIntervalMs = 100;
+
+// Env-configurable constants
+inline const uint64_t kDefaultHeartbeatTimeoutMs = GetEnv<uint64_t>("EXA_HEARTBEAT_TIMEOUT_MS", 10000);
+inline const uint64_t kDefaultGossipIntervalMs = GetEnv<uint64_t>("EXA_GOSSIP_INTERVAL_MS", 500);
+inline const size_t kDefaultGossipFanout = GetEnv<size_t>("EXA_GOSSIP_FANOUT", 3);
+inline const uint64_t kDefaultHeartbeatCheckIntervalMs = GetEnv<uint64_t>("EXA_HEARTBEAT_CHECK_INTERVAL_MS", 100);
+inline const uint64_t kDefaultWaiterExpirationCheckIntervalMs =
+    GetEnv<uint64_t>("EXA_WAITER_EXPIRATION_CHECK_INTERVAL_MS", 100);
 
 }  // namespace internal
 }  // namespace ex_actor

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -134,6 +134,7 @@ TEST(DistributedTest, ConstructionInDistributedModeWithDefaultScheduler) {
     ex_actor::ClusterConfig cluster_config {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
+        .network_config = {.heartbeat_timeout_ms = 5000},
     };
     ex_actor::ActorRegistry registry(/*thread_pool_size=*/4);
     co_await registry.StartOrJoinCluster(cluster_config);
@@ -175,6 +176,7 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
     ex_actor::ClusterConfig cluster_config {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
+        .network_config = {.heartbeat_timeout_ms = 5000},
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     co_await registry.StartOrJoinCluster(cluster_config);
@@ -295,6 +297,7 @@ TEST(DistributedTest, ActorLookUpInDistributeMode) {
     ex_actor::ClusterConfig cluster_config {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
+        .network_config = {.heartbeat_timeout_ms = 5000},
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     co_await registry.StartOrJoinCluster(cluster_config);
@@ -349,6 +352,7 @@ TEST(DistributedTest, ActorRefSerializationTest) {
     ex_actor::ClusterConfig cluster_config {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
+        .network_config = {.heartbeat_timeout_ms = 5000},
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     co_await registry.StartOrJoinCluster(cluster_config);
@@ -420,6 +424,7 @@ TEST(DistributedTest, DestroyRemoteActor) {
     ex_actor::ClusterConfig cluster_config {
         .listen_address = addresses.at(index),
         .contact_node_address = (index == 0) ? "" : addresses.at(0),
+        .network_config = {.heartbeat_timeout_ms = 5000},
     };
     ex_actor::ActorRegistry registry(thread_pool.GetScheduler());
     co_await registry.StartOrJoinCluster(cluster_config);

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -28,6 +28,7 @@ exec::task<void> MainCoroutine(int argc, char** argv) {
   ex_actor::ClusterConfig cluster_config {
       .listen_address = listen_address,
       .contact_node_address = contact_address,
+      .network_config = {.heartbeat_timeout_ms = 5000},
   };
   ex_actor::Init(shared_pool->GetScheduler());
   co_await ex_actor::StartOrJoinCluster(cluster_config);


### PR DESCRIPTION
## Summary
- Add a generic `GetEnv<T>` template in `constants.h` that reads environment variables with typed fallback (supports `std::string`, `double`, `float`, and all integral types).
- Replace `constexpr` network tuning constants with `inline const` variables initialized via `GetEnv<T>`, enabling runtime override without recompilation.
- Bump default heartbeat timeout from 5 s to 10 s for better production resilience; all existing distributed-mode tests explicitly set 5 s to preserve their timing assumptions.

### Env vars
| Variable | Default | Description |
|---|---|---|
| `EXA_HEARTBEAT_TIMEOUT_MS` | 10000 | Time before a node is considered dead |
| `EXA_GOSSIP_INTERVAL_MS` | 500 | Interval between gossip rounds |
| `EXA_GOSSIP_FANOUT` | 3 | Peers per gossip round |
| `EXA_HEARTBEAT_CHECK_INTERVAL_MS` | 100 | Heartbeat check polling interval |
| `EXA_WAITER_EXPIRATION_CHECK_INTERVAL_MS` | 100 | Cluster-state waiter expiration check interval |
