### PR TITLE
[perf] Replace coroutine-based Send() with VariantSender composition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "CAPNPROTO",
     "concurrentqueue",
     "constexpr",
+    "constructibility",
     "cout",
     "cppzmq",
     "ctest",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This programming paradigm is called "Actor Model". It's a very easy way to write
 # Key Features
 
 1. **Easy to Use** - Clean & intuitive API, turn your existing class into an actor.
-2. **Standard-Compliant** - Composible with everything in std::execution ecosystem.
+2. **Standard-Compliant** - Composable with everything in std::execution ecosystem.
 3. **Pluggable Scheduler** - Use any std::execution scheduler you like! We also [provide many out-of-box](https://ex-actor.github.io/ex-actor/schedulers/): work-sharing, work-stealing, custom priority and so on.
 
 
@@ -52,7 +52,7 @@ exec::task<void> MainCoroutine() {
   // 1. Create the actor.
   ex_actor::ActorRef actor = co_await ex_actor::Spawn<Counter>();
 
-  // 2. Call it! It returns a `std::execution::task`.
+  // 2. Call it! It returns a std::execution sender.
   int res = co_await actor.Send<&Counter::Add>(1);
   assert(res == 1);
 
@@ -65,7 +65,7 @@ int main() { stdexec::sync_wait(MainCoroutine()); }
 
 ## Actor Chaining Example
 
-Actor's method can be a coroutine. The following example shows how to create an actor inside an actor and call it without blocking the scheduler thread.
+Actor's method can be a sender. The following example shows how to create an actor inside an actor and call it without blocking the scheduler thread.
 
 <!-- doc test start -->
 ```cpp
@@ -81,7 +81,7 @@ public:
 
 class Father {
 public:
-  // actor's method can be a coroutine
+  // actor's method can be a sender
   exec::task<std::string> SpawnChildAndPing() {
     if (child_.IsEmpty()) {
       child_ = co_await ex_actor::Spawn<Child>();
@@ -95,7 +95,7 @@ private:
 
 exec::task<void> MainCoroutine() {
   // Here we have only one thread in scheduler, but it still can finish the entire work
-  // because we use coroutine, there is no blocking wait in actor's method.
+  // because everything is async, there is no blocking wait
   ex_actor::Init(/*thread_pool_size=*/1);
 
   ex_actor::ActorRef<Father> father = co_await ex_actor::Spawn<Father>();

--- a/docs/contents/tutorial.md
+++ b/docs/contents/tutorial.md
@@ -42,21 +42,21 @@ exec::task<void> MainCoroutine() {
   
   /*
   3. Everything is setup, you can call the actor's method now using `actor_ref.Send`.
-  This method returns a standard `std::execution::task`, compatible with everything
+  This method returns a standard std::execution sender, compatible with everything
   in the `std::execution` ecosystem. If you met "unsupported type" compile error: (1)
   */
-  auto task = actor.Send<&Counter::Add>(1);
+  auto sender = actor.Send<&Counter::Add>(1);
 
   /*
   3.1 For local actors, you can try `SendLocal`, which doesn't require the args to be serializable.
   */
-  auto task2 = actor.SendLocal<&Counter::Add>(1);
+  auto sender2 = actor.SendLocal<&Counter::Add>(1);
 
   /*
-  4. The task is lazy executed. To execute the task and wait for the result non-blockingly,
-  use `co_await`. Note that the task is not copyable, so you need to use `std::move`.
+  4. The sender is lazy executed. To execute the sender and wait for the result non-blockingly,
+  use `co_await`. Note that the sender is not copyable, so you need to use `std::move`.
   */
-  auto res = co_await std::move(task);
+  auto res = co_await std::move(sender);
   assert(res == 1);
 
   // A shorter way
@@ -99,7 +99,7 @@ public:
 
 class Father {
 public:
-  // Actor's method can be a coroutine.
+  // Actor's method can be a sender.
   exec::task<std::string> SpawnChildAndPing() {
     if (child_.IsEmpty()) {
       // this line won't block the scheduler thread
@@ -116,7 +116,7 @@ private:
 
 exec::task<void> MainCoroutine() {
   // Here we have only one thread in scheduler, but it still can finish the entire work,
-  // because we use coroutine, there is no blocking wait in actor's method.
+  // because everything is async, there is no blocking wait
   ex_actor::Init(/*thread_pool_size=*/1);
 
   ex_actor::ActorRef<Father> father = co_await ex_actor::Spawn<Father>();
@@ -151,7 +151,7 @@ class Proxy {
  public:
   explicit Proxy(ex_actor::ActorRef<PingWorker> actor_ref) : actor_ref_(actor_ref) {}
 
-  // Actor's method can be a coroutine.
+  // Actor's method can be a sender.
   exec::task<std::string> ProxyPing() {
     // This line won't block the scheduler thread.
     std::string ping_res = co_await actor_ref_.template Send<&PingWorker::Ping>();
@@ -183,7 +183,7 @@ int main() { stdexec::sync_wait(MainCoroutine()); }
 <!-- doc test end -->
 
 
-## Trigger task without waiting for the result immediately
+## Trigger senders without waiting for the result immediately
 
 You can use [`async_scope`](https://kirkshoop.github.io/async_scope/asyncscope.html) to trigger a task without waiting for the result immediately.
 
@@ -204,12 +204,12 @@ exec::task<void> MainCoroutine() {
   exec::async_scope scope;
 
   /*
-  for void tasks, use `async_scope.spawn`.
+  for void senders, use `async_scope.spawn`.
   */
   scope.spawn(actor.Send<&Counter::Add>(1));
   
   /*
-  for non-void tasks, if you don't want to get the result, attach an empty `then`
+  for non-void senders, if you don't want to get the result, attach an empty `then`
   to discard the result, then use `async_scope.spawn`.
   */
   scope.spawn(actor.Send<&Counter::AddAndGet>(1) | stdexec::then([](auto) {}));
@@ -221,7 +221,7 @@ exec::task<void> MainCoroutine() {
   int res = co_await std::move(future);
   assert(res == 3);
   
-  // you must wait for all task done before destroying the scope,
+  // you must wait for all senders done before destroying the scope,
   // or an exception will be thrown.
   co_await scope.on_empty();
 
@@ -233,9 +233,9 @@ int main() { stdexec::sync_wait(MainCoroutine()); }
 <!-- doc test end -->
 
 
-## Execute multiple tasks in parallel
+## Execute multiple senders in parallel
 
-You can execute multiple tasks in parallel using [`when_all`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#design-sender-adaptor-when_all) or [`async_scope`](https://kirkshoop.github.io/async_scope/asyncscope.html) in std::execution.
+You can execute multiple senders in parallel using [`when_all`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#design-sender-adaptor-when_all) or [`async_scope`](https://kirkshoop.github.io/async_scope/asyncscope.html) in std::execution.
 
 <!-- doc test start -->
 ```cpp
@@ -259,7 +259,7 @@ exec::task<void> MainCoroutine() {
   }
 
   /*
-  1. `when_all` example, handy for small number of tasks.
+  1. `when_all` example, handy for small number of senders.
   */
   auto [res1, res2, res3] = co_await stdexec::when_all(
     counters[0].Send<&Counter::AddAndGet>(1),
@@ -271,12 +271,12 @@ exec::task<void> MainCoroutine() {
   assert(res3 == 1);
 
   /*
-  2. for large number of tasks where you need a loop, use `async_scope`.
+  2. for large number of senders where you need a loop, use `async_scope`.
   */
   exec::async_scope scope;
 
   /*
-  2.1 async_scope.spawn example, which only accepts void tasks.
+  2.1 async_scope.spawn example, which only accepts void senders.
   */
   for (int i = 0; i < counters.size(); ++i) {
     scope.spawn(counters[i].Send<&Counter::Add>(1));
@@ -309,11 +309,11 @@ int main() { stdexec::sync_wait(MainCoroutine()); }
 ```
 <!-- doc test end -->
 
-## [Optional Read] Wrap the result using sender adapter
+## [Optional Read] Wrap the result using plain sender adapter
 
-We recommend you to use coroutine to wrap the result, which is easier and more readable.
+We recommend you to use `std::execution::task` coroutine to wrap the result, which is easier and more readable.
 
-But if you insist on using sender adapter for some reason, be cautious that you'll lose the scheduler affinity `std::execution::task` provided,
+But if you insist on using plain sender adapter for some reason, be cautious that you'll lose the scheduler affinity `std::execution::task` provided,
 the `ex::then` callback will run on the actor's thread, **do not capture local variable's reference, or `this` pointer of an actor instance in the callback**.
 
 <!-- doc test start -->

--- a/include/ex_actor/internal/actor_ref.h
+++ b/include/ex_actor/internal/actor_ref.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 #include "ex_actor/internal/basic_actor_ref.h"
 #include "ex_actor/internal/logging.h"
@@ -25,8 +26,10 @@
 #include "ex_actor/internal/network.h"
 #include "ex_actor/internal/reflect.h"
 #include "ex_actor/internal/serialization.h"
+#include "ex_actor/internal/util.h"
 
 namespace ex_actor::internal {
+
 template <class UserClass>
 class ActorRef : public BasicActorRef<UserClass> {
  public:
@@ -77,20 +80,26 @@ class ActorRef : public BasicActorRef<UserClass> {
   }
 
   /**
-   * @brief Send message to an actor. Returns a coroutine carrying the result.
+   * @brief Send message to an actor. Returns a sender carrying the result.
    * @note This method requires your args and return value can be serialized by reflect-cpp, if you met compile errors
    * like "Unsupported type", refer https://rfl.getml.com/concepts/custom_classes/ to add a serializer for it. Or if you
    * can confirm it's a local actor, use SendLocal() instead, which doesn't require your args to be serializable.
-   * @note Dynamic memory allocation will happen due to the use of coroutine. If you can confirm it's a local actor,
-   * consider using SendLocal() instead, which has better performance.
-   * @note The returned coroutine is not copyable. please use `co_await std::move(coroutine)`.
    */
   template <auto kMethod, class... Args>
-  [[nodiscard]] auto Send(Args... args) const
+  [[nodiscard]] ex::sender auto Send(Args... args) const
     requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
   {
-    // Add a fallback inline_scheduler for it.
-    return WrapSenderWithInlineScheduler(SendInternal<kMethod>(std::move(args)...));
+    using LocalSenderType =
+        decltype(std::declval<const ActorRef*>()->template SendLocal<kMethod>(std::declval<Args>()...));
+    using RemoteSenderType = decltype(SendRemote<kMethod>(std::declval<Args>()...));
+
+    EXA_THROW_CHECK(!this->IsEmpty()) << "Empty ActorRef, cannot call method on it.";
+
+    using VariantType = std::variant<LocalSenderType, RemoteSenderType>;
+    VariantType chosen_sender = (node_id_ == this_node_id_) ? VariantType(SendLocal<kMethod>(std::move(args)...))
+                                                            : VariantType(SendRemote<kMethod>(std::move(args)...));
+
+    return SenderVariant {std::move(chosen_sender)};
   }
 
   /**
@@ -107,25 +116,11 @@ class ActorRef : public BasicActorRef<UserClass> {
   uint64_t GetNodeId() const { return node_id_; }
 
  private:
-  uint64_t this_node_id_ = 0;
-  uint64_t node_id_ = 0;
-  BasicActorRef<MessageBroker> broker_actor_ref_;
-
   template <auto kMethod, class... Args>
-  [[nodiscard]] auto SendInternal(Args... args) const
-      -> exec::task<typename decltype(UnwrapReturnSenderIfNested<kMethod>())::type>
-    requires(std::is_invocable_v<decltype(kMethod), UserClass*, Args...>)
-  {
-    if (this->IsEmpty()) [[unlikely]] {
-      throw std::runtime_error("Empty ActorRef, cannot call method on it.");
-    }
-    if (node_id_ == this_node_id_) {
-      co_return co_await SendLocal<kMethod>(std::move(args)...);
-    }
-
-    // remote call
-    EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty()) << "Broker actor not set";
+  [[nodiscard]] ex::sender auto SendRemote(Args... args) const {
+    using UnwrappedType = typename decltype(UnwrapReturnSenderIfNested<kMethod>())::type;
     using Sig = Signature<decltype(kMethod)>;
+    EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty()) << "Broker actor not set";
     ActorMethodCallArgs<typename Sig::DecayedArgsTupleType> method_call_args {
         .args_tuple = typename Sig::DecayedArgsTupleType(std::move(args)...)};
 
@@ -135,22 +130,25 @@ class ActorRef : public BasicActorRef<UserClass> {
         .serialized_args = Serialize(method_call_args),
     }};
 
-    using UnwrappedType = decltype(UnwrapReturnSenderIfNested<kMethod>())::type;
-    ByteBuffer response_buf =
-        co_await broker_actor_ref_.SendLocal<&MessageBroker::SendRequest>(node_id_, Serialize(request));
-    auto reply = Deserialize<NetworkReply>(response_buf);
-
-    auto& ret = std::get<ActorMethodCallReply>(reply.variant);
-    if (!ret.success) {
-      EXA_THROW << "Got error from remote actor on node " << node_id_ << ": " << ret.error;
-    }
-    if constexpr (std::is_void_v<UnwrappedType>) {
-      co_return;
-    } else {
-      auto res = Deserialize<ActorMethodReturnValue<UnwrappedType>>(ret.serialized_result);
-      co_return res.return_value;
-    }
+    return broker_actor_ref_.template SendLocal<&MessageBroker::SendRequest>(node_id_, Serialize(request)) |
+           ex::then([node_id = node_id_](ByteBuffer response_buf) -> UnwrappedType {
+             auto reply = Deserialize<NetworkReply>(std::move(response_buf));
+             auto& ret = std::get<ActorMethodCallReply>(reply.variant);
+             if (!ret.success) {
+               EXA_THROW << "Got error from remote actor on node " << node_id << ": " << ret.error;
+             }
+             if constexpr (std::is_void_v<UnwrappedType>) {
+               return;
+             } else {
+               auto res = Deserialize<ActorMethodReturnValue<UnwrappedType>>(ret.serialized_result);
+               return std::move(res.return_value);
+             }
+           });
   }
+
+  uint64_t this_node_id_ = 0;
+  uint64_t node_id_ = 0;
+  BasicActorRef<MessageBroker> broker_actor_ref_;
 };
 
 template <class UserClass>

--- a/include/ex_actor/internal/reflect.h
+++ b/include/ex_actor/internal/reflect.h
@@ -126,4 +126,19 @@ std::string GetUniqueNameForFunction() {
 template <auto kFn>
 using FnReturnType = std::decay_t<typename Signature<decltype(kFn)>::ReturnType>;
 
+// Order-independent set equality of two completion_signatures types.
+template <class T, class... Ts>
+constexpr bool kContainedIn = (std::is_same_v<T, Ts> || ...);
+
+template <class SigsA, class SigsB>
+struct CompletionSignaturesMatchImpl;
+
+template <class... SigsA, class... SigsB>
+struct CompletionSignaturesMatchImpl<ex::completion_signatures<SigsA...>, ex::completion_signatures<SigsB...>>
+    : std::bool_constant<sizeof...(SigsA) == sizeof...(SigsB) && (kContainedIn<SigsA, SigsB...> && ...) &&
+                         (kContainedIn<SigsB, SigsA...> && ...)> {};
+
+template <class SigsA, class SigsB>
+constexpr bool kCompletionSignaturesMatch = CompletionSignaturesMatchImpl<SigsA, SigsB>::value;
+
 }  // namespace ex_actor::internal

--- a/include/ex_actor/internal/util.h
+++ b/include/ex_actor/internal/util.h
@@ -20,8 +20,11 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <variant>
 
 #include <spdlog/spdlog.h>
 #include <stdexec/execution.hpp>
@@ -30,6 +33,7 @@
 #include "ex_actor/3rd_lib/moody_camel_queue/blockingconcurrentqueue.h"
 #include "ex_actor/internal/alias.h"  // IWYU pragma: keep
 #include "ex_actor/internal/logging.h"
+#include "ex_actor/internal/reflect.h"
 
 namespace ex_actor {
 /**
@@ -308,6 +312,74 @@ auto& MapAt(Map& map, const Key& key, std::source_location loc = std::source_loc
   }
   return it->second;
 }
+
+// A sender that wraps two alternative senders in a variant, choosing at runtime.
+// Used to type erase different senders without using ex::task, so the scheduler can be preserved.
+template <class SenderA, class SenderB>
+  requires kCompletionSignaturesMatch<ex::completion_signatures_of_t<SenderA, ex::env<>>,
+                                      ex::completion_signatures_of_t<SenderB, ex::env<>>>
+struct SenderVariant : ex::sender_t {
+  std::variant<SenderA, SenderB> sender_variant;
+
+  explicit SenderVariant(std::variant<SenderA, SenderB> sender) : sender_variant(std::move(sender)) {}
+
+  using completion_signatures = ex::completion_signatures_of_t<SenderA, ex::env<>>;
+
+  template <ex::receiver Receiver>
+  struct VariantOperation {
+    using OpA = decltype(ex::connect(std::declval<SenderA>(), std::declval<Receiver>()));
+    using OpB = decltype(ex::connect(std::declval<SenderB>(), std::declval<Receiver>()));
+
+    // 0 = A active, 1 = B active
+    unsigned char index;
+
+    // Uses a plain union instead of std::variant to avoid requiring move-constructibility,
+    // since stdexec operation states are immovable.
+    union Storage {
+      OpA op_a;
+      OpB op_b;
+      Storage() noexcept {}
+      ~Storage() {}
+    } storage;
+
+    VariantOperation(std::integral_constant<unsigned char, 0> /*tag*/, SenderA&& sender, Receiver&& receiver)
+        : index(0) {
+      ::new (&storage.op_a) OpA(ex::connect(std::move(sender), std::move(receiver)));
+    }
+    VariantOperation(std::integral_constant<unsigned char, 1> /*tag*/, SenderB&& sender, Receiver&& receiver)
+        : index(1) {
+      ::new (&storage.op_b) OpB(ex::connect(std::move(sender), std::move(receiver)));
+    }
+
+    VariantOperation(VariantOperation&&) = delete;
+    VariantOperation& operator=(VariantOperation&&) = delete;
+
+    ~VariantOperation() {
+      if (index == 0) {
+        storage.op_a.~OpA();
+      } else {
+        storage.op_b.~OpB();
+      }
+    }
+
+    void start() noexcept {
+      if (index == 0) {
+        ex::start(storage.op_a);
+      } else {
+        ex::start(storage.op_b);
+      }
+    }
+  };
+
+  template <ex::receiver Receiver>
+  auto connect(Receiver receiver) && -> VariantOperation<Receiver> {
+    if (sender_variant.index() == 0) {
+      return {std::integral_constant<unsigned char, 0> {}, std::move(std::get<0>(sender_variant)), std::move(receiver)};
+    }
+    return {std::integral_constant<unsigned char, 1> {}, std::move(std::get<1>(sender_variant)), std::move(receiver)};
+  }
+};
+
 }  // namespace ex_actor::internal
 
 // Backward-compatibility alias — this namespace was removed in favor of ex_actor.


### PR DESCRIPTION
## Summary

- Replace the `exec::task` coroutine in `ActorRef::Send()` with a `VariantSender` that dispatches between local and remote sender paths at runtime via tagged union.
- Eliminates heap allocation for local sends and removes the extra coroutine frame for remote sends, using pure sender composition (`ex::then`) instead.

## Motivation

The previous `Send()` implementation used `exec::task` (a coroutine) to branch between local and remote paths. This incurred a heap allocation for the coroutine frame and unecessary rescheduling even for local sends. The new approach uses `VariantSender` to select the active sender at runtime while keeping everything on the stack, which has better performance.

## Test plan

- [x] Full Release build passes
- [x] All 19 tests pass

closes https://github.com/ex-actor/ex-actor/issues/227