### PR TITLE
[CI] Add codecov.yml to exclude test and 3rd_lib from coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto
+
+ignore:
+  - "test/**"
+  - "include/ex_actor/3rd_lib/**"


### PR DESCRIPTION
Add `codecov.yml` configuration to exclude `test/` and `include/ex_actor/3rd_lib/` from coverage reporting