### PR TITLE
[CI] exclude 3rd_lib from test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,8 +66,9 @@ jobs:
           gcovr --root ${{ github.workspace }} build \
             --gcov-executable gcov-14 \
             --exclude '/usr/.*' \
-            --exclude '.*/build/_deps/.*' \
-            --exclude '.*/test/.*' \
+            --exclude '(^|.*/)build/_deps/' \
+            --exclude '(^|.*/)test/' \
+            --exclude '(^|.*/)include/ex_actor/3rd_lib/' \
             --xml coverage.xml \
             --print-summary
 


### PR DESCRIPTION
Exclude build dependencies, test files, and vendored 3rd-party headers (`include/ex_actor/3rd_lib`) from coverage
