### PR TITLE
[fix] Add TSAN suppression for libstdc++ exception_ptr false positive

### DIFF
--- a/test/tsan_suppression.txt
+++ b/test/tsan_suppression.txt
@@ -7,8 +7,12 @@ race:zmq::
 # rethrow_exception/current_exception/__cxa_end_catch are compiled into libstdc++.so
 # WITHOUT -fsanitize=thread, so TSAN cannot see their acquire/release atomic refcount
 # operations. This causes false data-race reports when an exception_ptr crosses threads
-# (e.g. via stdexec's affine_on/finally sender chain).
+# via stdexec's affine_on/finally sender chain.
 # See https://stackoverflow.com/q/37587096
-# Matches only functions whose demangled name contains __exception_ptr (i.e. the
-# stdexec template instantiations that carry std::__exception_ptr::exception_ptr).
-race:__exception_ptr
+# Note: we cannot suppress the actual uninstrumented symbols (_M_release, _M_addref,
+# std::rethrow_exception, etc.) because they don't appear as named frames in the TSAN
+# stack -- they resolve to <null> library offsets. Instead we target stdexec::__final::,
+# which is the specific sender adaptor handling cross-thread completion forwarding in
+# affine_on. This is narrower than matching __exception_ptr (which would hit every
+# template instantiation carrying exception_ptr as a type parameter).
+race:stdexec::__final::

--- a/test/tsan_suppression.txt
+++ b/test/tsan_suppression.txt
@@ -9,10 +9,9 @@ race:zmq::
 # operations. This causes false data-race reports when an exception_ptr crosses threads
 # via stdexec's affine_on/finally sender chain.
 # See https://stackoverflow.com/q/37587096
-# Note: we cannot suppress the actual uninstrumented symbols (_M_release, _M_addref,
-# std::rethrow_exception, etc.) because they don't appear as named frames in the TSAN
-# stack -- they resolve to <null> library offsets. Instead we target stdexec::__final::,
-# which is the specific sender adaptor handling cross-thread completion forwarding in
-# affine_on. This is narrower than matching __exception_ptr (which would hit every
-# template instantiation carrying exception_ptr as a type parameter).
-race:stdexec::__final::
+# We target __exception_ptr which appears in the demangled names of instrumented
+# callers (e.g. as a template parameter in stdexec receivers) -- the actual
+# uninstrumented libstdc++ symbols (_M_release, _M_addref, std::rethrow_exception)
+# don't show up as named frames in the TSAN stack, so this is the most precise
+# pattern available without over-suppressing unrelated stdexec logic.
+race:__exception_ptr

--- a/test/tsan_suppression.txt
+++ b/test/tsan_suppression.txt
@@ -2,3 +2,13 @@
 
 # zmq false positive
 race:zmq::
+
+# libstdc++ exception_ptr false positive: _M_addref/_M_release (in eh_ptr.cc) and
+# rethrow_exception/current_exception/__cxa_end_catch are compiled into libstdc++.so
+# WITHOUT -fsanitize=thread, so TSAN cannot see their acquire/release atomic refcount
+# operations. This causes false data-race reports when an exception_ptr crosses threads
+# (e.g. via stdexec's affine_on/finally sender chain).
+# See https://stackoverflow.com/q/37587096
+# Matches only functions whose demangled name contains __exception_ptr (i.e. the
+# stdexec template instantiations that carry std::__exception_ptr::exception_ptr).
+race:__exception_ptr


### PR DESCRIPTION
suppress a TSAN false positive in this job: https://github.com/ex-actor/ex-actor/actions/runs/24389243172/job/71230642154?pr=242

- Adds a narrow TSAN suppression (`race:__exception_ptr`) to fix false data-race reports in `distributed_test` when `exception_ptr` crosses threads via stdexec's `affine_on`/`finally` sender chain.
- Root cause: the system `libstdc++.so` is compiled without `-fsanitize=thread`, so TSAN cannot observe the acquire/release atomic refcount operations in `_M_addref`/`_M_release` (`eh_ptr.cc`), causing it to miss the happens-before relationship.
- The suppression pattern matches only demangled names containing `__exception_ptr`, keeping the scope tight to avoid masking real races.
