### PR TITLE
[feat] Add optional node_name to ClusterConfig for peer identification

### DIFF
--- a/docs/contents/distributed_mode.md
+++ b/docs/contents/distributed_mode.md
@@ -35,9 +35,12 @@ EXA_REMOTE(&PingWorker::Create, &PingWorker::Ping);
 
 stdexec::task<void> MainCoroutine(int argc, char** argv) {
   std::string listen_address = argv[1];
-  std::string contact_address = (argc > 2) ? argv[2] : "";
-  // 2. Init the framework, then start or join a cluster.
+  std::string node_name = argv[2];
+  std::string peer_node_name = argv[3];
+  std::string contact_address = (argc > 4) ? argv[4] : "";
+
   ex_actor::Init(/*thread_pool_size=*/4);
+  // 2. start or join a cluster.
   co_await ex_actor::StartOrJoinCluster(ex_actor::ClusterConfig {
       // The public address other nodes use to connect to you,
       // we'll open a listening port at this address.
@@ -45,18 +48,22 @@ stdexec::task<void> MainCoroutine(int argc, char** argv) {
       // If you're the first node of the cluster, leave this empty.
       // Otherwise, set to any node in the cluster to join.
       .contact_node_address = contact_address,
+      // Optional friendly name for this node.
+      .node_name = node_name,
   });
 
-  // 3. Wait for the cluster to reach your desired state.
+  // 3. Wait until the peer we care about has joined the cluster.
   auto [cluster_state, condition_met] = co_await ex_actor::WaitClusterState(
-      /*predicate=*/[](const ex_actor::ClusterState& state) {
-        return state.nodes.size() >= 2;
+      /*predicate=*/[&](const ex_actor::ClusterState& state) {
+        return std::ranges::any_of(state.nodes,
+            [&](const auto& n) { return n.node_name == peer_node_name; });
       },
       /*timeout_ms=*/5000);
   assert(condition_met);
 
-  // 4. Pick a remote node, here we pick the first node whose address differs from ours.
-  auto it = std::ranges::find_if(cluster_state.nodes, [&](const auto& n) { return n.address != listen_address; });
+  // 4. Look up the peer node by its user-defined name.
+  auto it = std::ranges::find_if(cluster_state.nodes,
+      [&](const auto& n) { return n.node_name == peer_node_name; });
   auto remote_node_id = it->node_id;
 
   // 5. Create actor at remote node and play!
@@ -67,9 +74,9 @@ stdexec::task<void> MainCoroutine(int argc, char** argv) {
   assert(ping_res == "ack from Alice, msg got: hello");
   std::cout << "All work done" << std::endl;
 
-  // 6. Wait for OS exit signal(like CTRL+C or kill) before shutting down, otherwise the process
-  // will exit immediately, which might be earlier than the other node finishes its work,
-  // causing error in the other node.
+
+  // helper function to wait for OS exit signal(like CTRL+C or kill) before shutting down, otherwise the process
+  // might exit earlier than the peer node finishes its work, causing error in the peer node.
   co_await ex_actor::WaitOsExitSignal();
   ex_actor::Shutdown();
 }
@@ -87,13 +94,13 @@ int main(int argc, char** argv) { stdexec::sync_wait(MainCoroutine(argc, argv));
 Compile this program into a binary, let's say `distributed_node`.
 
 ```bash
-# usage: `./distributed_node <listen_address> [contact_address]`
+# usage: `./distributed_node <listen_address> <node_name> <peer_node_name> [contact_address]`
 
 # in one shell
-./distributed_node tcp://127.0.0.1:5301
+./distributed_node tcp://127.0.0.1:5301 node0 node1
 
 # in another shell
-./distributed_node tcp://127.0.0.1:5302 tcp://127.0.0.1:5301
+./distributed_node tcp://127.0.0.1:5302 node1 node0 tcp://127.0.0.1:5301
 ```
 
 Both processes should print "All work done" log.
@@ -150,7 +157,5 @@ we can take advantage of a schemafull protocol. For this reason, we choose [Cap'
 ### Network
 
 We choose [ZeroMQ](https://zeromq.org/), it's a well-known and sophisticated message passing library.
-
-The topology is a full mesh. Each node holds one receive DEALER socket bound locally and several send DEALER sockets connected to other nodes.
 
 The node states are synchronized via gossip protocol, no centralized coordination node.

--- a/include/ex_actor/internal/message.h
+++ b/include/ex_actor/internal/message.h
@@ -116,6 +116,7 @@ struct NodeState {
   uint64_t last_seen_timestamp_ms = 0;
   uint64_t node_id = 0;
   std::string address;
+  std::string node_name;
 };
 
 struct BrokerGossipMessage {

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -50,11 +50,15 @@ struct ClusterConfig {
   std::string listen_address;
   std::string contact_node_address;
   NetworkConfig network_config;
+  // Optional user-defined name for this node. Free-form, not required to be unique.
+  // Surfaced on NodeInfo so users can identify nodes in WaitClusterState predicates.
+  std::string node_name;
 };
 
 struct NodeInfo {
   uint64_t node_id = 0;
   std::string address;
+  std::string node_name;
 };
 
 // now it only has one field, but we keep it as a separate struct for future extensibility

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -154,8 +154,10 @@ void PeriodicalTaskScheduler::Loop(const std::stop_token& stop_token) {
 MessageBroker::MessageBroker(uint64_t this_node_id, ClusterConfig cluster_config)
     : this_node_id_(this_node_id), cluster_config_(std::move(cluster_config)) {
   EXA_THROW_CHECK(!cluster_config_.listen_address.empty()) << "listen_address must not be empty";
-  node_id_to_state_[this_node_id_] = {
-      .last_seen_timestamp_ms = GetTimeMs(), .node_id = this_node_id_, .address = cluster_config_.listen_address};
+  node_id_to_state_[this_node_id_] = {.last_seen_timestamp_ms = GetTimeMs(),
+                                      .node_id = this_node_id_,
+                                      .address = cluster_config_.listen_address,
+                                      .node_name = cluster_config_.node_name};
   if (!cluster_config_.contact_node_address.empty()) {
     EXA_THROW_CHECK_NE(cluster_config_.contact_node_address, cluster_config_.listen_address);
     contact_node_send_socket_ = zmq::socket_t(zmq_context_, zmq::socket_type::dealer);
@@ -385,6 +387,9 @@ void MessageBroker::HandleGossipMessage(const BrokerGossipMessage& gossip_messag
     EXA_THROW_CHECK_EQ(cur_node_state.address, incoming_node_state.address)
         << fmt_lib::format("Node {:#x} has conflicting address, {} vs {}.", cur_node_state.node_id,
                            cur_node_state.address, incoming_node_state.address);
+    EXA_THROW_CHECK_EQ(cur_node_state.node_name, incoming_node_state.node_name)
+        << fmt_lib::format("Node {:#x} has conflicting node_name, {} vs {}.", cur_node_state.node_id,
+                           cur_node_state.node_name, incoming_node_state.node_name);
     cur_node_state.last_seen_timestamp_ms =
         std::max(cur_node_state.last_seen_timestamp_ms, incoming_node_state.last_seen_timestamp_ms);
   }
@@ -502,7 +507,7 @@ std::vector<NodeInfo> MessageBroker::BuildAliveNodeInfoList() const {
   std::vector<NodeInfo> result;
   result.reserve(node_id_to_state_.size());
   for (const auto& [node_id, state] : node_id_to_state_) {
-    result.push_back(NodeInfo {.node_id = node_id, .address = state.address});
+    result.push_back(NodeInfo {.node_id = node_id, .address = state.address, .node_name = state.node_name});
   }
   return result;
 }

--- a/test/multi_process_test.cc
+++ b/test/multi_process_test.cc
@@ -20,27 +20,34 @@ class PingWorker {
 };
 EXA_REMOTE(&PingWorker::CreateFn, &PingWorker::Ping);
 
-// Usage: <binary> <listen_address> [contact_address]
+// Usage: <binary> <listen_address> <node_name> <peer_node_name> [contact_address]
 stdexec::task<void> MainCoroutine(int argc, char** argv) {
+  EXA_THROW_CHECK(argc >= 4) << "Usage: <binary> <listen_address> <node_name> <peer_node_name> [contact_address]";
   auto shared_pool = std::make_shared<ex_actor::WorkSharingThreadPool>(4);
   std::string listen_address = argv[1];
-  std::string contact_address = (argc > 2) ? argv[2] : "";
+  std::string node_name = argv[2];
+  std::string peer_node_name = argv[3];
+  std::string contact_address = (argc > 4) ? argv[4] : "";
   ex_actor::ClusterConfig cluster_config {
       .listen_address = listen_address,
       .contact_node_address = contact_address,
       .network_config = {.heartbeat_timeout_ms = 5000},
+      .node_name = node_name,
   };
   ex_actor::Init(shared_pool->GetScheduler());
   co_await ex_actor::StartOrJoinCluster(cluster_config);
   ex_actor::HoldResource(shared_pool);
 
-  auto [cluster_state, condition_met] =
-      co_await ex_actor::WaitClusterState([](const auto& state) { return state.nodes.size() >= 2; },
-                                          /*timeout_ms=*/5000);
-  EXA_THROW_CHECK(condition_met) << "Cannot connect to any remote node";
+  auto [cluster_state, condition_met] = co_await ex_actor::WaitClusterState(
+      [&](const auto& state) {
+        return std::ranges::any_of(state.nodes, [&](const auto& n) { return n.node_name == peer_node_name; });
+      },
+      /*timeout_ms=*/5000);
+  EXA_THROW_CHECK(condition_met) << "Cannot find peer node with name " << peer_node_name;
 
-  auto it = std::ranges::find_if(cluster_state.nodes, [&](const auto& n) { return n.address != listen_address; });
-  EXA_THROW_CHECK(it != cluster_state.nodes.end()) << "Cannot find any remote node";
+  auto it = std::ranges::find_if(cluster_state.nodes,
+                                 [&](const auto& n) { return n.node_name == peer_node_name; });
+  EXA_THROW_CHECK(it != cluster_state.nodes.end()) << "Cannot find peer node with name " << peer_node_name;
   auto remote_node_id = it->node_id;
 
   auto ping_worker = co_await ex_actor::Spawn<&PingWorker::CreateFn>(/*name=*/"Alice").ToNode(remote_node_id);

--- a/test/multi_process_test.py
+++ b/test/multi_process_test.py
@@ -15,11 +15,11 @@ ADDR0 = "tcp://127.0.0.1:5301"
 ADDR1 = "tcp://127.0.0.1:5302"
 
 log_file0 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")
-node0 = subprocess.Popen([argv[1], ADDR0], stdout=log_file0, stderr=subprocess.STDOUT)
+node0 = subprocess.Popen([argv[1], ADDR0, "node0", "node1"], stdout=log_file0, stderr=subprocess.STDOUT)
 log_file0.close()
 
 log_file1 = tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".log")
-node1 = subprocess.Popen([argv[1], ADDR1, ADDR0], stdout=log_file1, stderr=subprocess.STDOUT)
+node1 = subprocess.Popen([argv[1], ADDR1, "node1", "node0", ADDR0], stdout=log_file1, stderr=subprocess.STDOUT)
 log_file1.close()
 
 

--- a/test/network_test.cc
+++ b/test/network_test.cc
@@ -250,6 +250,80 @@ TEST(MessageBrokerTest, GossipWithConflictingAddressThrows) {
 }
 
 // ============================================================
+// node_name: surfaced on self NodeInfo
+// ============================================================
+
+TEST(MessageBrokerTest, NodeNameFromConfigAppearsOnSelfNodeInfo) {
+  auto config = MakeConfig("tcp://127.0.0.1:7265");
+  config.node_name = "master";
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  auto [result] = stdexec::sync_wait(broker.WaitClusterState(
+                                         [](const ex_actor::ClusterState& state) {
+                                           return std::ranges::any_of(state.nodes, [](const ex_actor::NodeInfo& n) {
+                                             return n.node_id == 0 && n.node_name == "master";
+                                           });
+                                         },
+                                         /*timeout_ms=*/10))
+                      .value();
+  EXPECT_TRUE(result.condition_met);
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
+// node_name: propagated via gossip onto peer NodeInfo
+// ============================================================
+
+TEST(MessageBrokerTest, NodeNameFromGossipAppearsOnPeerNodeInfo) {
+  auto config = MakeConfig("tcp://127.0.0.1:7266");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = 99999,
+                           .node_id = 1,
+                           .address = "tcp://127.0.0.1:7267",
+                           .node_name = "worker-1"}});
+
+  auto [result] = stdexec::sync_wait(broker.WaitClusterState(
+                                         [](const ex_actor::ClusterState& state) {
+                                           return std::ranges::any_of(state.nodes, [](const ex_actor::NodeInfo& n) {
+                                             return n.node_id == 1 && n.node_name == "worker-1";
+                                           });
+                                         },
+                                         /*timeout_ms=*/10))
+                      .value();
+  EXPECT_TRUE(result.condition_met);
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
+// HandleGossipMessage: conflicting node_name for same node_id throws
+// ============================================================
+
+TEST(MessageBrokerTest, GossipWithConflictingNodeNameThrows) {
+  auto config = MakeConfig("tcp://127.0.0.1:7268");
+  ex_actor::internal::MessageBroker broker(/*this_node_id=*/0, config);
+
+  DispatchGossip(broker, {{.last_seen_timestamp_ms = 100,
+                           .node_id = 1,
+                           .address = "tcp://127.0.0.1:7269",
+                           .node_name = "worker-1"}});
+
+  EXPECT_THAT(
+      [&]() {
+        DispatchGossip(broker, {{.last_seen_timestamp_ms = 100,
+                                 .node_id = 1,
+                                 .address = "tcp://127.0.0.1:7269",
+                                 .node_name = "worker-2"}});
+      },
+      testing::Throws<std::exception>(
+          testing::Property(&std::exception::what, testing::HasSubstr("Node 0x1 has conflicting node_name"))));
+
+  stdexec::sync_wait(broker.Stop());
+}
+
+// ============================================================
 // CheckHeartbeatTimeout: deactivates timed-out nodes
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Add optional `node_name` field to `ClusterConfig` and surface it on `NodeInfo`. The value is gossiped cluster-wide so users can identify and locate peers by a friendly name in `WaitClusterState` predicates instead of matching by address.
- Update `docs/contents/distributed_mode.md` tutorial and `multi_process_test` to demonstrate locating peers by `node_name`.

closes https://github.com/ex-actor/ex-actor/issues/232

## Test plan

- [x] New unit tests in `network_test.cc`:
  - `NodeNameFromConfigAppearsOnSelfNodeInfo`
  - `NodeNameFromGossipAppearsOnPeerNodeInfo`
  - `GossipWithConflictingNodeNameThrows`
- [x] Updated `multi_process_test` (C++ + Python driver) exercises the new `node_name`-based peer lookup end-to-end.
