### PR TITLE
[fix] workaround ZMQ bug on macOS

### DIFF
--- a/include/ex_actor/internal/constants.h
+++ b/include/ex_actor/internal/constants.h
@@ -44,6 +44,7 @@ inline T GetEnv(const char* name, T default_val) {
 }
 
 constexpr size_t kEmptyActorRefHashVal = 10086;
+constexpr uint64_t kContactSocketRebuildCooldownMs = 1000;
 
 // Env-configurable constants
 inline const uint64_t kDefaultHeartbeatTimeoutMs = GetEnv<uint64_t>("EXA_HEARTBEAT_TIMEOUT_MS", 10000);

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -251,6 +251,10 @@ class MessageBroker {
   // rate-limited so ZMQ has enough time to finish its own reconnect + handshake before we
   // wipe the socket. Set by ConnectContactSendSocket().
   uint64_t contact_node_send_socket_last_build_ms_ = 0;
+  // Whether a NodeState whose address matches `cluster_config_.contact_node_address` has
+  // been observed. Maintained by OnNodeAlive / OnNodeConnectionLost, consulted by
+  // BroadcastGossip to decide whether to rebuild `contact_node_send_socket_`.
+  bool contact_node_discovered_ = false;
   std::unordered_map<uint64_t, zmq::socket_t> node_id_to_send_socket_;
 
   BasicActorRef<MessageBroker> self_actor_ref_;

--- a/include/ex_actor/internal/network.h
+++ b/include/ex_actor/internal/network.h
@@ -195,6 +195,7 @@ class MessageBroker {
  private:
   void StartRecvSocketPuller();
   void StartPeriodicalTaskScheduler();
+  void ConnectContactSendSocket();
 
   std::vector<uint64_t> GetRandomPeers(size_t fanout);
 
@@ -240,8 +241,16 @@ class MessageBroker {
   std::mt19937_64 rng_ {std::random_device {}()};
 
   zmq::context_t zmq_context_ {/*io_threads_=*/1};
-  // connected at start, used for bootstrapping the network
+  // Connected at start and used for bootstrapping the network. On macOS we've observed
+  // that a DEALER connect() racing with the peer's bind() can finish the TCP handshake
+  // but silently skip the ZMTP handshake, leaving the socket stuck in a "connected but
+  // handshake never completes" state where outbound gossip is never delivered. See
+  // BroadcastGossip() for the recovery path.
   zmq::socket_t contact_node_send_socket_;
+  // Timestamp of the last (re)build of `contact_node_send_socket_`. Rebuilds are
+  // rate-limited so ZMQ has enough time to finish its own reconnect + handshake before we
+  // wipe the socket. Set by ConnectContactSendSocket().
+  uint64_t contact_node_send_socket_last_build_ms_ = 0;
   std::unordered_map<uint64_t, zmq::socket_t> node_id_to_send_socket_;
 
   BasicActorRef<MessageBroker> self_actor_ref_;

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -306,14 +306,7 @@ void MessageBroker::BroadcastGossip() {
     // handshake, leaving the socket "connected" to nothing. In that state every send is
     // enqueued into a dead pipe and the contact node never hears from us. Detect this by
     // checking whether any NodeState with the contact's address has reached us yet.
-    bool contact_discovered = false;
-    for (const auto& [node_id, state] : node_id_to_state_) {
-      if (state.address == cluster_config_.contact_node_address) {
-        contact_discovered = true;
-        break;
-      }
-    }
-    if (!contact_discovered &&
+    if (!contact_node_discovered_ &&
         GetTimeMs() - contact_node_send_socket_last_build_ms_ >= kContactSocketRebuildCooldownMs) {
       log::Info("[Gossip] Node {:#x} has not heard from contact {}, rebuilding contact socket", this_node_id_,
                 cluster_config_.contact_node_address);
@@ -440,6 +433,10 @@ void MessageBroker::OnNodeAlive(uint64_t node_id) {
   log::Info("[Gossip] Node {:#x} found node {:#x}, connecting to it at {}", this_node_id_, new_node.node_id,
             new_node.address);
 
+  if (new_node.address == cluster_config_.contact_node_address) {
+    contact_node_discovered_ = true;
+  }
+
   // Create send socket
   auto& socket = (node_id_to_send_socket_[new_node.node_id] = zmq::socket_t(zmq_context_, zmq::socket_type::dealer));
   socket.set(zmq::sockopt::linger, 0);
@@ -477,7 +474,13 @@ void MessageBroker::OnNodeConnectionLost(uint64_t node_id) {
     // this will wake up the coroutine and erase the iterator, don't use it after this
     request.sem.Acquire(1);
   }
-  node_id_to_state_.erase(node_id);
+  auto state_it = node_id_to_state_.find(node_id);
+  if (state_it != node_id_to_state_.end()) {
+    if (state_it->second.address == cluster_config_.contact_node_address) {
+      contact_node_discovered_ = false;
+    }
+    node_id_to_state_.erase(state_it);
+  }
   node_id_to_send_socket_.erase(node_id);
 
   // `deferred_replies_` should not be cleared.

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -160,10 +160,7 @@ MessageBroker::MessageBroker(uint64_t this_node_id, ClusterConfig cluster_config
                                       .node_name = cluster_config_.node_name};
   if (!cluster_config_.contact_node_address.empty()) {
     EXA_THROW_CHECK_NE(cluster_config_.contact_node_address, cluster_config_.listen_address);
-    contact_node_send_socket_ = zmq::socket_t(zmq_context_, zmq::socket_type::dealer);
-    contact_node_send_socket_.set(zmq::sockopt::linger, 0);
-    contact_node_send_socket_.set(zmq::sockopt::sndhwm, 0);
-    contact_node_send_socket_.connect(cluster_config_.contact_node_address);
+    ConnectContactSendSocket();
   }
 }
 
@@ -304,6 +301,18 @@ void MessageBroker::BroadcastGossip() {
   }
   // no matter the contact node is in `node_id_to_state_` or not, we always send a copy to it
   if (contact_node_send_socket_.handle() != nullptr) {
+    // On macOS, if `contact_node_send_socket_` was connected before the contact node
+    // bound its listener, ZMQ can complete the TCP handshake but silently skip the ZMTP
+    // handshake, leaving the socket "connected" to nothing. In that state every send is
+    // enqueued into a dead pipe and the node stays isolated. Detect this by checking
+    // whether we've been discovered by anyone yet -- if we still only know ourselves,
+    // rebuild the socket to force a fresh connection attempt.
+    if (node_id_to_state_.size() == 1 &&
+        GetTimeMs() - contact_node_send_socket_last_build_ms_ >= kContactSocketRebuildCooldownMs) {
+      log::Info("[Gossip] Node {:#x} not yet discovered by any peer, rebuilding contact socket to {}", this_node_id_,
+                cluster_config_.contact_node_address);
+      ConnectContactSendSocket();
+    }
     ZmqSendOrDie(contact_node_send_socket_, ByteBufferToZmqBuffer(serialized));
   }
 }
@@ -372,6 +381,14 @@ void MessageBroker::StartPeriodicalTaskScheduler() {
                   async_scope_.get_token());
       },
       kDefaultWaiterExpirationCheckIntervalMs);
+}
+
+void MessageBroker::ConnectContactSendSocket() {
+  contact_node_send_socket_ = zmq::socket_t(zmq_context_, zmq::socket_type::dealer);
+  contact_node_send_socket_.set(zmq::sockopt::linger, 0);
+  contact_node_send_socket_.set(zmq::sockopt::sndhwm, 0);
+  contact_node_send_socket_.connect(cluster_config_.contact_node_address);
+  contact_node_send_socket_last_build_ms_ = GetTimeMs();
 }
 
 void MessageBroker::HandleGossipMessage(const BrokerGossipMessage& gossip_message) {

--- a/src/ex_actor/internal/network.cc
+++ b/src/ex_actor/internal/network.cc
@@ -304,12 +304,18 @@ void MessageBroker::BroadcastGossip() {
     // On macOS, if `contact_node_send_socket_` was connected before the contact node
     // bound its listener, ZMQ can complete the TCP handshake but silently skip the ZMTP
     // handshake, leaving the socket "connected" to nothing. In that state every send is
-    // enqueued into a dead pipe and the node stays isolated. Detect this by checking
-    // whether we've been discovered by anyone yet -- if we still only know ourselves,
-    // rebuild the socket to force a fresh connection attempt.
-    if (node_id_to_state_.size() == 1 &&
+    // enqueued into a dead pipe and the contact node never hears from us. Detect this by
+    // checking whether any NodeState with the contact's address has reached us yet.
+    bool contact_discovered = false;
+    for (const auto& [node_id, state] : node_id_to_state_) {
+      if (state.address == cluster_config_.contact_node_address) {
+        contact_discovered = true;
+        break;
+      }
+    }
+    if (!contact_discovered &&
         GetTimeMs() - contact_node_send_socket_last_build_ms_ >= kContactSocketRebuildCooldownMs) {
-      log::Info("[Gossip] Node {:#x} not yet discovered by any peer, rebuilding contact socket to {}", this_node_id_,
+      log::Info("[Gossip] Node {:#x} has not heard from contact {}, rebuilding contact socket", this_node_id_,
                 cluster_config_.contact_node_address);
       ConnectContactSendSocket();
     }


### PR DESCRIPTION
## Summary
- `dynamic_connectivity_star_test` flaked on macOS (~20% failure rate) because `contact_node_send_socket_` could get stuck in a "TCP-connected, ZMTP-silent" state when its `connect()` raced with the contact node's `bind()`. Every gossip `send()` then enqueued into a dead pipe and the node stayed isolated.
- Root cause confirmed via `zmq_socket_monitor`: failing runs showed `CONNECT_DELAYED` + `CONNECTED` but **no** `HANDSHAKE_SUCCEEDED` on the stuck socket (see screenshot below).
- Fix: in `BroadcastGossip`, if we still only know ourselves (`node_id_to_state_.size() == 1`), no peer has discovered us yet — the contact socket must be wedged, so rebuild it before sending. The retry keeps firing every gossip tick until the handshake succeeds.

```
7 CONNECT_DELAYED
7 CONNECTED
6 HANDSHAKE_SUCCEEDED   <-- one node stuck
```

## Test plan
- [x] Reproduced the original flake (run 4 of 20 on unpatched code)
- [x] 100/100 consecutive `dynamic_connectivity_star_test` passes on macOS
- [x] 50/50 `dynamic_connectivity_chain_test` passes on macOS
- [x] Full `ctest -C Release` suite green (19/19)