### PR TITLE
[feat] Support heterogeneous scheduler types in SchedulerUnion

### DIFF
--- a/docs/contents/schedulers.md
+++ b/docs/contents/schedulers.md
@@ -137,11 +137,9 @@ struct TestActor {
 stdexec::task<void> MainCoroutine() {
   // 1. create two thread pools
   ex_actor::WorkSharingThreadPool thread_pool1(1);
-  ex_actor::WorkSharingThreadPool thread_pool2(1);
+  ex_actor::PriorityThreadPool thread_pool2(1);
   // 2. create a scheduler union, union two schedulers into one.
-  ex_actor::SchedulerUnion scheduler_union(std::vector<ex_actor::WorkSharingThreadPool::Scheduler> {
-    thread_pool1.GetScheduler(), thread_pool2.GetScheduler()
-  });
+  ex_actor::SchedulerUnion scheduler_union(thread_pool1.GetScheduler(), thread_pool2.GetScheduler());
   // 3. initialize the runtime with the scheduler union
   ex_actor::Init(scheduler_union.GetScheduler());
   // 4. create two actors, specify the scheduler index using .WithConfig().

--- a/include/ex_actor/internal/scheduler.h
+++ b/include/ex_actor/internal/scheduler.h
@@ -15,6 +15,9 @@
 #pragma once
 
 #include <thread>
+#include <tuple>
+#include <utility>
+#include <variant>
 
 #include <exec/static_thread_pool.hpp>
 
@@ -163,18 +166,19 @@ class WorkStealingThreadPool : public exec::static_thread_pool {
   auto GetScheduler() { return get_scheduler(); }
 };
 
-template <class InnerScheduler>
+template <class... Schedulers>
 class SchedulerUnion {
- public:
-  explicit SchedulerUnion(std::vector<InnerScheduler> schedulers, size_t default_scheduler_index = 0)
-      : schedulers_(std::move(schedulers)), default_scheduler_index_(default_scheduler_index) {
-    EXA_THROW_CHECK_GT(schedulers_.size(), 0) << "SchedulerUnion must have at least one scheduler";
-  }
+  static_assert(sizeof...(Schedulers) > 0, "SchedulerUnion must have at least one scheduler");
 
-  class Scheduler;
-  class Sender;
+ public:
+  template <class... Args>
+    requires(sizeof...(Args) == sizeof...(Schedulers))
+  explicit SchedulerUnion(Args&&... schedulers) : schedulers_(std::forward<Args>(schedulers)...) {}
+
+  struct Scheduler;
+  struct Sender;
   template <ex::receiver R>
-  class Operation;
+  struct Operation;
 
   Scheduler GetScheduler() { return Scheduler {.scheduler_union = this}; }
 
@@ -183,6 +187,16 @@ class SchedulerUnion {
     Sender schedule() const noexcept { return {.scheduler_union = scheduler_union}; }
     friend bool operator==(const Scheduler& lhs, const Scheduler& rhs) noexcept {
       return lhs.scheduler_union == rhs.scheduler_union;
+    }
+  };
+
+  template <ex::receiver R>
+  struct Operation {
+    using Variant = std::variant<decltype(std::declval<Schedulers&>().schedule().connect(std::declval<R>()))...>;
+    Variant inner;
+
+    void start() noexcept {
+      std::visit([](auto& inner_op) noexcept { inner_op.start(); }, inner);
     }
   };
 
@@ -199,17 +213,33 @@ class SchedulerUnion {
     };
     auto get_env() const noexcept -> Env { return Env {.scheduler_union = scheduler_union}; }
 
-    auto connect(ex::receiver auto receiver) {
+    template <ex::receiver R>
+    auto connect(R receiver) -> Operation<R> {
       auto env = ex::get_env(receiver);
-      auto scheduler_index = ex_actor::get_scheduler_index(env);
-      EXA_THROW_CHECK_LT(scheduler_index, scheduler_union->schedulers_.size()) << "Scheduler index out of range";
-      return scheduler_union->schedulers_[scheduler_index].schedule().connect(std::move(receiver));
+      size_t scheduler_index = ex_actor::get_scheduler_index(env);
+      EXA_THROW_CHECK_LT(scheduler_index, sizeof...(Schedulers)) << "Scheduler index out of range";
+      return BuildOperation<R>(std::move(receiver), scheduler_index, std::index_sequence_for<Schedulers...> {});
+    }
+
+   private:
+    template <ex::receiver R, size_t... kIndices>
+    Operation<R> BuildOperation(R receiver, size_t scheduler_index, std::index_sequence<kIndices...>) {
+      using Variant = typename Operation<R>::Variant;
+      using MakeFn = Variant (*)(SchedulerUnion*, R&&);
+      // Dispatch table: one entry per alternative. Each function moves the receiver exactly once.
+      static constexpr MakeFn kTable[sizeof...(Schedulers)] = {+[](SchedulerUnion* self, R&& r) -> Variant {
+        return Variant {std::in_place_index<kIndices>,
+                        std::get<kIndices>(self->schedulers_).schedule().connect(std::move(r))};
+      }...};
+      return Operation<R> {.inner = kTable[scheduler_index](scheduler_union, std::move(receiver))};
     }
   };
 
  private:
-  std::vector<InnerScheduler> schedulers_;
-  size_t default_scheduler_index_;
+  std::tuple<Schedulers...> schedulers_;
 };
+
+template <class... Schedulers>
+SchedulerUnion(Schedulers...) -> SchedulerUnion<Schedulers...>;
 
 }  // namespace ex_actor

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -75,8 +75,7 @@ struct TestActor2 {
 TEST(SchedulerTest, SchedulerUnionTest) {
   ex_actor::WorkSharingThreadPool thread_pool1(1);
   ex_actor::WorkSharingThreadPool thread_pool2(1);
-  ex_actor::SchedulerUnion scheduler_union(std::vector<ex_actor::WorkSharingThreadPool::Scheduler> {
-      thread_pool1.GetScheduler(), thread_pool2.GetScheduler()});
+  ex_actor::SchedulerUnion scheduler_union(thread_pool1.GetScheduler(), thread_pool2.GetScheduler());
   auto scheduler = scheduler_union.GetScheduler();
   auto start = ex::schedule(scheduler) | ex::then([] { return std::this_thread::get_id(); });
 
@@ -101,12 +100,27 @@ TEST(SchedulerTest, SchedulerUnionTest) {
   ex_actor::Shutdown();
 }
 
+TEST(SchedulerTest, SchedulerUnionHeterogeneousTest) {
+  // Mix two different scheduler types to prove variadic SchedulerUnion works.
+  ex_actor::WorkSharingThreadPool ws_pool(1);
+  ex_actor::PriorityThreadPool prio_pool(1);
+  ex_actor::SchedulerUnion scheduler_union(ws_pool.GetScheduler(), prio_pool.GetScheduler());
+  auto scheduler = scheduler_union.GetScheduler();
+  auto start = ex::schedule(scheduler) | ex::then([] { return std::this_thread::get_id(); });
+
+  auto sender1 = start | ex::write_env(ex::prop {ex_actor::get_scheduler_index, 0});
+  auto sender2 = start | ex::write_env(ex::prop {ex_actor::get_scheduler_index, 1});
+  auto [thread_id1] = ex::sync_wait(sender1).value();
+  auto [thread_id2] = ex::sync_wait(sender2).value();
+  ASSERT_NE(thread_id1, thread_id2);
+}
+
 TEST(SchedulerTest, TestResourceHolder) {
   auto shared_pool1 = std::make_unique<ex_actor::WorkSharingThreadPool>(10);
   auto shared_pool2 = std::make_unique<ex_actor::WorkSharingThreadPool>(10);
-  auto union_pool = std::make_unique<ex_actor::SchedulerUnion<ex_actor::WorkSharingThreadPool::Scheduler>>(
-      std::vector<ex_actor::WorkSharingThreadPool::Scheduler> {shared_pool1->GetScheduler(),
-                                                               shared_pool2->GetScheduler()});
+  auto union_pool = std::make_unique<
+      ex_actor::SchedulerUnion<ex_actor::WorkSharingThreadPool::Scheduler, ex_actor::WorkSharingThreadPool::Scheduler>>(
+      shared_pool1->GetScheduler(), shared_pool2->GetScheduler());
   ex_actor::Init(union_pool->GetScheduler());
   ex_actor::HoldResource(std::move(shared_pool1));
   ex_actor::HoldResource(std::move(shared_pool2));


### PR DESCRIPTION
## Summary
- Change `SchedulerUnion<InnerScheduler>` to variadic `SchedulerUnion<Schedulers...>`, so a union can combine different scheduler types (e.g. `WorkSharingThreadPool::Scheduler` and `PriorityThreadPool::Scheduler`) instead of requiring a homogeneous `std::vector`.
- Storage becomes `std::tuple<Schedulers...>`. `connect()` bounds-checks the runtime `scheduler_index`, then dispatches through a static function-pointer table that constructs a `std::variant<InnerOp...>` via `std::in_place_index`; the wrapping `Operation::start()` uses `std::visit`. No virtual calls, no heap allocation.
- Drop the unused `default_scheduler_index_` field. Add a CTAD guide so `SchedulerUnion(a, b)` still deduces cleanly.

## Test plan
- [x] `ctest -R scheduler_test` passes locally (Release build).
- [x] Added `SchedulerTest.SchedulerUnionHeterogeneousTest` that mixes `WorkSharingThreadPool::Scheduler` and `PriorityThreadPool::Scheduler` in a single `SchedulerUnion` and confirms tasks route to the correct thread pool based on `scheduler_index`.
- [x] Existing `SchedulerUnionTest` and `TestResourceHolder` updated to the new variadic construction and still pass.
