### PR TITLE
[fix] make ZMQ sends non-blocking and rename ConnectionLost to NetworkError

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -99,13 +99,13 @@ The process will block on `ex_actor::WaitOsExitSignal()`. You should kill them m
 
 ## Fault tolerance
 
-When a node can't be reached by any node in the cluster, it's considered dead, all in-flight remote calls will throw `ex_actor::ConnectionLost`, by catching this exception you can handle the failure gracefully.
+When a node can't be reached by any node in the cluster, it's considered dead, all in-flight remote calls will throw `ex_actor::NetworkError`, by catching this exception you can handle the failure gracefully. (`ex_actor::ConnectionLost` is a type alias kept for backward compatibility.)
 
 ```cpp
 try {
   co_await ref.Send<&YourClass::Method>();
-} catch (const ex_actor::ConnectionLost& e) {
-  // e.node_id tells you which node was lost
+} catch (const ex_actor::NetworkError& e) {
+  // e.remote_node_id tells you which node was lost
   // e.what() has a human-readable message
 }
 ```
@@ -116,7 +116,7 @@ For example, now a node dies, you want to recreate your actor to another node:
 bool connection_lost = false;
 try {
   co_await ref.Send<&YourClass::Method>();
-} catch (const ex_actor::ConnectionLost& e) {
+} catch (const ex_actor::NetworkError& e) {
   connection_lost = true;
 }
 

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -65,12 +65,13 @@ struct ClusterState {
 };
 
 /// Thrown when a remote operation fails due to the target node being
-/// unreachable (dead, timed-out heartbeat, connection refused, etc.).
-struct ConnectionLost : public std::runtime_error {
-  uint64_t node_id;
+/// unreachable (dead, timed-out heartbeat, connection refused, etc.),
+/// or when a network send operation cannot complete without blocking.
+struct NetworkError : public std::runtime_error {
+  uint64_t remote_node_id;
 
-  explicit ConnectionLost(uint64_t node_id, const std::string& message)
-      : std::runtime_error(message), node_id(node_id) {}
+  explicit NetworkError(uint64_t remote_node_id, const std::string& message)
+      : std::runtime_error(message), remote_node_id(remote_node_id) {}
 };
 
 struct WaitClusterStateResult {

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -287,11 +287,17 @@ void MessageBroker::BroadcastGossip() {
   for (uint64_t node_id : node_ids) {
     auto& node_state = MapAt(node_id_to_state_, node_id);
     auto& socket = MapAt(node_id_to_send_socket_, node_id);
-    EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::none));
+    auto result = socket.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::dontwait);
+    if (!result.has_value()) {
+      log::Warn("Node {:#x} failed to send gossip to node {:#x}: send buffer full", this_node_id_, node_id);
+    }
   }
   // no matter the contact node is in `node_id_to_state_` or not, we always send a copy to it
   if (contact_node_send_socket_.handle() != nullptr) {
-    EXA_THROW_CHECK(contact_node_send_socket_.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::none));
+    auto result = contact_node_send_socket_.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::dontwait);
+    if (!result.has_value()) {
+      log::Warn("Node {:#x} failed to send gossip to contact node: send buffer full", this_node_id_);
+    }
   }
 }
 
@@ -426,7 +432,7 @@ void MessageBroker::OnNodeConnectionLost(uint64_t node_id) {
   for (auto it : requests_to_fail) {
     auto& [request_id, request] = *it;
     request.exception_ptr = std::make_exception_ptr(
-        ConnectionLost(node_id, fmt_lib::format("Node {:#x} is dead, cannot complete request", node_id)));
+        NetworkError(node_id, fmt_lib::format("Node {:#x} is dead, cannot complete request", node_id)));
     // this will wake up the coroutine and erase the iterator, don't use it after this
     request.sem.Acquire(1);
   }
@@ -446,11 +452,16 @@ uint64_t MessageBroker::SendTwoWayMessage(uint64_t node_id, ByteBuffer data) {
                             }};
   auto socket_it = node_id_to_send_socket_.find(node_id);
   if (socket_it == node_id_to_send_socket_.end()) {
-    throw ConnectionLost(node_id, fmt_lib::format("Node {:#x} is trying to send request to an unconnected node {:#x}",
-                                                  this_node_id_, node_id));
+    throw NetworkError(node_id, fmt_lib::format("Node {:#x} is trying to send request to an unconnected node {:#x}",
+                                                this_node_id_, node_id));
   }
   auto& [target_node_id, socket] = *socket_it;
-  EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::none));
+  auto result = socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::dontwait);
+  if (!result.has_value()) {
+    throw NetworkError(node_id,
+                       fmt_lib::format("Node {:#x} failed to send message to node {:#x}: send buffer full (EAGAIN)",
+                                       this_node_id_, node_id));
+  }
   return request_id;
 }
 
@@ -479,7 +490,11 @@ void MessageBroker::SendReply(uint64_t request_node_id, uint64_t request_id, Byt
                                 .request_id = request_id,
                                 .payload = std::move(data),
                             }};
-  EXA_THROW_CHECK(socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::none));
+  auto result = socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::dontwait);
+  if (!result.has_value()) {
+    log::Warn("Node {:#x} failed to send reply to node {:#x}: send buffer full. It's likely the remote node is dead.",
+              this_node_id_, request_node_id);
+  }
 }
 
 std::vector<NodeInfo> MessageBroker::BuildAliveNodeInfoList() const {

--- a/test/heartbeat_test.cc
+++ b/test/heartbeat_test.cc
@@ -58,8 +58,8 @@ int main(int argc, char** argv) {
         auto ping = ping_worker.Send<&PingWorker::Ping>("hello");
         std::ignore = co_await std::move(ping);
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      } catch (const ex_actor::ConnectionLost& e) {
-        logging::Error("connection lost to node {:#x}: {}", e.node_id, e.what());
+      } catch (const ex_actor::NetworkError& e) {
+        logging::Error("connection lost to node {:#x}: {}", e.remote_node_id, e.what());
         break;
       }
     }

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -78,7 +78,7 @@ TEST(MessageBrokerTest, SendRequestToUnconnectedNodeThrows) {
   ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   EXPECT_THAT([&]() { stdexec::sync_wait(broker.SendRequest(/*to_node_id=*/99, {})); },
-              testing::Throws<ex_actor::ConnectionLost>(testing::Property(
+              testing::Throws<ex_actor::NetworkError>(testing::Property(
                   &std::exception::what, testing::HasSubstr("trying to send request to an unconnected node"))));
 
   stdexec::sync_wait(broker.Stop());


### PR DESCRIPTION
## Summary

- **Fix deadlock**: All ZMQ `send()` calls in `MessageBroker` now use `zmq::send_flags::dontwait` instead of blocking `zmq::send_flags::none`. When a send buffer is full, requests and replies throw `NetworkError` immediately rather than blocking the actor's processing thread (which prevents it from processing any other messages, including heartbeats and responses).
- **Gossip is best-effort**: Failed gossip sends log a warning and skip instead of crashing, since gossip will retry on the next interval.
- **Rename `ConnectionLost` to `NetworkError`**: The new name better reflects the broader set of failure modes (not just connection loss, but also send buffer full).
- **Rename `node_id` to `remote_node_id`** on the exception struct for clarity.
