### PR TITLE
[fix] Add macOS CI baseline and fix macOS toolchain settings

### DIFF
--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -32,6 +32,8 @@ jobs:
         build_type: [RelWithDebInfo]
         toolchain:
           - { os: windows-2025-vs2026, compiler: { cc: cl, cpp: cl } }
+          # macOS baseline
+          - { os: macos-15, compiler: { cc: clang, cpp: clang++ }, cxxflags: "-mmacosx-version-min=11.0" }
           # GCC versions
           - { os: ubuntu-24.04, compiler: { cc: gcc-11, cpp: g++-11 } }
           - { os: ubuntu-24.04, compiler: { cc: gcc-12, cpp: g++-12 } }

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -26,6 +26,7 @@ jobs:
       # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
       # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
       # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      # 4. <Macos, Release, latest Clang compiler toolchain on the default runner image, default generator>
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
@@ -33,7 +34,7 @@ jobs:
         toolchain:
           - { os: windows-2025-vs2026, compiler: { cc: cl, cpp: cl } }
           # macOS baseline
-          - { os: macos-15, compiler: { cc: clang, cpp: clang++ }, cxxflags: "-mmacosx-version-min=11.0" }
+          - { os: macos-15, compiler: { cc: clang, cpp: clang++ }, osx_deployment_target: "11.0" }
           # GCC versions
           - { os: ubuntu-24.04, compiler: { cc: gcc-11, cpp: g++-11 } }
           - { os: ubuntu-24.04, compiler: { cc: gcc-12, cpp: g++-12 } }
@@ -84,9 +85,12 @@ jobs:
           -B ${{ steps.strings.outputs.build-output-dir }}
           -DCMAKE_CXX_COMPILER=${{ matrix.toolchain.compiler.cpp }}
           -DCMAKE_C_COMPILER=${{ matrix.toolchain.compiler.cc }}
+          -DCMAKE_CXX_STANDARD=20
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON
           -DCMAKE_CXX_FLAGS="${{ matrix.toolchain.cxxflags }}"
           -DCMAKE_C_COMPILER_LAUNCHER=${{ runner.os == 'Windows' && 'sccache' || 'ccache' }}
           -DCMAKE_CXX_COMPILER_LAUNCHER=${{ runner.os == 'Windows' && 'sccache' || 'ccache' }}
+          ${{ matrix.toolchain.osx_deployment_target && format('-DCMAKE_OSX_DEPLOYMENT_TARGET={0}', matrix.toolchain.osx_deployment_target) || '' }}
           ${{ runner.os == 'Windows' && '-DCMAKE_POLICY_DEFAULT_CMP0141=NEW -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded' || '' }}
           -G "Ninja Multi-Config"
 

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -102,9 +102,17 @@ jobs:
         working-directory: ${{ steps.strings.outputs.build-output-dir }}
         # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-        if: runner.os != 'Windows'
+        if: runner.os == 'Linux'
         run: >
           TSAN_OPTIONS=suppressions=${{ github.workspace }}/test/tsan_suppression.txt
+          ctest --build-config ${{ matrix.build_type }} --output-on-failure
+
+      - name: Test(macOS)
+        working-directory: ${{ steps.strings.outputs.build-output-dir }}
+        # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        if: runner.os == 'macOS'
+        run: >
           ctest --build-config ${{ matrix.build_type }} --output-on-failure
 
       - name: Test(Windows)

--- a/.github/workflows/cmake_multi_platform.yml
+++ b/.github/workflows/cmake_multi_platform.yml
@@ -34,7 +34,7 @@ jobs:
         toolchain:
           - { os: windows-2025-vs2026, compiler: { cc: cl, cpp: cl } }
           # macOS baseline
-          - { os: macos-15, compiler: { cc: clang, cpp: clang++ }, osx_deployment_target: "11.0" }
+          - { os: macos-26, compiler: { cc: clang, cpp: clang++ } }
           # GCC versions
           - { os: ubuntu-24.04, compiler: { cc: gcc-11, cpp: g++-11 } }
           - { os: ubuntu-24.04, compiler: { cc: gcc-12, cpp: g++-12 } }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,8 +112,8 @@ target_link_libraries(
 )
 # Link libatomic for 128-bit atomic operations (required by MPSC_queue's Tagged_ptr)
 # Some platforms (e.g. macOS) do not provide a standalone libatomic.
-check_library_exists(atomic __atomic_fetch_add_8 "" EX_ACTOR_HAS_LIBATOMIC)
-if(EX_ACTOR_HAS_LIBATOMIC)
+check_library_exists(atomic __atomic_compare_exchange_16 "" EX_ACTOR_HAS_LIBATOMIC_16)
+if(EX_ACTOR_HAS_LIBATOMIC_16)
   target_link_libraries(ex_actor PUBLIC atomic)
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 project(ex_actor VERSION 0.1)
 include(cmake/CPM.cmake)
 include(CMakePackageConfigHelpers)
+include(CheckLibraryExists)
 
 # ------------------- global setups -------------------
 set(CMAKE_CXX_STANDARD 20)
@@ -110,7 +111,9 @@ target_link_libraries(
   spdlog::spdlog
 )
 # Link libatomic for 128-bit atomic operations (required by MPSC_queue's Tagged_ptr)
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+# Some platforms (e.g. macOS) do not provide a standalone libatomic.
+check_library_exists(atomic __atomic_fetch_add_8 "" EX_ACTOR_HAS_LIBATOMIC)
+if(EX_ACTOR_HAS_LIBATOMIC)
   target_link_libraries(ex_actor PUBLIC atomic)
 endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")


### PR DESCRIPTION
### Summary

- add a **macOS-15** baseline job in `cmake_multi_platform.yml`

- guard libatomic linkage with `check_library_exists` to avoid macOS link failures

- keep Linux/Windows behavior unchanged while enabling macOS builds

### Linked Issues
[#250](https://github.com/ex-actor/ex-actor/issues/250#issue-4313164365)