### PR TITLE
[fix] preserve deferred replies across reconnection and make HWM unlimited

### DIFF
--- a/include/ex_actor/internal/message.h
+++ b/include/ex_actor/internal/message.h
@@ -111,7 +111,6 @@ struct NetworkReply {
 // ===================================================
 
 struct NodeState {
-  bool alive = true;
   uint64_t last_seen_timestamp_ms = 0;
   uint64_t node_id = 0;
   std::string address;

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -148,6 +148,8 @@ class PeriodicalTaskScheduler {
  * @brief The network message broker, designed to be used as an Actor, so no locks are needed for the state.
  */
 class MessageBroker {
+  friend class MessageBrokerTestHelper;
+
  public:
   using RequestHandler = std::function<exec::task<ByteBuffer>(ByteBuffer)>;
 
@@ -225,6 +227,7 @@ class MessageBroker {
   ClusterConfig cluster_config_;
   uint64_t send_request_id_counter_ = 0;
 
+  // pending replies to peers that are not yet discovered.
   std::unordered_map</*node_id*/ uint64_t, std::vector<ReplyOperation>> deferred_replies_;
   std::unordered_map</*request_id*/ uint64_t, OutstandingRequest> outstanding_requests_;
 

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -54,6 +54,12 @@ ByteBuffer ZmqMsgToByteBuffer(zmq::message_t&& msg) {
 /// non-copy, return a view of the ByteBuffer
 zmq::const_buffer ByteBufferToZmqBuffer(const ByteBuffer& bytes) { return zmq::buffer(bytes.data(), bytes.size()); }
 
+/// All sockets are configured with unlimited sndhwm, so send should never fail with EAGAIN.
+void ZmqSendOrDie(zmq::socket_t& socket, zmq::const_buffer buf) {
+  auto result = socket.send(buf, zmq::send_flags::dontwait);
+  EXA_THROW_CHECK(result.has_value()) << "ZMQ send failed unexpectedly (sndhwm should be unlimited)";
+}
+
 }  // namespace
 
 // ----------------------RecvSocketPuller--------------------------
@@ -148,14 +154,13 @@ void PeriodicalTaskScheduler::Loop(const std::stop_token& stop_token) {
 MessageBroker::MessageBroker(uint64_t this_node_id, ClusterConfig cluster_config)
     : this_node_id_(this_node_id), cluster_config_(std::move(cluster_config)) {
   EXA_THROW_CHECK(!cluster_config_.listen_address.empty()) << "listen_address must not be empty";
-  node_id_to_state_[this_node_id_] = {.alive = true,
-                                      .last_seen_timestamp_ms = GetTimeMs(),
-                                      .node_id = this_node_id_,
-                                      .address = cluster_config_.listen_address};
+  node_id_to_state_[this_node_id_] = {
+      .last_seen_timestamp_ms = GetTimeMs(), .node_id = this_node_id_, .address = cluster_config_.listen_address};
   if (!cluster_config_.contact_node_address.empty()) {
     EXA_THROW_CHECK_NE(cluster_config_.contact_node_address, cluster_config_.listen_address);
     contact_node_send_socket_ = zmq::socket_t(zmq_context_, zmq::socket_type::dealer);
     contact_node_send_socket_.set(zmq::sockopt::linger, 0);
+    contact_node_send_socket_.set(zmq::sockopt::sndhwm, 0);
     contact_node_send_socket_.connect(cluster_config_.contact_node_address);
   }
 }
@@ -251,7 +256,7 @@ std::vector<uint64_t> MessageBroker::GetRandomPeers(size_t fanout) {
   std::vector<uint64_t> node_ids;
   node_ids.reserve(node_id_to_state_.size());
   for (const auto& [node_id, node_state] : node_id_to_state_) {
-    if (node_id != this_node_id_ && node_state.alive) {
+    if (node_id != this_node_id_) {
       node_ids.emplace_back(node_id);
     }
   }
@@ -274,11 +279,6 @@ void MessageBroker::BroadcastGossip() {
   gossip_message.from_node_id = this_node_id_;
   gossip_message.node_states.reserve(node_id_to_state_.size());
   for (const auto& [node_id, node_state] : node_id_to_state_) {
-    if (!node_state.alive) {
-      // Only broadcast alive nodes. Each node determines the liveness of its peers independently by heartbeat timeout.
-      // As a result, a node will only be considered dead when no one can see it.
-      continue;
-    }
     gossip_message.node_states.emplace_back(node_state);
   }
   BrokerMessage broker_msg {.variant = std::move(gossip_message)};
@@ -287,34 +287,30 @@ void MessageBroker::BroadcastGossip() {
   for (uint64_t node_id : node_ids) {
     auto& node_state = MapAt(node_id_to_state_, node_id);
     auto& socket = MapAt(node_id_to_send_socket_, node_id);
-    auto result = socket.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::dontwait);
-    if (!result.has_value()) {
-      log::Warn("Node {:#x} failed to send gossip to node {:#x}: send buffer full", this_node_id_, node_id);
-    }
+    ZmqSendOrDie(socket, ByteBufferToZmqBuffer(serialized));
   }
   // no matter the contact node is in `node_id_to_state_` or not, we always send a copy to it
   if (contact_node_send_socket_.handle() != nullptr) {
-    auto result = contact_node_send_socket_.send(ByteBufferToZmqBuffer(serialized), zmq::send_flags::dontwait);
-    if (!result.has_value()) {
-      log::Warn("Node {:#x} failed to send gossip to contact node: send buffer full", this_node_id_);
-    }
+    ZmqSendOrDie(contact_node_send_socket_, ByteBufferToZmqBuffer(serialized));
   }
 }
 
 void MessageBroker::CheckHeartbeatTimeout() {
   auto now_ms = GetTimeMs();
+  std::vector<uint64_t> nodes_to_remove;
   for (auto& [node_id, state] : node_id_to_state_) {
     // When using system_clock, remote timestamps may be slightly ahead of local clock due to
     // clock skew across machines. Treat future timestamps as "just seen" to avoid unsigned
     // underflow in the subtraction, which would falsely trigger a heartbeat timeout.
-    if (!state.alive ||                            // already dead
-        node_id == this_node_id_ ||                // ourselves
+    if (node_id == this_node_id_ ||                // ourselves
         state.last_seen_timestamp_ms >= now_ms ||  // timestamp in the future due to clock skew
         now_ms - state.last_seen_timestamp_ms < cluster_config_.network_config.heartbeat_timeout_ms  // not timeout yet
     ) {
       continue;
     }
-    MapAt(node_id_to_state_, node_id).alive = false;
+    nodes_to_remove.push_back(node_id);
+  }
+  for (uint64_t node_id : nodes_to_remove) {
     OnNodeConnectionLost(node_id);
   }
 }
@@ -334,6 +330,7 @@ void MessageBroker::StartRecvSocketPuller() {
   zmq::socket_t recv_socket {zmq_context_, zmq::socket_type::dealer};
   recv_socket.bind(cluster_config_.listen_address);
   recv_socket.set(zmq::sockopt::linger, 0);
+  recv_socket.set(zmq::sockopt::sndhwm, 0);
   log::Info("Node {:#x}'s recv socket bound to {}", this_node_id_, cluster_config_.listen_address);
 
   recv_socket_puller_ = std::make_unique<RecvSocketPuller>(std::move(recv_socket), [this](ByteBuffer raw) {
@@ -357,10 +354,6 @@ void MessageBroker::StartPeriodicalTaskScheduler() {
 void MessageBroker::HandleGossipMessage(const BrokerGossipMessage& gossip_message) {
   for (const auto& incoming_node_state : gossip_message.node_states) {
     auto [iter, inserted] = node_id_to_state_.try_emplace(incoming_node_state.node_id, incoming_node_state);
-    if (inserted && !incoming_node_state.alive) {
-      // a new dead node found, ignore it
-      continue;
-    }
     if (inserted) {
       // new alive node found
       OnNodeAlive(incoming_node_state.node_id);
@@ -371,8 +364,6 @@ void MessageBroker::HandleGossipMessage(const BrokerGossipMessage& gossip_messag
     EXA_THROW_CHECK_EQ(cur_node_state.address, incoming_node_state.address)
         << fmt_lib::format("Node {:#x} has conflicting address, {} vs {}.", cur_node_state.node_id,
                            cur_node_state.address, incoming_node_state.address);
-    EXA_THROW_CHECK(incoming_node_state.alive)
-        << fmt_lib::format("Invalid gossip message: node {:#x} is dead", incoming_node_state.node_id);
     cur_node_state.last_seen_timestamp_ms =
         std::max(cur_node_state.last_seen_timestamp_ms, incoming_node_state.last_seen_timestamp_ms);
   }
@@ -403,6 +394,7 @@ void MessageBroker::OnNodeAlive(uint64_t node_id) {
   // Create send socket
   auto& socket = (node_id_to_send_socket_[new_node.node_id] = zmq::socket_t(zmq_context_, zmq::socket_type::dealer));
   socket.set(zmq::sockopt::linger, 0);
+  socket.set(zmq::sockopt::sndhwm, 0);
   socket.connect(new_node.address);
 
   EvaluateClusterStateWaiters();
@@ -436,8 +428,11 @@ void MessageBroker::OnNodeConnectionLost(uint64_t node_id) {
     // this will wake up the coroutine and erase the iterator, don't use it after this
     request.sem.Acquire(1);
   }
-  deferred_replies_.erase(node_id);
+  node_id_to_state_.erase(node_id);
   node_id_to_send_socket_.erase(node_id);
+
+  // `deferred_replies_` should not be cleared.
+  // Because the node might be alive again, the death might just be a transient network issue.
 
   EvaluateClusterStateWaiters();
 }
@@ -456,26 +451,15 @@ uint64_t MessageBroker::SendTwoWayMessage(uint64_t node_id, ByteBuffer data) {
                                                 this_node_id_, node_id));
   }
   auto& [target_node_id, socket] = *socket_it;
-  auto result = socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::dontwait);
-  if (!result.has_value()) {
-    throw NetworkError(node_id,
-                       fmt_lib::format("Node {:#x} failed to send message to node {:#x}: send buffer full (EAGAIN)",
-                                       this_node_id_, node_id));
-  }
+  ZmqSendOrDie(socket, ByteBufferToZmqBuffer(Serialize(broker_msg)));
   return request_id;
 }
 
 void MessageBroker::SendReply(uint64_t request_node_id, uint64_t request_id, ByteBuffer data) {
   auto socket_it = node_id_to_send_socket_.find(request_node_id);
   if (socket_it == node_id_to_send_socket_.end()) {
-    // The requesting node connected to our recv socket and sent a request, but we haven't
-    // discovered it via gossip yet, so we have no send socket to reply through.
-    // This is possible because connection establishment is one-directional: when node A
-    // discovers us via gossip, it creates a DEALER socket and connects to our recv socket,
-    // allowing it to send requests immediately. However, gossip propagation is asynchronous,
-    // so we may not have received a gossip message containing node A's info yet.
-    // Buffer the reply until EstablishConnection() creates the reverse connection and
-    // the broker flushes it.
+    // It's possible due to the async nature of gossip protocol. When A discovers B via gossip, B may not discover A
+    // yet. Pend the reply until we discover the peer.
     deferred_replies_[request_node_id].push_back(ReplyOperation {
         .request_node_id = request_node_id,
         .request_id = request_id,
@@ -490,20 +474,14 @@ void MessageBroker::SendReply(uint64_t request_node_id, uint64_t request_id, Byt
                                 .request_id = request_id,
                                 .payload = std::move(data),
                             }};
-  auto result = socket.send(ByteBufferToZmqBuffer(Serialize(broker_msg)), zmq::send_flags::dontwait);
-  if (!result.has_value()) {
-    log::Warn("Node {:#x} failed to send reply to node {:#x}: send buffer full. It's likely the remote node is dead.",
-              this_node_id_, request_node_id);
-  }
+  ZmqSendOrDie(socket, ByteBufferToZmqBuffer(Serialize(broker_msg)));
 }
 
 std::vector<NodeInfo> MessageBroker::BuildAliveNodeInfoList() const {
   std::vector<NodeInfo> result;
   result.reserve(node_id_to_state_.size());
   for (const auto& [node_id, state] : node_id_to_state_) {
-    if (state.alive) {
-      result.push_back(NodeInfo {.node_id = node_id, .address = state.address});
-    }
+    result.push_back(NodeInfo {.node_id = node_id, .address = state.address});
   }
   return result;
 }

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -18,6 +18,15 @@
 
 using ex_actor::internal::ByteBuffer;
 
+namespace ex_actor::internal {
+class MessageBrokerTestHelper {
+ public:
+  static void SetRequestHandler(MessageBroker& broker, MessageBroker::RequestHandler handler) {
+    broker.request_handler_ = std::move(handler);
+  }
+};
+}  // namespace ex_actor::internal
+
 namespace {
 
 ByteBuffer MakeBytes(const std::string& str) {
@@ -37,6 +46,18 @@ ex_actor::ClusterConfig MakeConfig(const std::string& address, const std::string
   config.network_config.heartbeat_timeout_ms = heartbeat_timeout_ms;
   config.network_config.gossip_interval_ms = gossip_interval_ms;
   return config;
+}
+
+void DispatchIncomingRequest(ex_actor::internal::MessageBroker& broker, uint64_t request_node_id,
+                            uint64_t response_node_id, uint64_t request_id, ByteBuffer payload) {
+  ex_actor::internal::BrokerMessage broker_msg {.variant = ex_actor::internal::BrokerTwoWayMessage {
+                                                    .request_node_id = request_node_id,
+                                                    .response_node_id = response_node_id,
+                                                    .request_id = request_id,
+                                                    .payload = std::move(payload),
+                                                }};
+  auto raw = ex_actor::internal::Serialize(broker_msg);
+  stdexec::sync_wait(broker.DispatchReceivedMessage(std::move(raw)));
 }
 
 void DispatchGossip(ex_actor::internal::MessageBroker& broker,
@@ -104,7 +125,7 @@ TEST(MessageBrokerTest, WaitClusterStateReturnsTrueForGossipDiscoveredNode) {
   ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7221"}});
+                 {{.last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7221"}});
 
   auto [result] = stdexec::sync_wait(broker.WaitClusterState(
                                          [](const ex_actor::ClusterState& state) {
@@ -183,7 +204,7 @@ TEST(MessageBrokerTest, WaitClusterStateResolvesOnGossipDiscovery) {
               }));
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7241"}});
+                 {{.last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7241"}});
 
   stdexec::sync_wait(scope.on_empty());
   EXPECT_TRUE(condition_met.load(std::memory_order_relaxed));
@@ -200,9 +221,9 @@ TEST(MessageBrokerTest, DuplicateGossipForSameNodeDoesNotThrow) {
   ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7251"}});
+                 {{.last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7251"}});
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 200, .node_id = 1, .address = "tcp://127.0.0.1:7251"}});
+                 {{.last_seen_timestamp_ms = 200, .node_id = 1, .address = "tcp://127.0.0.1:7251"}});
 
   stdexec::sync_wait(broker.Stop());
 }
@@ -216,12 +237,12 @@ TEST(MessageBrokerTest, GossipWithConflictingAddressThrows) {
   ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7261"}});
+                 {{.last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7261"}});
 
   EXPECT_THAT(
       [&]() {
         DispatchGossip(
-            broker, {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7262"}});
+            broker, {{.last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7262"}});
       },
       testing::Throws<std::exception>(
           testing::Property(&std::exception::what, testing::HasSubstr("Node 0x1 has conflicting address"))));
@@ -241,7 +262,7 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutDeactivatesTimedOutNodes) {
 
   // Discover node 1 via gossip so it gets added to node_id_to_state_
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7271"}});
+                 {{.last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7271"}});
 
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
   // now node 1 should be dead
@@ -279,7 +300,7 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutErrorsOutstandingRequests) {
 
   // Discover node 1 via gossip so it gets added to node_id_to_state_ and a send socket is created
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7281"}});
+                 {{.last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7281"}});
 
   exec::async_scope scope;
   std::atomic<bool> got_error = false;
@@ -307,7 +328,7 @@ TEST(MessageBrokerTest, HandleRepliedResponseResolvesOutstandingRequest) {
 
   // Discover node 1 via gossip so we can send requests to it
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7291"}});
+                 {{.last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7291"}});
 
   exec::async_scope scope;
   std::atomic<bool> got_response = false;
@@ -395,7 +416,7 @@ TEST(MessageBrokerTest, MultipleWaitersNotifiedOnGossipDiscovery) {
   }
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7321"}});
+                 {{.last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7321"}});
 
   stdexec::sync_wait(scope.on_empty());
   EXPECT_EQ(success_count.load(std::memory_order_relaxed), 3);
@@ -437,8 +458,8 @@ TEST(MessageBrokerTest, GossipIntroducesMultipleNodesAtOnce) {
               }));
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7331"},
-                  {.alive = true, .last_seen_timestamp_ms = 200, .node_id = 2, .address = "tcp://127.0.0.1:7332"}});
+                 {{.last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7331"},
+                  {.last_seen_timestamp_ms = 200, .node_id = 2, .address = "tcp://127.0.0.1:7332"}});
 
   stdexec::sync_wait(scope.on_empty());
   EXPECT_EQ(success_count.load(std::memory_order_relaxed), 2);
@@ -484,7 +505,7 @@ TEST(MessageBrokerTest, GossipUpdatesLastSeenToMax) {
 
   // Discover node 1 via gossip first
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7361"}});
+                 {{.last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7361"}});
 
   // Sleep so the initial last_seen becomes stale
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -494,7 +515,7 @@ TEST(MessageBrokerTest, GossipUpdatesLastSeenToMax) {
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count();
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = now_ms, .node_id = 1, .address = "tcp://127.0.0.1:7361"}});
+                 {{.last_seen_timestamp_ms = now_ms, .node_id = 1, .address = "tcp://127.0.0.1:7361"}});
 
   // The node should NOT be timed out since we just refreshed it
   broker.CheckHeartbeatTimeout();
@@ -531,8 +552,7 @@ TEST(MessageBrokerTest, HeartbeatTimeoutUsesWallClockEpoch) {
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
           .count();
 
-  DispatchGossip(broker, {{.alive = true,
-                           .last_seen_timestamp_ms = wall_clock_now_ms,
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = wall_clock_now_ms,
                            .node_id = 1,
                            .address = "tcp://127.0.0.1:7366"}});
 
@@ -583,8 +603,7 @@ TEST(MessageBrokerTest, CheckHeartbeatTimeoutToleratesClockSkew) {
           .count() +
       5000;
 
-  DispatchGossip(broker, {{.alive = true,
-                           .last_seen_timestamp_ms = future_ms,
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = future_ms,
                            .node_id = 1,
                            .address = "tcp://127.0.0.1:7368"}});
 
@@ -640,8 +659,7 @@ TEST(MessageBrokerTest, ContactNodeRestartWithSameAddressDifferentNodeId) {
   ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   // Discover the contact node (node 1) via gossip
-  DispatchGossip(broker, {{.alive = true,
-                           .last_seen_timestamp_ms = 1,
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = 1,
                            .node_id = 1,
                            .address = "tcp://127.0.0.1:7391"}});
 
@@ -652,8 +670,7 @@ TEST(MessageBrokerTest, ContactNodeRestartWithSameAddressDifferentNodeId) {
   // The contact node restarts with the same address but a new node ID (node 2).
   // Before the fix, OnNodeAlive would crash here because the contact_node_send_socket_
   // had already been moved into node_id_to_send_socket_ for node 1.
-  EXPECT_NO_THROW(DispatchGossip(broker, {{.alive = true,
-                                           .last_seen_timestamp_ms = 99999,
+  EXPECT_NO_THROW(DispatchGossip(broker, {{.last_seen_timestamp_ms = 99999,
                                            .node_id = 2,
                                            .address = "tcp://127.0.0.1:7391"}}));
 
@@ -685,6 +702,13 @@ TEST(MessageBrokerTest, DeadNodeIsNotBroadcastViaGossip) {
   //
   // To exercise the real BroadcastGossip path, broker0 sends gossip over ZMQ
   // to a recv socket that feeds into broker2's DispatchReceivedMessage.
+  // Declare capture_ctx/capture_socket before the brokers so they are destroyed
+  // after the brokers. broker0's ZMQ I/O thread may still hold references to
+  // message metadata when the context is torn down, causing a data race if the
+  // capture context is destroyed first.
+  zmq::context_t capture_ctx {1};
+  zmq::socket_t capture_socket {capture_ctx, zmq::socket_type::dealer};
+
   auto config0 = MakeConfig("tcp://127.0.0.1:7400",
                             /*contact_address=*/"tcp://127.0.0.1:7402",
                             /*heartbeat_timeout_ms=*/1);
@@ -696,19 +720,17 @@ TEST(MessageBrokerTest, DeadNodeIsNotBroadcastViaGossip) {
   ex_actor::internal::MessageBroker broker2(/*this_node_id=*/2, config2);
 
   // Set up a ZMQ recv socket on broker2's address to capture what broker0 sends
-  zmq::context_t capture_ctx {1};
-  zmq::socket_t capture_socket {capture_ctx, zmq::socket_type::dealer};
   capture_socket.bind("tcp://127.0.0.1:7402");
   capture_socket.set(zmq::sockopt::rcvtimeo, 2000);
   capture_socket.set(zmq::sockopt::linger, 0);
 
   // Both brokers discover node 1
   DispatchGossip(broker0,
-                 {{.alive = true, .last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7401"},
-                  {.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7402"}});
+                 {{.last_seen_timestamp_ms = 1, .node_id = 1, .address = "tcp://127.0.0.1:7401"},
+                  {.last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7402"}});
   DispatchGossip(broker2,
-                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 0, .address = "tcp://127.0.0.1:7400"},
-                  {.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7401"}});
+                 {{.last_seen_timestamp_ms = 99999, .node_id = 0, .address = "tcp://127.0.0.1:7400"},
+                  {.last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7401"}});
 
   // Node 1 times out from broker0's perspective
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
@@ -755,56 +777,6 @@ TEST(MessageBrokerTest, DeadNodeIsNotBroadcastViaGossip) {
   stdexec::sync_wait(broker2.Stop());
 }
 
-TEST(MessageBrokerTest, HandleGossipMessageRejectsDeadNodeState) {
-  auto config = MakeConfig("tcp://127.0.0.1:7410");
-  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
-
-  // Discover node 1 first so it exists in the state map
-  DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 100, .node_id = 1, .address = "tcp://127.0.0.1:7411"}});
-
-  // A gossip message claiming node 1 is dead should be rejected
-  EXPECT_THAT(
-      [&]() {
-        DispatchGossip(
-            broker,
-            {{.alive = false, .last_seen_timestamp_ms = 200, .node_id = 1, .address = "tcp://127.0.0.1:7411"}});
-      },
-      testing::Throws<std::exception>(
-          testing::Property(&std::exception::what, testing::HasSubstr("Invalid gossip message"))));
-
-  stdexec::sync_wait(broker.Stop());
-}
-
-TEST(MessageBrokerTest, HandleGossipMessageIgnoresNewDeadNode) {
-  auto config = MakeConfig("tcp://127.0.0.1:7420");
-  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
-
-  // A gossip message about a previously unknown dead node should be silently ignored
-  DispatchGossip(broker,
-                 {{.alive = false, .last_seen_timestamp_ms = 100, .node_id = 5, .address = "tcp://127.0.0.1:7425"}});
-
-  // Node 5 should not appear in the cluster state
-  exec::async_scope scope;
-  std::atomic<bool> condition_met = true;
-  scope.spawn(ex_actor::internal::WrapSenderWithInlineScheduler(
-      broker.WaitClusterState(
-          [](const ex_actor::ClusterState& state) {
-            return std::ranges::any_of(state.nodes, [](const ex_actor::NodeInfo& n) { return n.node_id == 5; });
-          },
-          /*timeout_ms=*/0) |
-      stdexec::then(
-          [&condition_met](const ex_actor::WaitClusterStateResult& res) { condition_met = res.condition_met; })));
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  broker.CheckClusterStateWaiterTimeout();
-
-  stdexec::sync_wait(scope.on_empty());
-  EXPECT_FALSE(condition_met) << "A previously unknown dead node should not appear in the cluster state";
-
-  stdexec::sync_wait(broker.Stop());
-}
-
 // ============================================================
 // BroadcastGossip after gossip discovery sends to all discovered peers
 // ============================================================
@@ -814,11 +786,96 @@ TEST(MessageBrokerTest, BroadcastGossipAfterDiscovery) {
   ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
 
   DispatchGossip(broker,
-                 {{.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7381"},
-                  {.alive = true, .last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7382"}});
+                 {{.last_seen_timestamp_ms = 99999, .node_id = 1, .address = "tcp://127.0.0.1:7381"},
+                  {.last_seen_timestamp_ms = 99999, .node_id = 2, .address = "tcp://127.0.0.1:7382"}});
 
   // BroadcastGossip picks random peers from the discovered set and sends to them
   EXPECT_NO_THROW(broker.BroadcastGossip());
 
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
+// Deferred replies survive node connection loss:
+// When a reply is deferred (because we have no send socket for the requester),
+// and the requester node dies and reconnects, the deferred reply must still be
+// flushed upon reconnection.
+// ============================================================
+
+TEST(MessageBrokerTest, DeferredReplySurvivesNodeConnectionLossAndReconnection) {
+  // Declare capture_ctx/capture_socket before the broker so they are destroyed
+  // after the broker, avoiding a data race between the broker's ZMQ I/O thread
+  // and the capture context's teardown.
+  zmq::context_t capture_ctx {1};
+  zmq::socket_t capture_socket {capture_ctx, zmq::socket_type::dealer};
+
+  // Broker B (node 1) will receive requests from node 0 and defer replies.
+  auto config = MakeConfig("tcp://127.0.0.1:7410",
+                           /*contact_address=*/"",
+                           /*heartbeat_timeout_ms=*/1);
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/1, config);
+
+  // Set up an echo request handler so HandleIncomingRequest can process requests.
+  ex_actor::internal::MessageBrokerTestHelper::SetRequestHandler(
+      broker, [](ByteBuffer data) -> exec::task<ByteBuffer> { co_return std::move(data); });
+
+  // Set up a capture socket on node 0's address to intercept replies sent by broker.
+  capture_socket.bind("tcp://127.0.0.1:7411");
+  capture_socket.set(zmq::sockopt::rcvtimeo, 2000);
+  capture_socket.set(zmq::sockopt::linger, 0);
+
+  // --- Phase 1: Request arrives while node 0 is unknown → reply deferred ---
+  // Node 0 sends a request to broker (node 1). Broker doesn't know node 0 yet,
+  // so the reply will be deferred in deferred_replies_.
+  DispatchIncomingRequest(broker, /*request_node_id=*/0, /*response_node_id=*/1,
+                          /*request_id=*/100, MakeBytes("request_1"));
+
+  // --- Phase 2: Node 0 appears via gossip (with stale timestamp) ---
+  // OnNodeAlive is triggered → send socket created → deferred reply flushed.
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = 1, .node_id = 0, .address = "tcp://127.0.0.1:7411"}});
+
+  // Capture socket should receive the flushed reply.
+  {
+    zmq::message_t reply_msg;
+    auto recv_result = capture_socket.recv(reply_msg);
+    ASSERT_TRUE(recv_result.has_value()) << "Expected to receive the flushed deferred reply (phase 2)";
+    auto reply_broker_msg = ex_actor::internal::Deserialize<ex_actor::internal::BrokerMessage>(
+        ex_actor::internal::ByteBuffer(static_cast<const std::byte*>(reply_msg.data()),
+                                       static_cast<const std::byte*>(reply_msg.data()) + reply_msg.size()));
+    auto& two_way = std::get<ex_actor::internal::BrokerTwoWayMessage>(reply_broker_msg.variant);
+    EXPECT_EQ(two_way.request_node_id, 0U);
+    EXPECT_EQ(two_way.request_id, 100U);
+    EXPECT_EQ(BytesToString(two_way.payload), "request_1");
+  }
+
+  // --- Phase 3: Node 0 dies (heartbeat timeout) ---
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  broker.CheckHeartbeatTimeout();
+
+  // --- Phase 4: While node 0 is dead, another request arrives → reply deferred ---
+  DispatchIncomingRequest(broker, /*request_node_id=*/0, /*response_node_id=*/1,
+                          /*request_id=*/200, MakeBytes("request_2"));
+
+  // --- Phase 5: Node 0 reappears via gossip ---
+  // Because the fix removes node 0 from node_id_to_state_ on death (instead of
+  // marking alive=false), this gossip triggers OnNodeAlive again, which flushes
+  // the deferred reply accumulated in phase 4.
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = 99999, .node_id = 0, .address = "tcp://127.0.0.1:7411"}});
+
+  // Capture socket should receive the second deferred reply.
+  {
+    zmq::message_t reply_msg;
+    auto recv_result = capture_socket.recv(reply_msg);
+    ASSERT_TRUE(recv_result.has_value()) << "Expected to receive the flushed deferred reply (phase 5)";
+    auto reply_broker_msg = ex_actor::internal::Deserialize<ex_actor::internal::BrokerMessage>(
+        ex_actor::internal::ByteBuffer(static_cast<const std::byte*>(reply_msg.data()),
+                                       static_cast<const std::byte*>(reply_msg.data()) + reply_msg.size()));
+    auto& two_way = std::get<ex_actor::internal::BrokerTwoWayMessage>(reply_broker_msg.variant);
+    EXPECT_EQ(two_way.request_node_id, 0U);
+    EXPECT_EQ(two_way.request_id, 200U);
+    EXPECT_EQ(BytesToString(two_way.payload), "request_2");
+  }
+
+  capture_socket.close();
   stdexec::sync_wait(broker.Stop());
 }


### PR DESCRIPTION
## Summary

- **Remove `NodeState::alive` flag** — Replace with a remove-on-death model where dead nodes are fully erased from `node_id_to_state_` instead of being marked `alive=false`. Presence in the map now equals alive, simplifying all state checks.
- **Preserve deferred replies across node death/reconnection** — `OnNodeConnectionLost` no longer clears `deferred_replies_` for the dead node. When a node transiently disconnects and reconnects, pending replies accumulated while it was gone are correctly flushed upon rediscovery via gossip.
- **Unlimited ZMQ send HWM + `ZmqSendOrDie`** — All ZMQ sockets now set `sndhwm=0` (unlimited). A new `ZmqSendOrDie` helper replaces the inconsistent per-callsite EAGAIN handling (some logged warnings, some threw, some silently dropped messages).

## Test plan

- [x] New test `DeferredReplySurvivesNodeConnectionLossAndReconnection` validates the full lifecycle: request arrives while peer is unknown → reply deferred → peer appears → reply flushed → peer dies → new request → reply deferred again → peer reappears → reply flushed again.


closes https://github.com/ex-actor/ex-actor/issues/215
