### PR TITLE
[docs] Document GCC < 13 coroutine bug and clean up tutorial links

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,8 @@ While this framework has some successful applications internally, we believe the
 ## Standing on the Shoulders of Giants
 
 * [stdexec](https://github.com/NVIDIA/stdexec) - Early implementation of std::execution in C++20.
-* [daking::MPSC_queue](https://github.com/dakingffo/MPSC_queue) - A high-performance lock-free MPSC queue.
-* [moodycamel::ConcurrentQueue](https://github.com/cameron314/concurrentqueue) - An industrial-strength MPMC queue.
 * [ZeroMQ](https://zeromq.org/) - An open-source universal messaging library.
 * [reflect-cpp](https://github.com/getml/reflect-cpp) - A reflection-based C++20 serialization library.
+* [daking::MPSC_queue](https://github.com/dakingffo/MPSC_queue) - A high-performance lock-free MPSC queue.
+* [moodycamel::ConcurrentQueue](https://github.com/cameron314/concurrentqueue) - An industrial-strength MPMC queue.
 * [Cap'n Proto](https://capnproto.org/) - An insanely fast data interchange format.
-* [spdlog](https://github.com/gabime/spdlog) - A sophisticated C++ logging library.

--- a/docs/contents/installation.md
+++ b/docs/contents/installation.md
@@ -10,6 +10,10 @@ This project requires C++20. The following compilers are tested in CI:
 | Clang    | 16 - 18         |
 | MSVC     | 14.50 / `_MSC_VER` 1950 (VS 2026) |
 
+!!! warning "Caution: GCC < 13 has a compiler bug"
+
+    GCC versions before 13 have a coroutine bug that causes **double-free errors** when a temporary containing heap-allocated fields (e.g. `std::string`) is used as a direct initializer in a `co_await` expression. This affects any API argument like structs passed to `Send()` or `Spawn()`. See [Known Issues](#known-issues-gcc-before-13) for details and workarounds.
+
 ## CMake Projects
 
 ### Use cmake package manager ([CPM](https://github.com/cpm-cmake/CPM.cmake)) (Recommended)
@@ -40,8 +44,11 @@ target_link_libraries(main ex_actor::ex_actor)
 
 ```
 
-**Highly recommend you to use `CPM_SOURCE_CACHE` environment variable to set a cache directory for CPM.cmake.**
-It's useful when you fail the download due to network issues, and want to retry again. With this you don't need to download the successfully downloaded package again.
+!!! Note
+
+    Highly recommend you to use `CPM_SOURCE_CACHE` env variable to set a cache directory for CPM.cmake,
+    e.g. `export CPM_SOURCE_CACHE=$HOME/.cache/CPM`.
+    It's useful when the downloading process fails/blocks due to network issues, and you want to retry again. With this you don't need to download the dependencies again and again.
 
 ### Use legacy install and find_package
 
@@ -183,3 +190,58 @@ All of them will be automatically downloaded and built from source, you don't ne
 We know it's a headache to resolve dependency conflicts, so we carefully choose minimal dependencies.
 If you meet any dependency conflict, either try to modify our version in CMakeLists.txt to match your project, or modify your version to match ours.
 Welcome to open an issue to let us know if you have any problem.
+
+## Known Issues: GCC before 13 { #known-issues-gcc-before-13 }
+
+GCC versions before 13 have a [coroutine bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107288) (duplicate of [bug 101367](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=101367), fixed by [r13-4479](https://gcc.gnu.org/cgit/gcc/commit/?id=58a7b1e354530d)) that causes **double-free errors** when a **temporary object containing heap-allocated data** (e.g. `std::string`) is used as a direct initializer in a `co_await` expression. 
+
+The bug is triggered when a **temporary struct** containing heap-allocated fields appears in a `co_await`-ed expression — regardless of whether the callee takes the argument by value or by const reference.
+
+Any API where a temporary containing heap-allocated fields is passed as an argument to a `co_await`-ed expression can trigger this. You can workaround it by assigning the temporary to a named variable first.
+e.g.:
+
+
+### Send / Spawn
+
+```cpp
+// BAD — double-free on GCC < 13
+co_await actor.Send<&MyActor::Process>(MyRequest{.name = "hello"});
+```
+
+```cpp
+// GOOD — works on all supported compilers
+MyRequest req{.name = "hello"};
+co_await actor.Send<&MyActor::Process>(std::move(req));
+```
+
+### Spawn().WithConfig()
+
+```cpp
+// BAD — double-free on GCC < 13
+auto actor = co_await Spawn<MyActor>().WithConfig({.actor_name = "my_actor"});
+```
+
+```cpp
+// GOOD — works on all supported compilers
+ex_actor::ActorConfig config{.actor_name = "my_actor"};
+auto actor = co_await Spawn<MyActor>().WithConfig(config);
+```
+
+### StartOrJoinCluster
+
+```cpp
+// BAD — double-free on GCC < 13
+co_await ex_actor::StartOrJoinCluster(ex_actor::ClusterConfig{
+    .listen_address = "tcp://127.0.0.1:5301",
+    .contact_node_address = "tcp://127.0.0.1:5302",
+});
+```
+
+```cpp
+// GOOD — works on all supported compilers
+ex_actor::ClusterConfig cluster_config{
+    .listen_address = "tcp://127.0.0.1:5301",
+    .contact_node_address = "tcp://127.0.0.1:5302",
+};
+co_await ex_actor::StartOrJoinCluster(cluster_config);
+```

--- a/docs/contents/tutorial.md
+++ b/docs/contents/tutorial.md
@@ -2,19 +2,18 @@
 
 The best way to learn a new library is to learn from examples, let's go through some examples and you'll learn all you want :)
 
-This framework is based on `std::execution`, but **it's fine if you are not familiar with it, the example is easy enough to understand**.
+This framework is based on [`std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html),
+but **it's fine if you are not familiar with it, the example is easy enough to understand**.
 
-std::execution is essentially an unified interface for schedulers and async tasks. It standardizes the interfaces so that everyone
-conforming the standard can use others' work seamlessly. Check [P2300 proposal](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html) and [stdexec's doc](https://github.com/NVIDIA/stdexec?tab=readme-ov-file#resources) if you want to learn more.
-
-Note: C++26 is not finalized now. Currently we're based on the early implementation of `std::execution` - [nvidia/stdexec](https://github.com/NVIDIA/stdexec), so you'll see namespace `stdexec` instead of `std::execution` in the following examples.
+Note: C++26 is not finalized now. Currently we're based on the early implementation of `std::execution` - [nvidia/stdexec](https://github.com/NVIDIA/stdexec),
+so you'll see namespace `stdexec` instead of `std::execution` in the following examples.
 
 ## Basic case - turn your class into an actor
 
 First let's go through a basic example - create your first actor and call it.
 
 Nearly all of our APIs are async, so let's put everything in a coroutine, then we can easily use `co_await` to wait for the result non-blockingly.
-Here we use [`std::execution::task`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3552r3.html), which is the standard coroutine type in `std::execution`.
+Here we use `std::execution::task`, which is the standard coroutine type in `std::execution`.
 
 <!-- doc test start -->
 ```cpp
@@ -228,7 +227,7 @@ int main() { stdexec::sync_wait(MainCoroutine()); }
 
 ## Execute multiple senders in parallel
 
-You can execute multiple senders in parallel using [`when_all`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html#design-sender-adaptor-when_all) or `simple_counting_scope` + `spawn`/`spawn_future` in std::execution.
+You can execute multiple senders in parallel using `when_all` or `simple_counting_scope` + `spawn`/`spawn_future` in std::execution.
 
 <!-- doc test start -->
 ```cpp

--- a/docs/doc_cli.py
+++ b/docs/doc_cli.py
@@ -2,37 +2,13 @@
 """Build or serve project documentation with mkdocs. Works on both Linux/macOS and Windows."""
 
 import argparse
-import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 docs_dir = Path(__file__).resolve().parent
 project_root = docs_dir.parent
 contents_dir = docs_dir / "contents"
-
-# Copy assets
-assets_dst = contents_dir / "assets"
-if assets_dst.exists():
-    shutil.rmtree(assets_dst)
-shutil.copytree(project_root / "assets", assets_dst)
-
-# Copy README.md -> contents/index.md
-index_md = contents_dir / "index.md"
-text = (project_root / "README.md").read_text(encoding="utf-8")
-text = "# Introduction\n" + text
-text = re.sub(
-    r"<!-- GITHUB README ONLY START -->.*?<!-- GITHUB README ONLY END -->",
-    "",
-    text,
-    flags=re.DOTALL,
-)
-index_md.write_text(text, encoding="utf-8")
-
-# Copy CONTRIBUTING.md -> contents/contributing.md
-contributing_md = contents_dir / "contributing.md"
-shutil.copy2(project_root / "CONTRIBUTING.md", contributing_md)
 
 parser = argparse.ArgumentParser(description="Build or serve project documentation.")
 parser.add_argument("command", choices=["serve", "build"])
@@ -45,18 +21,26 @@ DEPS = (
     "mkdocs-add-number-plugin,"
     "mkdocs-enumerate-headings-plugin,"
     "mkdocs-git-revision-date-localized-plugin,"
-    "mkdocs-git-committers-plugin-2"
+    "mkdocs-git-committers-plugin-2,"
+    "click<8.3"
 )
 
 if args.command == "serve":
     subprocess.run(
-        ["uvx", "--with", DEPS, "mkdocs", "serve", "-a", f"0.0.0.0:{args.port}"],
+        [
+            "uvx", "--python", "3.10", "--with", DEPS, "mkdocs", "serve",
+            "-a", f"0.0.0.0:{args.port}",
+            "--livereload",
+            "--watch", str(project_root / "README.md"),
+            "--watch", str(project_root / "CONTRIBUTING.md"),
+            "--watch", str(project_root / "assets"),
+        ],
         cwd=docs_dir,
         check=True,
     )
 elif args.command == "build":
     subprocess.run(
-        ["uvx", "--with", DEPS, "mkdocs", "build"],
+        ["uvx", "--python", "3.10", "--with", DEPS, "mkdocs", "build"],
         cwd=docs_dir,
         check=True,
     )

--- a/docs/hooks/copy_root_files.py
+++ b/docs/hooks/copy_root_files.py
@@ -1,0 +1,67 @@
+"""MkDocs hook: re-copy root files (README, CONTRIBUTING, assets) into docs/contents on each build.
+
+Only writes when content has actually changed, to avoid triggering infinite rebuild loops.
+"""
+
+import filecmp
+import re
+import shutil
+from pathlib import Path
+
+docs_dir = Path(__file__).resolve().parent.parent
+project_root = docs_dir.parent
+contents_dir = docs_dir / "contents"
+
+
+def _write_if_changed(path: Path, new_text: str) -> None:
+    if path.exists() and path.read_text(encoding="utf-8") == new_text:
+        return
+    path.write_text(new_text, encoding="utf-8")
+
+
+def _copy_if_changed(src: Path, dst: Path) -> None:
+    if dst.exists() and filecmp.cmp(src, dst, shallow=False):
+        return
+    shutil.copy2(src, dst)
+
+
+def _copytree_if_changed(src_dir: Path, dst_dir: Path) -> None:
+    """Sync src_dir into dst_dir, only writing files whose content differs."""
+    src_files = {p.relative_to(src_dir): p for p in src_dir.rglob("*") if p.is_file()}
+    dst_files = {p.relative_to(dst_dir): p for p in dst_dir.rglob("*") if p.is_file()} if dst_dir.exists() else {}
+
+    changed = False
+    for rel, src_path in src_files.items():
+        dst_path = dst_dir / rel
+        if rel in dst_files and filecmp.cmp(src_path, dst_path, shallow=False):
+            continue
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src_path, dst_path)
+        changed = True
+
+    # Remove files in dst that no longer exist in src
+    for rel in dst_files:
+        if rel not in src_files:
+            (dst_dir / rel).unlink()
+            changed = True
+
+    return changed
+
+
+def on_pre_build(**kwargs):
+    # Copy assets
+    _copytree_if_changed(project_root / "assets", contents_dir / "assets")
+
+    # Copy README.md -> contents/index.md
+    text = (project_root / "README.md").read_text(encoding="utf-8")
+    text = "# Introduction\n" + text
+    text = re.sub(
+        r"<!-- GITHUB README ONLY START -->.*?<!-- GITHUB README ONLY END -->",
+        "",
+        text,
+        flags=re.DOTALL,
+    )
+    _write_if_changed(contents_dir / "index.md", text)
+
+    # Copy CONTRIBUTING.md -> contents/contributing.md
+    _copy_if_changed(project_root / "CONTRIBUTING.md", contents_dir / "contributing.md")

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -69,6 +69,9 @@ plugins:
       repository: ex-actor/ex-actor
       branch: main
 
+hooks:
+  - hooks/copy_root_files.py
+
 markdown_extensions:
   - toc:
       toc_depth: 3

--- a/include/ex_actor/internal/actor_config.h
+++ b/include/ex_actor/internal/actor_config.h
@@ -30,19 +30,9 @@ struct ActorConfig {
   /**
    * @brief Actor's name, should be unique within one node.
    *
-   * @note Before gcc 13, we can't use heap-allocated temp variable after co_await, or there will be a double free
-   * error. here actor_name is heap allocated. so when using ActorConfig with actor_name, we should define it
-   * explicitly.
-   *
-   * i.e. you can't `co_await Spawn<X>().WithConfig({.actor_name = "xxx"})` directly with a temporary config
-   * containing heap-allocated fields, instead, you should define a separate named variable for the config:
-   *
-   * @code
-   * ex_actor::ActorConfig config {.actor_name = "xxx"};
-   * auto actor = co_await Spawn<X>().WithConfig(config);
-   * @endcode
-   *
-   * see gcc's bug report: https://gcc.gnu.org/pipermail/gcc-bugs/2022-October/800402.html
+   * @note GCC < 13 has a coroutine bug that double-frees temporaries containing heap-allocated fields
+   * (like this std::optional<std::string>) in co_await expressions. Assign to a named variable first.
+   * See docs/contents/installation.md "Known Issues: GCC before 13" for details and workarounds.
    */
   std::optional<std::string> actor_name;
 

--- a/test/basic_api_test.cc
+++ b/test/basic_api_test.cc
@@ -114,19 +114,8 @@ TEST(BasicApiTest, NestActorRefCase) {
 
 TEST(BasicApiTest, SpawnWithFullConfig) {
   auto coroutine = []() -> stdexec::task<void> {
-    /*
-    before gcc 13, we can't use heap-allocated temp variable after co_await, or there will be a double free error.
-    here actor_name is heap allocated. so when using ActorConfig with actor_name, we should define it explicitly.
-
-    i.e. you can't `co_await Spawn<X>().WithConfig({.actor_name = "A"})` with a temporary config containing
-    heap-allocated fields, instead, you should define a separate named variable for the config:
-    ```cpp
-    ex_actor::ActorConfig a_config {.actor_name = "A"};
-    auto remote_a = co_await registry.Spawn<&A::Create>().WithConfig(a_config);
-    ```
-
-    see https://gcc.gnu.org/pipermail/gcc-bugs/2022-October/800402.html
-    */
+    // GCC < 13 workaround: assign configs with heap-allocated fields to named variables before co_await.
+    // See docs/contents/installation.md "Known Issues: GCC before 13".
     ex_actor::ActorConfig config1 {.max_message_executed_per_activation = 10, .actor_name = "counter1"};
     auto counter = co_await ex_actor::Spawn<Counter>().WithConfig(config1);
 

--- a/test/distributed_test.cc
+++ b/test/distributed_test.cc
@@ -219,19 +219,8 @@ TEST(DistributedTest, ConstructionInDistributedMode) {
     EXPECT_EQ(self_reply, "ack from Self, msg got: hi");
 
     logging::Info("node {} creating remote actor A", index);
-    /*
-    before gcc 13, we can't use heap-allocated temp variable after co_await, or there will be a double free error.
-    here actor_name is heap allocated. so when using ActorConfig with actor_name, we should define it explicitly.
-
-    i.e. you can't `co_await Spawn<X>().WithConfig({.actor_name = "A"})` with a temporary config containing
-    heap-allocated fields, instead, you should define a separate named variable for the config:
-    ```cpp
-    ex_actor::ActorConfig a_config {.actor_name = "A"};
-    auto remote_a = co_await registry.Spawn<&A::Create>().ToNode(remote_node_id).WithConfig(a_config);
-    ```
-
-    see https://gcc.gnu.org/pipermail/gcc-bugs/2022-October/800402.html
-    */
+    // GCC < 13 workaround: assign configs with heap-allocated fields to named variables before co_await.
+    // See docs/contents/installation.md "Known Issues: GCC before 13".
     ex_actor::ActorConfig a_config {.actor_name = "A"};
     auto remote_a = co_await registry.Spawn<&A::Create>().ToNode(remote_node_id).WithConfig(a_config);
 


### PR DESCRIPTION
- **Document GCC < 13 coroutine double-free bug**: Add a warning banner at the top of the compiler requirements table and a new "Known Issues: GCC before 13" section to `installation.md`, with code examples showing the broken pattern and the workaround for `ActorConfig` and `ClusterConfig`.
- **Clean up tutorial links**: Remove verbose inline hyperlinks in `tutorial.md` (for `std::execution::task`, `when_all`, and the P2300 intro paragraph) to improve readability, while keeping the main `std::execution` reference link.
- Also refactor `doc_cli.py`: move root-file copying into an MkDocs `on_pre_build` hook for proper livereload support, and pin `python 3.10` / `click<8.3` for build compatibility.
