### PR TITLE
[refactor] Rename LocalActorRef to BasicActorRef

### DIFF
--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-#include "ex_actor/internal/local_actor_ref.h"
+#include "ex_actor/internal/basic_actor_ref.h"
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/message.h"
 #include "ex_actor/internal/network.h"
@@ -28,13 +28,13 @@
 
 namespace ex_actor::internal {
 template <class UserClass>
-class ActorRef : public LocalActorRef<UserClass> {
+class ActorRef : public BasicActorRef<UserClass> {
  public:
-  ActorRef() : LocalActorRef<UserClass>() {}
+  ActorRef() : BasicActorRef<UserClass>() {}
 
   ActorRef(uint64_t this_node_id, uint64_t node_id, uint64_t actor_id, TypeErasedActor* actor,
-           const LocalActorRef<MessageBroker>& broker_actor_ref)
-      : LocalActorRef<UserClass>(actor_id, actor),
+           const BasicActorRef<MessageBroker>& broker_actor_ref)
+      : BasicActorRef<UserClass>(actor_id, actor),
         this_node_id_(this_node_id),
         node_id_(node_id),
         broker_actor_ref_(broker_actor_ref) {}
@@ -47,7 +47,7 @@ class ActorRef : public LocalActorRef<UserClass> {
   }
 
   void SetLocalRuntimeInfo(uint64_t this_node_id, TypeErasedActor* actor,
-                           const LocalActorRef<MessageBroker>& broker_actor_ref) {
+                           const BasicActorRef<MessageBroker>& broker_actor_ref) {
     this_node_id_ = this_node_id;
     this->type_erased_actor_ = actor;
     broker_actor_ref_ = broker_actor_ref;
@@ -63,7 +63,7 @@ class ActorRef : public LocalActorRef<UserClass> {
     requires std::is_convertible_v<Other*, UserClass*>
   // NOLINTNEXTLINE(google-explicit-constructor) - implicit conversion is intentional for polymorphism support
   ActorRef(const ActorRef<Other>& other)
-      : LocalActorRef<UserClass>(other),
+      : BasicActorRef<UserClass>(other),
         this_node_id_(other.this_node_id_),
         node_id_(other.node_id_),
         broker_actor_ref_(other.broker_actor_ref_) {}
@@ -101,7 +101,7 @@ class ActorRef : public LocalActorRef<UserClass> {
     requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
   {
     EXA_THROW_CHECK_EQ(node_id_, this_node_id_) << "Cannot call remote actor using SendLocal, use Send instead.";
-    return LocalActorRef<UserClass>::template SendLocal<kMethod>(std::move(args)...);
+    return BasicActorRef<UserClass>::template SendLocal<kMethod>(std::move(args)...);
   }
 
   uint64_t GetNodeId() const { return node_id_; }
@@ -109,7 +109,7 @@ class ActorRef : public LocalActorRef<UserClass> {
  private:
   uint64_t this_node_id_ = 0;
   uint64_t node_id_ = 0;
-  LocalActorRef<MessageBroker> broker_actor_ref_;
+  BasicActorRef<MessageBroker> broker_actor_ref_;
 
   template <auto kMethod, class... Args>
   [[nodiscard]] auto SendInternal(Args... args) const
@@ -161,8 +161,8 @@ void NotifyOnSpawned(TypeErasedActor* actor, const ActorRef<UserClass>& self_ref
 }
 
 template <class UserClass>
-void NotifyOnSpawned(TypeErasedActor* actor, const LocalActorRef<UserClass>& self_ref) {
-  if constexpr (requires(UserClass& user_class, LocalActorRef<UserClass> self_ref) {
+void NotifyOnSpawned(TypeErasedActor* actor, const BasicActorRef<UserClass>& self_ref) {
+  if constexpr (requires(UserClass& user_class, BasicActorRef<UserClass> self_ref) {
                   user_class.OnSpawned(self_ref);
                 }) {
     static_cast<UserClass*>(actor->GetUserClassInstanceAddress())->OnSpawned(self_ref);
@@ -194,7 +194,7 @@ namespace ex_actor::internal {
 struct ActorRefSerdeContext {
   uint64_t this_node_id = 0;
   std::function<TypeErasedActor*(uint64_t)> actor_look_up_fn;
-  LocalActorRef<MessageBroker> broker_actor_ref;
+  BasicActorRef<MessageBroker> broker_actor_ref;
 };
 }  // namespace ex_actor::internal
 

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -42,7 +42,7 @@ namespace ex_actor::internal {
 class ActorRegistryBackend {
  public:
   explicit ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler, uint64_t this_node_id,
-                                LocalActorRef<MessageBroker> broker_actor_ref);
+                                BasicActorRef<MessageBroker> broker_actor_ref);
 
   exec::task<void> AsyncDestroyAllActors();
 
@@ -149,7 +149,7 @@ class ActorRegistryBackend {
   /**
    * @brief Update the broker actor ref. Called when switching to distributed mode after init.
    */
-  void SetBrokerActorRef(LocalActorRef<MessageBroker> broker_actor_ref);
+  void SetBrokerActorRef(BasicActorRef<MessageBroker> broker_actor_ref);
 
   /**
    * @brief Handle a network request. Returns the serialized reply data.
@@ -177,7 +177,7 @@ class ActorRegistryBackend {
   std::mt19937 random_num_generator_;
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
   uint64_t this_node_id_ = 0;
-  LocalActorRef<MessageBroker> broker_actor_ref_;
+  BasicActorRef<MessageBroker> broker_actor_ref_;
   std::unordered_map<uint64_t, std::unique_ptr<TypeErasedActor>> actor_id_to_actor_;
   std::unordered_map<std::string, std::uint64_t> actor_name_to_id_;
 
@@ -217,7 +217,7 @@ class SpawnBuilder : public ex::sender_t {
   using completion_signatures = ex::completion_signatures<ex::set_value_t(ActorRef<UserClass>),
                                                           ex::set_error_t(std::exception_ptr), ex::set_stopped_t()>;
 
-  explicit SpawnBuilder(LocalActorRef<ActorRegistryBackend> backend_ref, Args... args)
+  explicit SpawnBuilder(BasicActorRef<ActorRegistryBackend> backend_ref, Args... args)
       : backend_ref_(std::move(backend_ref)), args_(std::move(args)...) {}
 
   SpawnBuilder& ToNode(uint64_t node_id) & {
@@ -269,7 +269,7 @@ class SpawnBuilder : public ex::sender_t {
         std::forward<Tuple>(args));
   }
 
-  LocalActorRef<ActorRegistryBackend> backend_ref_;
+  BasicActorRef<ActorRegistryBackend> backend_ref_;
   uint64_t node_id_ = 0;
   ActorConfig config_ {};
   std::tuple<Args...> args_;
@@ -355,9 +355,9 @@ class ActorRegistry {
   WorkSharingThreadPool control_plane_thread_pool_;
   std::unique_ptr<TypeErasedActorScheduler> scheduler_;
   std::unique_ptr<Actor<MessageBroker>> broker_actor_;
-  LocalActorRef<MessageBroker> broker_actor_ref_;
+  BasicActorRef<MessageBroker> broker_actor_ref_;
   Actor<ActorRegistryBackend> backend_actor_;
-  LocalActorRef<ActorRegistryBackend> backend_actor_ref_;
+  BasicActorRef<ActorRegistryBackend> backend_actor_ref_;
 
   explicit ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeErasedActorScheduler> scheduler);
 };

--- a/include/ex_actor/internal/basic_actor_ref.h
+++ b/include/ex_actor/internal/basic_actor_ref.h
@@ -24,14 +24,14 @@
 namespace ex_actor::internal {
 
 template <class UserClass>
-class LocalActorRef {
+class BasicActorRef {
  public:
-  LocalActorRef() : is_empty_(true) {}
+  BasicActorRef() : is_empty_(true) {}
 
-  LocalActorRef(uint64_t actor_id, TypeErasedActor* actor)
+  BasicActorRef(uint64_t actor_id, TypeErasedActor* actor)
       : is_empty_(false), actor_id_(actor_id), type_erased_actor_(actor) {}
 
-  friend bool operator==(const LocalActorRef& lhs, const LocalActorRef& rhs) {
+  friend bool operator==(const BasicActorRef& lhs, const BasicActorRef& rhs) {
     if (lhs.is_empty_ && rhs.is_empty_) {
       return true;
     }
@@ -39,23 +39,23 @@ class LocalActorRef {
   }
 
   template <class U>
-  friend class LocalActorRef;
+  friend class BasicActorRef;
 
   template <class U>
   friend class ActorRef;
 
-  // Converting constructor from LocalActorRef<U> where U* is convertible to UserClass*
+  // Converting constructor from BasicActorRef<U> where U* is convertible to UserClass*
   template <class Other>
     requires std::is_convertible_v<Other*, UserClass*>
   // NOLINTNEXTLINE(google-explicit-constructor) - implicit conversion is intentional for polymorphism support
-  LocalActorRef(const LocalActorRef<Other>& other)
+  BasicActorRef(const BasicActorRef<Other>& other)
       : is_empty_(other.is_empty_), actor_id_(other.actor_id_), type_erased_actor_(other.type_erased_actor_) {}
 
   // Converting assignment operator - delegates to converting constructor
   template <class Other>
     requires std::is_convertible_v<Other*, UserClass*>
-  LocalActorRef<UserClass>& operator=(const LocalActorRef<Other>& other) {
-    *this = LocalActorRef<UserClass>(other);
+  BasicActorRef<UserClass>& operator=(const BasicActorRef<Other>& other) {
+    *this = BasicActorRef<UserClass>(other);
     return *this;
   }
 
@@ -66,9 +66,9 @@ class LocalActorRef {
   [[nodiscard]] ex::sender auto SendLocal(Args... args) const
     requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
   {
-    EXA_THROW_CHECK(!IsEmpty()) << "Empty LocalActorRef, cannot call method on it.";
-    EXA_THROW_CHECK(type_erased_actor_ != nullptr)
-        << "Local actor instance not set, it's typically because you converted a remote ActorRef to LocalActorRef.";
+    EXA_THROW_CHECK(!IsEmpty()) << "Empty BasicActorRef, cannot call method on it.";
+    EXA_THROW_CHECK(type_erased_actor_ != nullptr) << "Underlying actor instance not set, it's typically because you "
+                                                      "converted a remote ActorRef to BasicActorRef.";
     return type_erased_actor_->template CallActorMethod<kMethod>(std::move(args)...);
   }
 
@@ -84,13 +84,13 @@ class LocalActorRef {
 }  // namespace ex_actor::internal
 
 namespace ex_actor {
-using internal::LocalActorRef;
+using internal::BasicActorRef;
 }  // namespace ex_actor
 
 namespace std {
 template <class UserClass>
-struct hash<ex_actor::LocalActorRef<UserClass>> {
-  size_t operator()(const ex_actor::LocalActorRef<UserClass>& ref) const {
+struct hash<ex_actor::BasicActorRef<UserClass>> {
+  size_t operator()(const ex_actor::BasicActorRef<UserClass>& ref) const {
     if (ref.IsEmpty()) {
       return ex_actor::internal::kEmptyActorRefHashVal;
     }

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -32,8 +32,8 @@
 #include <exec/task.hpp>
 #include <zmq.hpp>
 
+#include "ex_actor/internal/basic_actor_ref.h"
 #include "ex_actor/internal/constants.h"
-#include "ex_actor/internal/local_actor_ref.h"
 #include "ex_actor/internal/message.h"
 #include "ex_actor/internal/util.h"
 
@@ -159,7 +159,7 @@ class MessageBroker {
   /**
    * @brief Called by the framework after the actor is spawned to inject the self actor ref.
    */
-  void OnSpawned(LocalActorRef<MessageBroker> self_actor_ref);
+  void OnSpawned(BasicActorRef<MessageBroker> self_actor_ref);
 
   /**
    * @brief Start the recv socket puller and periodical task scheduler.
@@ -242,7 +242,7 @@ class MessageBroker {
   zmq::socket_t contact_node_send_socket_;
   std::unordered_map<uint64_t, zmq::socket_t> node_id_to_send_socket_;
 
-  LocalActorRef<MessageBroker> self_actor_ref_;
+  BasicActorRef<MessageBroker> self_actor_ref_;
   RequestHandler request_handler_;
   exec::async_scope async_scope_;
   std::unique_ptr<RecvSocketPuller> recv_socket_puller_;

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -27,12 +27,12 @@ namespace ex_actor::internal {
 
 // ----------------------ActorRegistryBackend--------------------------
 ActorRegistryBackend::ActorRegistryBackend(std::unique_ptr<TypeErasedActorScheduler> scheduler, uint64_t this_node_id,
-                                           LocalActorRef<MessageBroker> broker_actor_ref)
+                                           BasicActorRef<MessageBroker> broker_actor_ref)
     : scheduler_(std::move(scheduler)), this_node_id_(this_node_id), broker_actor_ref_(broker_actor_ref) {
   InitRandomNumGenerator();
 }
 
-void ActorRegistryBackend::SetBrokerActorRef(LocalActorRef<MessageBroker> broker_actor_ref) {
+void ActorRegistryBackend::SetBrokerActorRef(BasicActorRef<MessageBroker> broker_actor_ref) {
   broker_actor_ref_ = broker_actor_ref;
 }
 
@@ -224,7 +224,7 @@ exec::task<void> ActorRegistry::StartOrJoinCluster(const ClusterConfig& cluster_
   broker_actor_ = std::make_unique<Actor<MessageBroker>>(std::move(control_plane_scheduler), ActorConfig {},
                                                          this_node_id_, cluster_config);
 
-  broker_actor_ref_ = LocalActorRef<MessageBroker>(/*actor_id=*/UINT64_MAX, broker_actor_.get());
+  broker_actor_ref_ = BasicActorRef<MessageBroker>(/*actor_id=*/UINT64_MAX, broker_actor_.get());
   NotifyOnSpawned<MessageBroker>(broker_actor_.get(), broker_actor_ref_);
 
   // Update the backend actor's broker ref so it can forward network requests

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -171,7 +171,7 @@ MessageBroker::~MessageBroker() {
   }
 }
 
-void MessageBroker::OnSpawned(LocalActorRef<MessageBroker> self_actor_ref) { self_actor_ref_ = self_actor_ref; }
+void MessageBroker::OnSpawned(BasicActorRef<MessageBroker> self_actor_ref) { self_actor_ref_ = self_actor_ref; }
 
 void MessageBroker::Start(RequestHandler request_handler) {
   EXA_THROW_CHECK(!self_actor_ref_.IsEmpty()) << "OnSpawned() must be called before Start()";

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -173,12 +173,12 @@ TEST(BasicApiTest, LookUpNamedActor) {
   ex_actor::Shutdown();
 }
 
-TEST(BasicApiTest, RemoteActorRefSlicedToLocalActorRefShouldThrowOnUse) {
+TEST(BasicApiTest, RemoteActorRefSlicedToBasicActorRefShouldThrowOnUse) {
   ex_actor::internal::ActorRef<Counter> remote_ref(
       /*this_node_id=*/1, /*node_id=*/2, /*actor_id=*/42, /*actor=*/nullptr, /*broker_actor_ref=*/ {});
-  // Slicing a remote ActorRef to LocalActorRef is allowed at the type level (due to inheritance),
+  // Slicing a remote ActorRef to BasicActorRef is allowed at the type level (due to inheritance),
   // but calling SendLocal on it will throw because type_erased_actor_ is nullptr.
-  ex_actor::LocalActorRef<Counter> local_ref = remote_ref;
+  ex_actor::BasicActorRef<Counter> local_ref = remote_ref;
   EXPECT_THAT([&] { std::ignore = local_ref.SendLocal<&Counter::GetValue>(); },
               Throws<std::exception>(Property(&std::exception::what, HasSubstr("Local actor instance not set"))));
 }


### PR DESCRIPTION
## Summary

- Rename `LocalActorRef` to `BasicActorRef` and `local_actor_ref.h` to `basic_actor_ref.h`
- `LocalActorRef` was misleading because `ActorRef` (which handles remote calls) inherits from it — "Local" as a base class name implied the subclass is also local
- `BasicActorRef` better communicates it is the simpler, lightweight actor reference without network awareness

## Test plan

- [x] Full cmake build passes (0 errors)
- [x] All 18 tests pass (`ctest -C Release`)
- [x] No remaining references to `LocalActorRef` or `local_actor_ref` in source tree
