### PR TITLE
[CI] fix coverage filter to exclude test and 3rd_lib

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -65,10 +65,8 @@ jobs:
         run: |
           gcovr --root ${{ github.workspace }} build \
             --gcov-executable gcov-14 \
-            --exclude '/usr/.*' \
-            --exclude '(^|.*/)build/_deps/' \
-            --exclude '(^|.*/)test/' \
-            --exclude '(^|.*/)include/ex_actor/3rd_lib/' \
+            --filter 'src/' \
+            --filter 'include/ex_actor/(?!3rd_lib/)' \
             --xml coverage.xml \
             --print-summary
 


### PR DESCRIPTION
## Summary
- Switch gcovr from `--exclude` (denylist) to `--filter` (allowlist) to fix test/ and 3rd_lib/ still appearing in Codecov dashboard
- The `--exclude` regex wasn't matching resolved paths correctly; `--filter` only includes files we explicitly want (`src/` and `include/ex_actor/` minus `3rd_lib/`)

## Test plan
- [ ] Verify CI passes and coverage report only contains src/ and include/ex_actor/ files
- [ ] Check Codecov dashboard no longer shows test/ or 3rd_lib/ files

🤖 Generated with [Claude Code](https://claude.com/claude-code)