### PR TITLE
[ci] Add Bazel lockfile check workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,3 @@
 common --enable_bzlmod
+common --lockfile_mode=error
 build --cxxopt='-std=c++20'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for all text files
+* text=auto eol=lf

--- a/.github/workflows/check_bazel_build.yml
+++ b/.github/workflows/check_bazel_build.yml
@@ -1,0 +1,21 @@
+name: Check Bazel lockfile
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check_lockfile:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check MODULE.bazel.lock is up-to-date
+        run: bazel mod graph --check_direct_dependencies=error

--- a/.github/workflows/check_bazel_build.yml
+++ b/.github/workflows/check_bazel_build.yml
@@ -17,5 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve module graph
+        run: bazel mod graph --lockfile_mode=update --check_direct_dependencies=error
+
       - name: Check MODULE.bazel.lock is up-to-date
-        run: bazel mod graph --check_direct_dependencies=error
+        run: git diff --exit-code MODULE.bazel.lock


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow (`check_bazel_build.yml`) that verifies `MODULE.bazel.lock` is up-to-date by running `bazel mod graph` with `--lockfile_mode=error` (set in `.bazelrc`).
- Add `--lockfile_mode=error` to `.bazelrc` so lock file staleness is caught both in CI and locally.
- Add `.gitattributes` to enforce LF line endings.

## Test plan
- [ ] Verify the `Check Bazel lockfile` workflow passes on this PR.
- [ ] Confirm that modifying `MODULE.bazel` without updating the lock file causes the workflow to fail.

Made with [Cursor](https://cursor.com)