### PR TITLE
Make UserClass's constructor run on actor thread

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,2 @@
 [files]
-extend-exclude = ["include/ex_actor/3rd_lib/cppzmq/"]
+extend-exclude = ["include/ex_actor/3rd_lib/"]

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,9 +6,11 @@ coverage:
     project:
       default:
         target: auto
+        informational: true
     patch:
       default:
         target: auto
+        informational: true
 
 ignore:
   - "test/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+github_checks:
+  annotations: true
+
 coverage:
   status:
     project:

--- a/include/ex_actor/3rd_lib/README.md
+++ b/include/ex_actor/3rd_lib/README.md
@@ -1,0 +1,65 @@
+# Vendored Third-Party Libraries
+
+This directory contains third-party libraries vendored directly into ex_actor to avoid external dependencies.
+
+## Structure
+
+```
+3rd_lib/
+├── absl/                   # Subset of abseil-cpp (LTS 20260107.1)
+│   ├── base/               # Platform detection, macros, config
+│   ├── functional/         # AnyInvocable (move-only type-erased callable with SBO)
+│   │   └── internal/
+│   ├── meta/               # Type traits utilities
+│   └── utility/            # Utility helpers
+├── daking/                 # Lock-free MPSC queue
+├── moody_camel_queue/      # High-performance concurrent queue
+└── README.md
+```
+
+## Namespace and Macro Convention
+
+All vendored libraries are placed under the `ex_actor::embedded_3rd` namespace to avoid conflicts with users who may have their own versions of the same libraries.
+
+| Library | Original Namespace | Vendored Namespace |
+|---------|-------------------|-------------------|
+| abseil  | `absl`            | `ex_actor::embedded_3rd::absl` |
+| daking  | `daking`          | `ex_actor::embedded_3rd::daking` |
+| moodycamel | `moodycamel`  | `ex_actor::embedded_3rd::moodycamel` |
+
+For libraries that define macros (e.g., abseil's `ABSL_*`), prefix all macros with `EX_ACTOR_` to avoid collisions. For example: `ABSL_PREDICT_TRUE` becomes `EX_ACTOR_ABSL_PREDICT_TRUE`.
+
+## How to Add a New Vendored Library
+
+1. **Create a subdirectory** under `3rd_lib/` named after the library.
+
+2. **Copy only the headers you need** — trace the include graph from the entry-point header and copy the minimal set of files that satisfies all `#include` directives.
+
+3. **Rename the namespace** to `ex_actor::embedded_3rd::<library_name>`:
+   ```bash
+   find 3rd_lib/<lib>/ -name "*.h" -exec sed -i 's/\bnamespace <orig>\b/namespace ex_actor::embedded_3rd::<orig>/g' {} +
+   find 3rd_lib/<lib>/ -name "*.h" -exec sed -i 's/\b<orig>::/ex_actor::embedded_3rd::<orig>::/g' {} +
+   ```
+
+4. **Rename macros** with a unique prefix (e.g., `EX_ACTOR_<LIB>_`):
+   ```bash
+   find 3rd_lib/<lib>/ -name "*.h" -exec sed -i 's/\b<ORIG_PREFIX>_/EX_ACTOR_<ORIG_PREFIX>_/g' {} +
+   ```
+
+5. **Fix include paths** to point to the new location:
+   ```bash
+   find 3rd_lib/<lib>/ -name "*.h" -exec sed -i 's|#include "<orig>/|#include "ex_actor/3rd_lib/<lib>/|g' {} +
+   ```
+
+6. **Disable inline/versioned namespaces** if present (e.g., abseil's `ABSL_OPTION_USE_INLINE_NAMESPACE`) — they are redundant once the outer namespace is renamed.
+
+7. **Verify no collateral damage** — if other files in `3rd_lib/` were accidentally modified by your sed commands, restore them with `git checkout`.
+
+8. **Test** — write a minimal .cc that includes the header and exercises the vendored API, then rebuild the full project and run tests.
+
+## How to Upgrade an Existing Vendored Library
+
+1. Delete the library's subdirectory.
+2. Re-download from the desired release tag.
+3. Re-apply steps 2-8 from "How to Add" above.
+4. Update the version noted in this README's structure section.

--- a/include/ex_actor/3rd_lib/absl/base/attributes.h
+++ b/include/ex_actor/3rd_lib/absl/base/attributes.h
@@ -1,0 +1,1100 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This header file defines macros for declaring attributes for functions,
+// types, and variables.
+//
+// These macros are used within Abseil and allow the compiler to optimize, where
+// applicable, certain function calls.
+//
+// Most macros here are exposing GCC or Clang features, and are stubbed out for
+// other compilers.
+//
+// GCC attributes documentation:
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Function-Attributes.html
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Variable-Attributes.html
+//   https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Type-Attributes.html
+//
+// Most attributes in this file are already supported by GCC 4.7. However, some
+// of them are not supported in older version of Clang. Thus, we check
+// `__has_attribute()` first. If the check fails, we check if we are on GCC and
+// assume the attribute exists on GCC (which is verified on GCC 4.7).
+
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+
+#ifndef EX_ACTOR_ABSL_BASE_ATTRIBUTES_H_
+#define EX_ACTOR_ABSL_BASE_ATTRIBUTES_H_
+
+#include "ex_actor/3rd_lib/absl/base/config.h"
+
+// EX_ACTOR_ABSL_HAVE_ATTRIBUTE
+//
+// A function-like feature checking macro that is a wrapper around
+// `__has_attribute`, which is defined by GCC 5+ and Clang and evaluates to a
+// nonzero constant integer if the attribute is supported or 0 if not.
+//
+// It evaluates to zero if `__has_attribute` is not defined by the compiler.
+//
+// GCC: https://gcc.gnu.org/gcc-5/changes.html
+// Clang: https://clang.llvm.org/docs/LanguageExtensions.html
+#ifdef __has_attribute
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE(x) 0
+#endif
+
+// EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE
+//
+// A function-like feature checking macro that accepts C++11 style attributes.
+// It's a wrapper around `__has_cpp_attribute`, defined by ISO C++ SD-6
+// (https://en.cppreference.com/w/cpp/experimental/feature_test). If we don't
+// find `__has_cpp_attribute`, will evaluate to 0.
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+// NOTE: requiring __cplusplus above should not be necessary, but
+// works around https://bugs.llvm.org/show_bug.cgi?id=23435.
+#define EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#else
+#define EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(x) 0
+#endif
+
+// -----------------------------------------------------------------------------
+// Function Attributes
+// -----------------------------------------------------------------------------
+//
+// GCC: https://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html
+// Clang: https://clang.llvm.org/docs/AttributeReference.html
+
+// EX_ACTOR_ABSL_PRINTF_ATTRIBUTE
+// EX_ACTOR_ABSL_SCANF_ATTRIBUTE
+//
+// Tells the compiler to perform `printf` format string checking if the
+// compiler supports it; see the 'format' attribute in
+// <https://gcc.gnu.org/onlinedocs/gcc-4.7.0/gcc/Function-Attributes.html>.
+//
+// Note: As the GCC manual states, "[s]ince non-static C++ methods
+// have an implicit 'this' argument, the arguments of such methods
+// should be counted from two, not one."
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__printf__, string_index, first_to_check)))
+#define EX_ACTOR_ABSL_SCANF_ATTRIBUTE(string_index, first_to_check) \
+  __attribute__((__format__(__scanf__, string_index, first_to_check)))
+#else
+#define EX_ACTOR_ABSL_PRINTF_ATTRIBUTE(string_index, first_to_check)
+#define EX_ACTOR_ABSL_SCANF_ATTRIBUTE(string_index, first_to_check)
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_ALWAYS_INLINE
+// EX_ACTOR_ABSL_ATTRIBUTE_NOINLINE
+//
+// Forces functions to either inline or not inline. Introduced in gcc 3.1.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(always_inline) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_ALWAYS_INLINE 1
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_ALWAYS_INLINE
+#endif
+
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(noinline) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_NOINLINE __attribute__((noinline))
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_NOINLINE 1
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NOINLINE
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_TAIL_CALL
+//
+// Prevents the compiler from optimizing away stack frames for functions which
+// end in a call to another function.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(disable_tail_calls)
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL 1
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_TAIL_CALL __attribute__((disable_tail_calls))
+#elif defined(__GNUC__) && !defined(__clang__) && !defined(__e2k__)
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL 1
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_TAIL_CALL \
+  __attribute__((optimize("no-optimize-sibling-calls")))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_TAIL_CALL
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_NO_TAIL_CALL 0
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_WEAK
+//
+// Tags a function as weak for the purposes of compilation and linking.
+// Weak attributes did not work properly in LLVM's Windows backend before
+// 9.0.0, so disable them there. See https://bugs.llvm.org/show_bug.cgi?id=37598
+// for further information. Weak attributes do not work across DLL boundary.
+// The MinGW compiler doesn't complain about the weak attribute until the link
+// step, presumably because Windows doesn't use ELF binaries.
+#if (EX_ACTOR_ABSL_HAVE_ATTRIBUTE(weak) ||                                 \
+     (defined(__GNUC__) && !defined(__clang__))) &&               \
+    (!defined(_WIN32) ||                                          \
+     (defined(__clang__) && __clang_major__ >= 9 &&               \
+      !defined(EX_ACTOR_ABSL_BUILD_DLL) && !defined(EX_ACTOR_ABSL_CONSUME_DLL))) && \
+    !defined(__MINGW32__)
+#undef EX_ACTOR_ABSL_ATTRIBUTE_WEAK
+#define EX_ACTOR_ABSL_ATTRIBUTE_WEAK __attribute__((weak))
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_WEAK 1
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_WEAK
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_WEAK 0
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NONNULL
+//
+// Tells the compiler either (a) that a particular function parameter
+// should be a non-null pointer, or (b) that all pointer arguments should
+// be non-null.
+//
+// Note: As the GCC manual states, "[s]ince non-static C++ methods
+// have an implicit 'this' argument, the arguments of such methods
+// should be counted from two, not one."
+//
+// Args are indexed starting at 1.
+//
+// For non-static class member functions, the implicit `this` argument
+// is arg 1, and the first explicit argument is arg 2. For static class member
+// functions, there is no implicit `this`, and the first explicit argument is
+// arg 1.
+//
+// Example:
+//
+//   /* arg_a cannot be null, but arg_b can */
+//   void Function(void* arg_a, void* arg_b) EX_ACTOR_ABSL_ATTRIBUTE_NONNULL(1);
+//
+//   class C {
+//     /* arg_a cannot be null, but arg_b can */
+//     void Method(void* arg_a, void* arg_b) EX_ACTOR_ABSL_ATTRIBUTE_NONNULL(2);
+//
+//     /* arg_a cannot be null, but arg_b can */
+//     static void StaticMethod(void* arg_a, void* arg_b)
+//     EX_ACTOR_ABSL_ATTRIBUTE_NONNULL(1);
+//   };
+//
+// If no arguments are provided, then all pointer arguments should be non-null.
+//
+//  /* No pointer arguments may be null. */
+//  void Function(void* arg_a, void* arg_b, int arg_c) EX_ACTOR_ABSL_ATTRIBUTE_NONNULL();
+//
+// NOTE: The GCC nonnull attribute actually accepts a list of arguments, but
+// EX_ACTOR_ABSL_ATTRIBUTE_NONNULL does not.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(nonnull) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_NONNULL(arg_index) __attribute__((nonnull(arg_index)))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NONNULL(...)
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NORETURN
+//
+// Tells the compiler that a given function never returns.
+//
+// Deprecated: Prefer the `[[noreturn]]` attribute standardized by C++11 over
+// this macro.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(noreturn) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NORETURN __declspec(noreturn)
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NORETURN
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS
+//
+// Tells the AddressSanitizer (or other memory testing tools) to ignore a given
+// function. Useful for cases when a function reads random locations on stack,
+// calls _exit from a cloned subprocess, deliberately accesses buffer
+// out of bounds or does other scary things with memory.
+// NOTE: GCC supports AddressSanitizer(asan) since 4.8.
+// https://gcc.gnu.org/gcc-4.8/changes.html
+#if defined(EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER) && \
+    EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize_address)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#elif defined(EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER) && defined(_MSC_VER) && \
+    _MSC_VER >= 1928
+// https://docs.microsoft.com/en-us/cpp/cpp/no-sanitize-address
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS __declspec(no_sanitize_address)
+#elif defined(EX_ACTOR_ABSL_HAVE_HWADDRESS_SANITIZER) && EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize)
+// HWAddressSanitizer is a sanitizer similar to AddressSanitizer, which uses CPU
+// features to detect similar bugs with less CPU and memory overhead.
+// NOTE: GCC supports HWAddressSanitizer(hwasan) since 11.
+// https://gcc.gnu.org/gcc-11/changes.html
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS \
+  __attribute__((no_sanitize("hwaddress")))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY
+//
+// Tells the MemorySanitizer to relax the handling of a given function. All "Use
+// of uninitialized value" warnings from such functions will be suppressed, and
+// all values loaded from memory will be considered fully initialized.  This
+// attribute is similar to the EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_ADDRESS attribute
+// above, but deals with initialized-ness rather than addressability issues.
+// NOTE: MemorySanitizer(msan) is supported by Clang but not GCC.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize_memory)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_MEMORY
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_THREAD
+//
+// Tells the ThreadSanitizer to not instrument a given function.
+// NOTE: GCC supports ThreadSanitizer(tsan) since 4.8.
+// https://gcc.gnu.org/gcc-4.8/changes.html
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize_thread)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_THREAD __attribute__((no_sanitize_thread))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_THREAD
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED
+//
+// Tells the UndefinedSanitizer to ignore a given function. Useful for cases
+// where certain behavior (eg. division by zero) is being used intentionally.
+// NOTE: GCC supports UndefinedBehaviorSanitizer(ubsan) since 4.9.
+// https://gcc.gnu.org/gcc-4.9/changes.html
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize_undefined)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED \
+  __attribute__((no_sanitize_undefined))
+#elif EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED \
+  __attribute__((no_sanitize("undefined")))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_UNDEFINED
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_CFI
+//
+// Tells the ControlFlowIntegrity sanitizer to not instrument a given function.
+// See https://clang.llvm.org/docs/ControlFlowIntegrity.html for details.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize) && defined(__llvm__)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_CFI __attribute__((no_sanitize("cfi")))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_CFI
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_SAFESTACK
+//
+// Tells the SafeStack to not instrument a given function.
+// See https://clang.llvm.org/docs/SafeStack.html for details.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(no_sanitize)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_SAFESTACK \
+  __attribute__((no_sanitize("safe-stack")))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_SANITIZE_SAFESTACK
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_RETURNS_NONNULL
+//
+// Tells the compiler that a particular function never returns a null pointer.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(returns_nonnull)
+#define EX_ACTOR_ABSL_ATTRIBUTE_RETURNS_NONNULL __attribute__((returns_nonnull))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_RETURNS_NONNULL
+#endif
+
+// EX_ACTOR_ABSL_HAVE_ATTRIBUTE_SECTION
+//
+// Indicates whether labeled sections are supported. Weak symbol support is
+// a prerequisite. Labeled sections are not supported on Darwin/iOS.
+#ifdef EX_ACTOR_ABSL_HAVE_ATTRIBUTE_SECTION
+#error EX_ACTOR_ABSL_HAVE_ATTRIBUTE_SECTION cannot be directly set
+#elif (EX_ACTOR_ABSL_HAVE_ATTRIBUTE(section) ||                \
+       (defined(__GNUC__) && !defined(__clang__))) && \
+    !defined(__APPLE__) && EX_ACTOR_ABSL_HAVE_ATTRIBUTE_WEAK
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_SECTION 1
+
+// EX_ACTOR_ABSL_ATTRIBUTE_SECTION
+//
+// Tells the compiler/linker to put a given function into a section and define
+// `__start_ ## name` and `__stop_ ## name` symbols to bracket the section.
+// This functionality is supported by GNU linker.  Any function annotated with
+// `EX_ACTOR_ABSL_ATTRIBUTE_SECTION` must not be inlined, or it will be placed into
+// whatever section its caller is placed into.
+//
+#ifndef EX_ACTOR_ABSL_ATTRIBUTE_SECTION
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION(name) \
+  __attribute__((section(#name))) __attribute__((noinline))
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_SECTION_VARIABLE
+//
+// Tells the compiler/linker to put a given variable into a section and define
+// `__start_ ## name` and `__stop_ ## name` symbols to bracket the section.
+// This functionality is supported by GNU linker.
+#ifndef EX_ACTOR_ABSL_ATTRIBUTE_SECTION_VARIABLE
+#ifdef _AIX
+// __attribute__((section(#name))) on AIX is achieved by using the `.csect`
+// pseudo op which includes an additional integer as part of its syntax
+// indicating alignment. If data fall under different alignments then you might
+// get a compilation error indicating a `Section type conflict`.
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_VARIABLE(name)
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_VARIABLE(name) __attribute__((section(#name)))
+#endif
+#endif
+
+// EX_ACTOR_ABSL_DECLARE_ATTRIBUTE_SECTION_VARS
+//
+// A weak section declaration to be used as a global declaration
+// for EX_ACTOR_ABSL_ATTRIBUTE_SECTION_START|STOP(name) to compile and link
+// even without functions with EX_ACTOR_ABSL_ATTRIBUTE_SECTION(name).
+// EX_ACTOR_ABSL_DEFINE_ATTRIBUTE_SECTION should be in the exactly one file; it's
+// a no-op on ELF but not on Mach-O.
+//
+#ifndef EX_ACTOR_ABSL_DECLARE_ATTRIBUTE_SECTION_VARS
+#define EX_ACTOR_ABSL_DECLARE_ATTRIBUTE_SECTION_VARS(name)   \
+  extern char __start_##name[] EX_ACTOR_ABSL_ATTRIBUTE_WEAK; \
+  extern char __stop_##name[] EX_ACTOR_ABSL_ATTRIBUTE_WEAK
+#endif
+#ifndef EX_ACTOR_ABSL_DEFINE_ATTRIBUTE_SECTION_VARS
+#define EX_ACTOR_ABSL_INIT_ATTRIBUTE_SECTION_VARS(name)
+#define EX_ACTOR_ABSL_DEFINE_ATTRIBUTE_SECTION_VARS(name)
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_SECTION_START
+//
+// Returns `void*` pointers to start/end of a section of code with
+// functions having EX_ACTOR_ABSL_ATTRIBUTE_SECTION(name).
+// Returns 0 if no such functions exist.
+// One must EX_ACTOR_ABSL_DECLARE_ATTRIBUTE_SECTION_VARS(name) for this to compile and
+// link.
+//
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_START(name) \
+  (reinterpret_cast<void *>(__start_##name))
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_STOP(name) \
+  (reinterpret_cast<void *>(__stop_##name))
+
+#else  // !EX_ACTOR_ABSL_HAVE_ATTRIBUTE_SECTION
+
+#define EX_ACTOR_ABSL_HAVE_ATTRIBUTE_SECTION 0
+
+// provide dummy definitions
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION(name)
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_VARIABLE(name)
+#define EX_ACTOR_ABSL_INIT_ATTRIBUTE_SECTION_VARS(name)
+#define EX_ACTOR_ABSL_DEFINE_ATTRIBUTE_SECTION_VARS(name)
+#define EX_ACTOR_ABSL_DECLARE_ATTRIBUTE_SECTION_VARS(name)
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_START(name) (reinterpret_cast<void *>(0))
+#define EX_ACTOR_ABSL_ATTRIBUTE_SECTION_STOP(name) (reinterpret_cast<void *>(0))
+
+#endif  // EX_ACTOR_ABSL_ATTRIBUTE_SECTION
+
+// EX_ACTOR_ABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+//
+// Support for aligning the stack on 32-bit x86.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(force_align_arg_pointer) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#if defined(__i386__)
+#define EX_ACTOR_ABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC \
+  __attribute__((force_align_arg_pointer))
+#define EX_ACTOR_ABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (0)
+#elif defined(__x86_64__)
+#define EX_ACTOR_ABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (1)
+#define EX_ACTOR_ABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+#else  // !__i386__ && !__x86_64
+#define EX_ACTOR_ABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (0)
+#define EX_ACTOR_ABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+#endif  // __i386__
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_STACK_ALIGN_FOR_OLD_LIBC
+#define EX_ACTOR_ABSL_REQUIRE_STACK_ALIGN_TRAMPOLINE (0)
+#endif
+
+// EX_ACTOR_ABSL_MUST_USE_RESULT
+//
+// Tells the compiler to warn about unused results.
+//
+// For code or headers that are assured to only build with C++17 and up, prefer
+// just using the standard `[[nodiscard]]` directly over this macro.
+//
+// When annotating a function, it must appear as the first part of the
+// declaration or definition. The compiler will warn if the return value from
+// such a function is unused:
+//
+//   EX_ACTOR_ABSL_MUST_USE_RESULT Sprocket* AllocateSprocket();
+//   AllocateSprocket();  // Triggers a warning.
+//
+// When annotating a class, it is equivalent to annotating every function which
+// returns an instance.
+//
+//   class EX_ACTOR_ABSL_MUST_USE_RESULT Sprocket {};
+//   Sprocket();  // Triggers a warning.
+//
+//   Sprocket MakeSprocket();
+//   MakeSprocket();  // Triggers a warning.
+//
+// Note that references and pointers are not instances:
+//
+//   Sprocket* SprocketPointer();
+//   SprocketPointer();  // Does *not* trigger a warning.
+//
+// EX_ACTOR_ABSL_MUST_USE_RESULT allows using cast-to-void to suppress the unused result
+// warning. For that, warn_unused_result is used only for clang but not for gcc.
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
+//
+// Note: past advice was to place the macro after the argument list.
+//
+// TODO(b/176172494): Use EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(nodiscard) when all code is
+// compliant with the stricter [[nodiscard]].
+#if defined(__clang__) && EX_ACTOR_ABSL_HAVE_ATTRIBUTE(warn_unused_result)
+#define EX_ACTOR_ABSL_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define EX_ACTOR_ABSL_MUST_USE_RESULT
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_HOT, EX_ACTOR_ABSL_ATTRIBUTE_COLD
+//
+// Tells GCC that a function is hot or cold. GCC can use this information to
+// improve static analysis, i.e. a conditional branch to a cold function
+// is likely to be not-taken.
+// This annotation is used for function declarations.
+//
+// Example:
+//
+//   int foo() EX_ACTOR_ABSL_ATTRIBUTE_HOT;
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(hot) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_HOT __attribute__((hot))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_HOT
+#endif
+
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(cold) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_COLD __attribute__((cold))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_COLD
+#endif
+
+// EX_ACTOR_ABSL_XRAY_ALWAYS_INSTRUMENT, EX_ACTOR_ABSL_XRAY_NEVER_INSTRUMENT, EX_ACTOR_ABSL_XRAY_LOG_ARGS
+//
+// We define the EX_ACTOR_ABSL_XRAY_ALWAYS_INSTRUMENT and EX_ACTOR_ABSL_XRAY_NEVER_INSTRUMENT
+// macro used as an attribute to mark functions that must always or never be
+// instrumented by XRay. Currently, this is only supported in Clang/LLVM.
+//
+// For reference on the LLVM XRay instrumentation, see
+// http://llvm.org/docs/XRay.html.
+//
+// A function with the XRAY_ALWAYS_INSTRUMENT macro attribute in its declaration
+// will always get the XRay instrumentation sleds. These sleds may introduce
+// some binary size and runtime overhead and must be used sparingly.
+//
+// These attributes only take effect when the following conditions are met:
+//
+//   * The file/target is built in at least C++11 mode, with a Clang compiler
+//     that supports XRay attributes.
+//   * The file/target is built with the -fxray-instrument flag set for the
+//     Clang/LLVM compiler.
+//   * The function is defined in the translation unit (the compiler honors the
+//     attribute in either the definition or the declaration, and must match).
+//
+// There are cases when, even when building with XRay instrumentation, users
+// might want to control specifically which functions are instrumented for a
+// particular build using special-case lists provided to the compiler. These
+// special case lists are provided to Clang via the
+// -fxray-always-instrument=... and -fxray-never-instrument=... flags. The
+// attributes in source take precedence over these special-case lists.
+//
+// To disable the XRay attributes at build-time, users may define
+// EX_ACTOR_ABSL_NO_XRAY_ATTRIBUTES. Do NOT define EX_ACTOR_ABSL_NO_XRAY_ATTRIBUTES on specific
+// packages/targets, as this may lead to conflicting definitions of functions at
+// link-time.
+//
+// XRay isn't currently supported on Android:
+// https://github.com/android/ndk/issues/368
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::xray_always_instrument) && \
+    !defined(EX_ACTOR_ABSL_NO_XRAY_ATTRIBUTES) && !defined(__ANDROID__)
+#define EX_ACTOR_ABSL_XRAY_ALWAYS_INSTRUMENT [[clang::xray_always_instrument]]
+#define EX_ACTOR_ABSL_XRAY_NEVER_INSTRUMENT [[clang::xray_never_instrument]]
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::xray_log_args)
+#define EX_ACTOR_ABSL_XRAY_LOG_ARGS(N) \
+  [[clang::xray_always_instrument, clang::xray_log_args(N)]]
+#else
+#define EX_ACTOR_ABSL_XRAY_LOG_ARGS(N) [[clang::xray_always_instrument]]
+#endif
+#else
+#define EX_ACTOR_ABSL_XRAY_ALWAYS_INSTRUMENT
+#define EX_ACTOR_ABSL_XRAY_NEVER_INSTRUMENT
+#define EX_ACTOR_ABSL_XRAY_LOG_ARGS(N)
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NULL_AFTER_MOVE
+//
+// Indicates that a user-defined smart-pointer-like type makes guarantees on the
+// state of a moved-from object, leaving it in a null state, where it can be
+// used as long as it is not dereferenced. In other words, these are the same
+// semantics that smart pointers from the standard library provide.
+//
+// The clang-tidy check bugprone-use-after-move allows member functions of types
+// marked with this attribute to be called on objects that have been moved from;
+// without the attribute, this would result in a use-after-move warning.
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::annotate) && defined(__clang__) && \
+    __clang_major__ >= 12
+#define EX_ACTOR_ABSL_ATTRIBUTE_NULL_AFTER_MOVE                       \
+  [[clang::annotate("clang-tidy", "bugprone-use-after-move", \
+                    "null_after_move")]]
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NULL_AFTER_MOVE
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_REINITIALIZES
+//
+// Indicates that a member function reinitializes the entire object to a known
+// state, independent of the previous state of the object.
+//
+// The clang-tidy check bugprone-use-after-move allows member functions marked
+// with this attribute to be called on objects that have been moved from;
+// without the attribute, this would result in a use-after-move warning.
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::reinitializes)
+#define EX_ACTOR_ABSL_ATTRIBUTE_REINITIALIZES [[clang::reinitializes]]
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_REINITIALIZES
+#endif
+
+// -----------------------------------------------------------------------------
+// Variable Attributes
+// -----------------------------------------------------------------------------
+
+// EX_ACTOR_ABSL_ATTRIBUTE_UNUSED
+//
+// Prevents the compiler from complaining about variables that appear unused.
+//
+// Deprecated: Use the standard C++17 `[[maybe_unused]]` instead.
+//
+// Due to differences in positioning requirements between the old, compiler
+// specific __attribute__ syntax and the now standard `[[maybe_unused]]`, this
+// macro does not attempt to take advantage of `[[maybe_unused]]`.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(unused) || (defined(__GNUC__) && !defined(__clang__))
+#undef EX_ACTOR_ABSL_ATTRIBUTE_UNUSED
+#define EX_ACTOR_ABSL_ATTRIBUTE_UNUSED __attribute__((__unused__))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_UNUSED
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_INITIAL_EXEC
+//
+// Tells the compiler to use "initial-exec" mode for a thread-local variable.
+// See http://people.redhat.com/drepper/tls.pdf for the gory details.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(tls_model) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_INITIAL_EXEC __attribute__((tls_model("initial-exec")))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_INITIAL_EXEC
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_PACKED
+//
+// Instructs the compiler not to use natural alignment for a tagged data
+// structure, but instead to reduce its alignment to 1.
+//
+// Use of this attribute is HIGHLY DISCOURAGED. Taking the address of or
+// binding a reference to any unaligned member is UB, and it is very easy to
+// do so unintentionally when passing such members as function arguments.
+//
+// DO NOT APPLY THIS ATTRIBUTE TO STRUCTS CONTAINING ATOMICS. Doing
+// so can cause atomic variables to be mis-aligned and silently violate
+// atomicity on x86.
+//
+// This attribute can either be applied to members of a structure or to a
+// structure in its entirety. Applying this attribute (judiciously) to a
+// structure in its entirety to optimize the memory footprint of very
+// commonly-used structs is fine. Do not apply this attribute to a structure in
+// its entirety if the purpose is to control the offsets of the members in the
+// structure. Instead, apply this attribute only to structure members that need
+// it.
+//
+// When applying EX_ACTOR_ABSL_ATTRIBUTE_PACKED only to specific structure members the
+// natural alignment of structure members not annotated is preserved. Aligned
+// member accesses are faster than non-aligned member accesses even if the
+// targeted microprocessor supports non-aligned accesses.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(packed) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_PACKED __attribute__((__packed__))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_PACKED
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_FUNC_ALIGN
+//
+// Tells the compiler to align the function start at least to certain
+// alignment boundary
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(aligned) || (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_ATTRIBUTE_FUNC_ALIGN(bytes) __attribute__((aligned(bytes)))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_FUNC_ALIGN(bytes)
+#endif
+
+// EX_ACTOR_ABSL_FALLTHROUGH_INTENDED
+//
+// Annotates implicit fall-through between switch labels, allowing a case to
+// indicate intentional fallthrough and turn off warnings about any lack of a
+// `break` statement. The EX_ACTOR_ABSL_FALLTHROUGH_INTENDED macro should be followed by
+// a semicolon and can be used in most places where `break` can, provided that
+// no statements exist between it and the next switch label.
+//
+// Example:
+//
+//  switch (x) {
+//    case 40:
+//    case 41:
+//      if (truth_is_out_there) {
+//        ++x;
+//        EX_ACTOR_ABSL_FALLTHROUGH_INTENDED;  // Use instead of/along with annotations
+//                                    // in comments
+//      } else {
+//        return x;
+//      }
+//    case 42:
+//      ...
+//
+// Notes: When supported, GCC and Clang can issue a warning on switch labels
+// with unannotated fallthrough using the warning `-Wimplicit-fallthrough`. See
+// clang documentation on language extensions for details:
+// https://clang.llvm.org/docs/AttributeReference.html#fallthrough-clang-fallthrough
+//
+// When used with unsupported compilers, the EX_ACTOR_ABSL_FALLTHROUGH_INTENDED macro has
+// no effect on diagnostics. In any case this macro has no effect on runtime
+// behavior and performance of code.
+
+#ifdef EX_ACTOR_ABSL_FALLTHROUGH_INTENDED
+#error "EX_ACTOR_ABSL_FALLTHROUGH_INTENDED should not be defined."
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(fallthrough)
+#define EX_ACTOR_ABSL_FALLTHROUGH_INTENDED [[fallthrough]]
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::fallthrough)
+#define EX_ACTOR_ABSL_FALLTHROUGH_INTENDED [[clang::fallthrough]]
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gnu::fallthrough)
+#define EX_ACTOR_ABSL_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
+#else
+#define EX_ACTOR_ABSL_FALLTHROUGH_INTENDED \
+  do {                            \
+  } while (0)
+#endif
+
+// EX_ACTOR_ABSL_DEPRECATED()
+//
+// Marks a deprecated class, struct, enum, function, method and variable
+// declarations. The macro argument is used as a custom diagnostic message (e.g.
+// suggestion of a better alternative).
+//
+// For code or headers that are assured to only build with C++14 and up, prefer
+// just using the standard `[[deprecated("message")]]` directly over this macro.
+//
+// Examples:
+//
+//   class EX_ACTOR_ABSL_DEPRECATED("Use Bar instead") Foo {...};
+//
+//   EX_ACTOR_ABSL_DEPRECATED("Use Baz() instead") void Bar() {...}
+//
+//   template <typename T>
+//   EX_ACTOR_ABSL_DEPRECATED("Use DoThat() instead")
+//   void DoThis();
+//
+//   enum FooEnum {
+//     kBar EX_ACTOR_ABSL_DEPRECATED("Use kBaz instead"),
+//   };
+//
+// Every usage of a deprecated entity will trigger a warning when compiled with
+// GCC/Clang's `-Wdeprecated-declarations` option. Google's production toolchain
+// turns this warning off by default, instead relying on clang-tidy to report
+// new uses of deprecated code.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(deprecated)
+#define EX_ACTOR_ABSL_DEPRECATED(message) __attribute__((deprecated(message)))
+#else
+#define EX_ACTOR_ABSL_DEPRECATED(message)
+#endif
+
+// When deprecating Abseil code, it is sometimes necessary to turn off the
+// warning within Abseil, until the deprecated code is actually removed. The
+// deprecated code can be surrounded with these directives to achieve that
+// result.
+//
+// class EX_ACTOR_ABSL_DEPRECATED("Use Bar instead") Foo;
+//
+// EX_ACTOR_ABSL_INTERNAL_DISABLE_DEPRECATED_DECLARATION_WARNING
+// Baz ComputeBazFromFoo(Foo f);
+// EX_ACTOR_ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING
+#if defined(__GNUC__) || defined(__clang__)
+// Clang also supports these GCC pragmas.
+#define EX_ACTOR_ABSL_INTERNAL_DISABLE_DEPRECATED_DECLARATION_WARNING \
+  _Pragma("GCC diagnostic push")             \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#define EX_ACTOR_ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING \
+  _Pragma("GCC diagnostic pop")
+#elif defined(_MSC_VER)
+#define EX_ACTOR_ABSL_INTERNAL_DISABLE_DEPRECATED_DECLARATION_WARNING \
+  _Pragma("warning(push)") _Pragma("warning(disable: 4996)")
+#define EX_ACTOR_ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING \
+  _Pragma("warning(pop)")
+#else
+#define EX_ACTOR_ABSL_INTERNAL_DISABLE_DEPRECATED_DECLARATION_WARNING
+#define EX_ACTOR_ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING
+#endif  // defined(__GNUC__) || defined(__clang__)
+
+// EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT
+//
+// EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT is placed *after* the data members of an aggregate
+// type to indicate that the annotated member must be explicitly initialized by
+// the user whenever the aggregate is constructed. For example:
+//
+//   struct Coord {
+//     int x EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT;
+//     int y EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT;
+//   };
+//   Coord coord = {1};  // warning: field 'y' is not explicitly initialized
+//
+// Note that usage on C arrays is not supported in C++.
+// Use a struct (such as std::array) to wrap the array member instead.
+//
+// Avoid applying this attribute to the members of non-aggregate types.
+// The behavior within non-aggregates is unspecified and subject to change.
+//
+// Do NOT attempt to suppress or demote the error generated by this attribute.
+// Just like with a missing function argument, it is a hard error by design.
+//
+// See the upstream documentation for more details:
+// https://clang.llvm.org/docs/AttributeReference.html#require-explicit-initialization
+#ifdef __cplusplus
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::require_explicit_initialization)
+// clang-format off
+#define EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT \
+  [[clang::require_explicit_initialization]] = \
+    AbslInternal_YouForgotToExplicitlyInitializeAField::v
+#else
+#define EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT \
+  = AbslInternal_YouForgotToExplicitlyInitializeAField::v
+#endif
+// clang-format on
+#else
+// clang-format off
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(require_explicit_initialization)
+#define EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT \
+  __attribute__((require_explicit_initialization))
+#else
+#define EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT \
+  /* No portable fallback for C is available */
+#endif
+// clang-format on
+#endif
+
+#ifdef __cplusplus
+struct AbslInternal_YouForgotToExplicitlyInitializeAField {
+  // A portable version of [[clang::require_explicit_initialization]] that
+  // never builds, as a last resort for all toolchains.
+  // The error messages are poor, so we don't rely on this unless we have to.
+  template <class T>
+#if !defined(SWIG)
+  constexpr
+#endif
+  operator T() const /* NOLINT */ {
+    const void *volatile deliberately_volatile_ptr = nullptr;
+    // Infinite loop to prevent constexpr compilation
+    for (;;) {
+      // This assignment ensures the 'this' pointer is not optimized away, so
+      // that linking always fails.
+      deliberately_volatile_ptr = this;  // Deliberately not constexpr
+      (void)deliberately_volatile_ptr;
+    }
+  }
+  // This is deliberately left undefined to prevent linking
+  static AbslInternal_YouForgotToExplicitlyInitializeAField v;
+};
+#endif
+
+// EX_ACTOR_ABSL_CONST_INIT
+//
+// A variable declaration annotated with the `EX_ACTOR_ABSL_CONST_INIT` attribute will
+// not compile (on supported platforms) unless the variable has a constant
+// initializer. This is useful for variables with static and thread storage
+// duration, because it guarantees that they will not suffer from the so-called
+// "static init order fiasco".
+//
+// This attribute must be placed on the initializing declaration of the
+// variable. Some compilers will give a -Wmissing-constinit warning when this
+// attribute is placed on some other declaration but missing from the
+// initializing declaration.
+//
+// In some cases (notably with thread_local variables), `EX_ACTOR_ABSL_CONST_INIT` can
+// also be used in a non-initializing declaration to tell the compiler that a
+// variable is already initialized, reducing overhead that would otherwise be
+// incurred by a hidden guard variable. Thus annotating all declarations with
+// this attribute is recommended to potentially enhance optimization.
+//
+// Example:
+//
+//   class MyClass {
+//    public:
+//     EX_ACTOR_ABSL_CONST_INIT static MyType my_var;
+//   };
+//
+//   EX_ACTOR_ABSL_CONST_INIT MyType MyClass::my_var = MakeMyType(...);
+//
+// For code or headers that are assured to only build with C++20 and up, prefer
+// just using the standard `constinit` keyword directly over this macro.
+//
+// Note that this attribute is redundant if the variable is declared constexpr.
+#if defined(__cpp_constinit) && __cpp_constinit >= 201907L
+#define EX_ACTOR_ABSL_CONST_INIT constinit
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::require_constant_initialization)
+#define EX_ACTOR_ABSL_CONST_INIT [[clang::require_constant_initialization]]
+#else
+#define EX_ACTOR_ABSL_CONST_INIT
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION
+//
+// EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION is used to annotate declarations of "pure"
+// functions. A function is pure if its return value is only a function of its
+// arguments. The pure attribute prohibits a function from modifying the state
+// of the program that is observable by means other than inspecting the
+// function's return value. Declaring such functions with the pure attribute
+// allows the compiler to avoid emitting some calls in repeated invocations of
+// the function with the same argument values.
+//
+// Example:
+//
+//  EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION std::string FormatTime(Time t);
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gnu::pure)
+#define EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION [[gnu::pure]]
+#elif EX_ACTOR_ABSL_HAVE_ATTRIBUTE(pure)
+#define EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION __attribute__((pure))
+#else
+// If the attribute isn't defined, we'll fallback to EX_ACTOR_ABSL_MUST_USE_RESULT since
+// pure functions are useless if its return is ignored.
+#define EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION EX_ACTOR_ABSL_MUST_USE_RESULT
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION
+//
+// EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION is used to annotate declarations of "const"
+// functions. A const function is similar to a pure function, with one
+// exception: Pure functions may return value that depend on a non-volatile
+// object that isn't provided as a function argument, while the const function
+// is guaranteed to return the same result given the same arguments.
+//
+// Example:
+//
+//  EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION int64_t ToInt64Milliseconds(Duration d);
+#if defined(_MSC_VER) && !defined(__clang__)
+// Put the MSVC case first since MSVC seems to parse const as a C++ keyword.
+#define EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gnu::const)
+#define EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION [[gnu::const]]
+#elif EX_ACTOR_ABSL_HAVE_ATTRIBUTE(const)
+#define EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION __attribute__((const))
+#else
+// Since const functions are more restrictive pure function, we'll fallback to a
+// pure function if the const attribute is not handled.
+#define EX_ACTOR_ABSL_ATTRIBUTE_CONST_FUNCTION EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND indicates that a resource owned by a function
+// parameter or implicit object parameter is retained by the return value of the
+// annotated function (or, for a parameter of a constructor, in the value of the
+// constructed object). This attribute causes warnings to be produced if a
+// temporary object does not live long enough.
+//
+// When applied to a reference parameter, the referenced object is assumed to be
+// retained by the return value of the function. When applied to a non-reference
+// parameter (for example, a pointer or a class type), all temporaries
+// referenced by the parameter are assumed to be retained by the return value of
+// the function.
+//
+// See also the upstream documentation:
+// https://clang.llvm.org/docs/AttributeReference.html#lifetimebound
+// https://learn.microsoft.com/en-us/cpp/code-quality/c26816?view=msvc-170
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::lifetimebound)
+#define EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND [[clang::lifetimebound]]
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(msvc::lifetimebound)
+#define EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif EX_ACTOR_ABSL_HAVE_ATTRIBUTE(lifetimebound)
+#define EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND __attribute__((lifetimebound))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND
+#endif
+
+// Internal attribute; name and documentation TBD.
+//
+// See the upstream documentation:
+// https://clang.llvm.org/docs/AttributeReference.html#lifetime_capture_by
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::lifetime_capture_by)
+#define EX_ACTOR_ABSL_INTERNAL_ATTRIBUTE_CAPTURED_BY(Owner) \
+  [[clang::lifetime_capture_by(Owner)]]
+#else
+#define EX_ACTOR_ABSL_INTERNAL_ATTRIBUTE_CAPTURED_BY(Owner)
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_VIEW indicates that a type is solely a "view" of data that it
+// points to, similarly to a span, string_view, or other non-owning reference
+// type.
+// This enables diagnosing certain lifetime issues similar to those enabled by
+// EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND, such as:
+//
+//   struct EX_ACTOR_ABSL_ATTRIBUTE_VIEW StringView {
+//     template<class R>
+//     StringView(const R&);
+//   };
+//
+//   StringView f(std::string s) {
+//     return s;  // warning: address of stack memory returned
+//   }
+//
+// We disable this on Clang versions < 13 because of the following
+// false-positive:
+//
+//   ex_actor::embedded_3rd::absl::string_view f(std::optional<ex_actor::embedded_3rd::absl::string_view> sv) { return *sv; }
+//
+// See the following links for details:
+// https://reviews.llvm.org/D64448
+// https://lists.llvm.org/pipermail/cfe-dev/2018-November/060355.html
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gsl::Pointer) && \
+    (!defined(__clang_major__) || __clang_major__ >= 13)
+#define EX_ACTOR_ABSL_ATTRIBUTE_VIEW [[gsl::Pointer]]
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_VIEW
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_OWNER indicates that a type is a container, smart pointer, or
+// similar class that owns all the data that it points to.
+// This enables diagnosing certain lifetime issues similar to those enabled by
+// EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND, such as:
+//
+//   struct EX_ACTOR_ABSL_ATTRIBUTE_VIEW StringView {
+//     template<class R>
+//     StringView(const R&);
+//   };
+//
+//   struct EX_ACTOR_ABSL_ATTRIBUTE_OWNER String {};
+//
+//   StringView f(String s) {
+//     return s;  // warning: address of stack memory returned
+//   }
+//
+// We disable this on Clang versions < 13 because of the following
+// false-positive:
+//
+//   ex_actor::embedded_3rd::absl::string_view f(std::optional<ex_actor::embedded_3rd::absl::string_view> sv) { return *sv; }
+//
+// See the following links for details:
+// https://reviews.llvm.org/D64448
+// https://lists.llvm.org/pipermail/cfe-dev/2018-November/060355.html
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gsl::Owner) && \
+    (!defined(__clang_major__) || __clang_major__ >= 13)
+#define EX_ACTOR_ABSL_ATTRIBUTE_OWNER [[gsl::Owner]]
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_OWNER
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_TRIVIAL_ABI
+// Indicates that a type is "trivially relocatable" -- meaning it can be
+// relocated without invoking the constructor/destructor, using a form of move
+// elision.
+//
+// From a memory safety point of view, putting aside destructor ordering, it's
+// safe to apply EX_ACTOR_ABSL_ATTRIBUTE_TRIVIAL_ABI if an object's location
+// can change over the course of its lifetime: if a constructor can be run one
+// place, and then the object magically teleports to another place where some
+// methods are run, and then the object teleports to yet another place where it
+// is destroyed. This is notably not true for self-referential types, where the
+// move-constructor must keep the self-reference up to date. If the type changed
+// location without invoking the move constructor, it would have a dangling
+// self-reference.
+//
+// The use of this teleporting machinery means that the number of paired
+// move/destroy operations can change, and so it is a bad idea to apply this to
+// a type meant to count the number of moves.
+//
+// Warning: applying this can, rarely, break callers. Objects passed by value
+// will be destroyed at the end of the call, instead of the end of the
+// full-expression containing the call. In addition, it changes the ABI
+// of functions accepting this type by value (e.g. to pass in registers).
+//
+// See also the upstream documentation:
+// https://clang.llvm.org/docs/AttributeReference.html#trivial-abi
+//
+// b/321691395 - This is currently disabled in open-source builds since
+// compiler support differs. If system libraries compiled with GCC are mixed
+// with libraries compiled with Clang, types will have different ideas about
+// their ABI, leading to hard to debug crashes.
+#define EX_ACTOR_ABSL_ATTRIBUTE_TRIVIAL_ABI
+
+// EX_ACTOR_ABSL_ATTRIBUTE_NO_UNIQUE_ADDRESS
+//
+// Indicates a data member can be optimized to occupy no space (if it is empty)
+// and/or its tail padding can be used for other members.
+//
+// For code that is assured to only build with C++20 or later, prefer using
+// the standard attribute `[[no_unique_address]]` directly instead of this
+// macro.
+//
+// https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/#c20-no_unique_address
+// Current versions of MSVC have disabled `[[no_unique_address]]` since it
+// breaks ABI compatibility, but offers `[[msvc::no_unique_address]]` for
+// situations when it can be assured that it is desired. Since Abseil does not
+// claim ABI compatibility in mixed builds, we can offer it unconditionally.
+#if defined(_MSC_VER) && _MSC_VER >= 1929
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(no_unique_address)
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_UNINITIALIZED
+//
+// GCC and Clang support a flag `-ftrivial-auto-var-init=<option>` (<option>
+// can be "zero" or "pattern") that can be used to initialize automatic stack
+// variables. Variables with this attribute will be left uninitialized,
+// overriding the compiler flag.
+//
+// See https://clang.llvm.org/docs/AttributeReference.html#uninitialized
+// and https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-uninitialized-variable-attribute
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::uninitialized)
+#define EX_ACTOR_ABSL_ATTRIBUTE_UNINITIALIZED [[clang::uninitialized]]
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gnu::uninitialized)
+#define EX_ACTOR_ABSL_ATTRIBUTE_UNINITIALIZED [[gnu::uninitialized]]
+#elif EX_ACTOR_ABSL_HAVE_ATTRIBUTE(uninitialized)
+#define EX_ACTOR_ABSL_ATTRIBUTE_UNINITIALIZED __attribute__((uninitialized))
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_UNINITIALIZED
+#endif
+
+// EX_ACTOR_ABSL_ATTRIBUTE_WARN_UNUSED
+//
+// Compilers routinely warn about trivial variables that are unused.  For
+// non-trivial types, this warning is suppressed since the
+// constructor/destructor may be intentional and load-bearing, for example, with
+// a RAII scoped lock.
+//
+// For example:
+//
+// class EX_ACTOR_ABSL_ATTRIBUTE_WARN_UNUSED MyType {
+//  public:
+//   MyType();
+//   ~MyType();
+// };
+//
+// void foo() {
+//   // Warns with EX_ACTOR_ABSL_ATTRIBUTE_WARN_UNUSED attribute present.
+//   MyType unused;
+// }
+//
+// See https://clang.llvm.org/docs/AttributeReference.html#warn-unused and
+// https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Attributes.html#index-warn_005funused-type-attribute
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(gnu::warn_unused)
+#define EX_ACTOR_ABSL_ATTRIBUTE_WARN_UNUSED [[gnu::warn_unused]]
+#else
+#define EX_ACTOR_ABSL_ATTRIBUTE_WARN_UNUSED
+#endif
+
+#endif  // EX_ACTOR_ABSL_BASE_ATTRIBUTES_H_

--- a/include/ex_actor/3rd_lib/absl/base/attributes.h
+++ b/include/ex_actor/3rd_lib/absl/base/attributes.h
@@ -531,25 +531,6 @@
 #define EX_ACTOR_ABSL_XRAY_LOG_ARGS(N)
 #endif
 
-// EX_ACTOR_ABSL_ATTRIBUTE_NULL_AFTER_MOVE
-//
-// Indicates that a user-defined smart-pointer-like type makes guarantees on the
-// state of a moved-from object, leaving it in a null state, where it can be
-// used as long as it is not dereferenced. In other words, these are the same
-// semantics that smart pointers from the standard library provide.
-//
-// The clang-tidy check bugprone-use-after-move allows member functions of types
-// marked with this attribute to be called on objects that have been moved from;
-// without the attribute, this would result in a use-after-move warning.
-#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::annotate) && defined(__clang__) && \
-    __clang_major__ >= 12
-#define EX_ACTOR_ABSL_ATTRIBUTE_NULL_AFTER_MOVE                       \
-  [[clang::annotate("clang-tidy", "bugprone-use-after-move", \
-                    "null_after_move")]]
-#else
-#define EX_ACTOR_ABSL_ATTRIBUTE_NULL_AFTER_MOVE
-#endif
-
 // EX_ACTOR_ABSL_ATTRIBUTE_REINITIALIZES
 //
 // Indicates that a member function reinitializes the entire object to a known
@@ -741,6 +722,46 @@
 #define EX_ACTOR_ABSL_INTERNAL_RESTORE_DEPRECATED_DECLARATION_WARNING
 #endif  // defined(__GNUC__) || defined(__clang__)
 
+// EX_ACTOR_ABSL_CONST_INIT
+//
+// A variable declaration annotated with the `EX_ACTOR_ABSL_CONST_INIT` attribute will
+// not compile (on supported platforms) unless the variable has a constant
+// initializer. This is useful for variables with static and thread storage
+// duration, because it guarantees that they will not suffer from the so-called
+// "static init order fiasco".
+//
+// This attribute must be placed on the initializing declaration of the
+// variable. Some compilers will give a -Wmissing-constinit warning when this
+// attribute is placed on some other declaration but missing from the
+// initializing declaration.
+//
+// In some cases (notably with thread_local variables), `EX_ACTOR_ABSL_CONST_INIT` can
+// also be used in a non-initializing declaration to tell the compiler that a
+// variable is already initialized, reducing overhead that would otherwise be
+// incurred by a hidden guard variable. Thus annotating all declarations with
+// this attribute is recommended to potentially enhance optimization.
+//
+// Example:
+//
+//   class MyClass {
+//    public:
+//     EX_ACTOR_ABSL_CONST_INIT static MyType my_var;
+//   };
+//
+//   EX_ACTOR_ABSL_CONST_INIT MyType MyClass::my_var = MakeMyType(...);
+//
+// For code or headers that are assured to only build with C++20 and up, prefer
+// just using the standard `constinit` keyword directly over this macro.
+//
+// Note that this attribute is redundant if the variable is declared constexpr.
+#if defined(__cpp_constinit) && __cpp_constinit >= 201907L
+#define EX_ACTOR_ABSL_CONST_INIT constinit
+#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::require_constant_initialization)
+#define EX_ACTOR_ABSL_CONST_INIT [[clang::require_constant_initialization]]
+#else
+#define EX_ACTOR_ABSL_CONST_INIT
+#endif
+
 // EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT
 //
 // EX_ACTOR_ABSL_REQUIRE_EXPLICIT_INIT is placed *after* the data members of an aggregate
@@ -809,46 +830,6 @@ struct AbslInternal_YouForgotToExplicitlyInitializeAField {
   // This is deliberately left undefined to prevent linking
   static AbslInternal_YouForgotToExplicitlyInitializeAField v;
 };
-#endif
-
-// EX_ACTOR_ABSL_CONST_INIT
-//
-// A variable declaration annotated with the `EX_ACTOR_ABSL_CONST_INIT` attribute will
-// not compile (on supported platforms) unless the variable has a constant
-// initializer. This is useful for variables with static and thread storage
-// duration, because it guarantees that they will not suffer from the so-called
-// "static init order fiasco".
-//
-// This attribute must be placed on the initializing declaration of the
-// variable. Some compilers will give a -Wmissing-constinit warning when this
-// attribute is placed on some other declaration but missing from the
-// initializing declaration.
-//
-// In some cases (notably with thread_local variables), `EX_ACTOR_ABSL_CONST_INIT` can
-// also be used in a non-initializing declaration to tell the compiler that a
-// variable is already initialized, reducing overhead that would otherwise be
-// incurred by a hidden guard variable. Thus annotating all declarations with
-// this attribute is recommended to potentially enhance optimization.
-//
-// Example:
-//
-//   class MyClass {
-//    public:
-//     EX_ACTOR_ABSL_CONST_INIT static MyType my_var;
-//   };
-//
-//   EX_ACTOR_ABSL_CONST_INIT MyType MyClass::my_var = MakeMyType(...);
-//
-// For code or headers that are assured to only build with C++20 and up, prefer
-// just using the standard `constinit` keyword directly over this macro.
-//
-// Note that this attribute is redundant if the variable is declared constexpr.
-#if defined(__cpp_constinit) && __cpp_constinit >= 201907L
-#define EX_ACTOR_ABSL_CONST_INIT constinit
-#elif EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::require_constant_initialization)
-#define EX_ACTOR_ABSL_CONST_INIT [[clang::require_constant_initialization]]
-#else
-#define EX_ACTOR_ABSL_CONST_INIT
 #endif
 
 // EX_ACTOR_ABSL_ATTRIBUTE_PURE_FUNCTION
@@ -952,7 +933,7 @@ struct AbslInternal_YouForgotToExplicitlyInitializeAField {
 // We disable this on Clang versions < 13 because of the following
 // false-positive:
 //
-//   ex_actor::embedded_3rd::absl::string_view f(std::optional<ex_actor::embedded_3rd::absl::string_view> sv) { return *sv; }
+//   ex_actor::embedded_3rd::absl::string_view f(ex_actor::embedded_3rd::absl::optional<ex_actor::embedded_3rd::absl::string_view> sv) { return *sv; }
 //
 // See the following links for details:
 // https://reviews.llvm.org/D64448
@@ -983,7 +964,7 @@ struct AbslInternal_YouForgotToExplicitlyInitializeAField {
 // We disable this on Clang versions < 13 because of the following
 // false-positive:
 //
-//   ex_actor::embedded_3rd::absl::string_view f(std::optional<ex_actor::embedded_3rd::absl::string_view> sv) { return *sv; }
+//   ex_actor::embedded_3rd::absl::string_view f(ex_actor::embedded_3rd::absl::optional<ex_actor::embedded_3rd::absl::string_view> sv) { return *sv; }
 //
 // See the following links for details:
 // https://reviews.llvm.org/D64448

--- a/include/ex_actor/3rd_lib/absl/base/config.h
+++ b/include/ex_actor/3rd_lib/absl/base/config.h
@@ -117,8 +117,8 @@
 //
 // LTS releases can be obtained from
 // https://github.com/abseil/abseil-cpp/releases.
-#undef EX_ACTOR_ABSL_LTS_RELEASE_VERSION
-#undef EX_ACTOR_ABSL_LTS_RELEASE_PATCH_LEVEL
+#define EX_ACTOR_ABSL_LTS_RELEASE_VERSION 20260107
+#define EX_ACTOR_ABSL_LTS_RELEASE_PATCH_LEVEL 1
 
 // Helper macro to convert a CPP variable to a string literal.
 #define EX_ACTOR_ABSL_INTERNAL_DO_TOKEN_STR(x) #x
@@ -493,6 +493,34 @@ static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #error "absl endian detection needs to be set up for your compiler"
 #endif
 
+// macOS < 10.13 and iOS < 12 don't support <any>, <optional>, or <variant>
+// because the libc++ shared library shipped on the system doesn't have the
+// requisite exported symbols.  See
+// https://github.com/abseil/abseil-cpp/issues/207 and
+// https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes
+//
+// libc++ spells out the availability requirements in the file
+// llvm-project/libcxx/include/__config via the #define
+// _LIBCPP_AVAILABILITY_BAD_OPTIONAL_ACCESS. The set of versions has been
+// modified a few times, via
+// https://github.com/llvm/llvm-project/commit/7fb40e1569dd66292b647f4501b85517e9247953
+// and
+// https://github.com/llvm/llvm-project/commit/0bc451e7e137c4ccadcd3377250874f641ca514a
+// The second has the actually correct versions, thus, is what we copy here.
+#if defined(__APPLE__) &&                                         \
+    ((defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) &&   \
+      __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101300) ||  \
+     (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) &&  \
+      __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 120000) || \
+     (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) &&   \
+      __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 50000) ||   \
+     (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) &&      \
+      __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 120000))
+#define EX_ACTOR_ABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE 1
+#else
+#define EX_ACTOR_ABSL_INTERNAL_APPLE_CXX17_TYPES_UNAVAILABLE 0
+#endif
+
 // Deprecated macros for polyfill detection.
 #define EX_ACTOR_ABSL_HAVE_STD_ANY 1
 #define EX_ACTOR_ABSL_USES_STD_ANY 1
@@ -502,42 +530,6 @@ static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #define EX_ACTOR_ABSL_USES_STD_STRING_VIEW 1
 #define EX_ACTOR_ABSL_HAVE_STD_VARIANT 1
 #define EX_ACTOR_ABSL_USES_STD_VARIANT 1
-
-// EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION
-//
-// Checks whether C++20 std::source_location is available.
-#ifdef EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION
-#error "EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION cannot be directly set."
-#elif (defined(__cpp_lib_source_location) &&    \
-       __cpp_lib_source_location >= 201907L) || \
-    (defined(EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG) &&   \
-     EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L)
-#ifdef __has_include
-#if __has_include(<source_location>)
-#define EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION 1
-#endif
-#else
-// No __has_include support, so just assume C++ language version is correct.
-#define EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION 1
-#endif
-#endif
-
-// EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION
-//
-// Indicates whether ex_actor::embedded_3rd::absl::SourceLocation is an alias for std::source_location.
-#if !defined(EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION)
-#error options.h is misconfigured.
-#elif EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 0 || \
-    (EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 2 &&  \
-     !defined(EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION))
-#undef EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION
-#elif EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 1 || \
-    (EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 2 &&  \
-     defined(EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION))
-#define EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION 1
-#else
-#error options.h is misconfigured.
-#endif
 
 // EX_ACTOR_ABSL_HAVE_STD_ORDERING
 //
@@ -704,7 +696,7 @@ static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 // Clang standalone LeakSanitizer (-fsanitize=leak)
 #elif EX_ACTOR_ABSL_HAVE_FEATURE(leak_sanitizer)
 #define EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER 1
-#elif defined(EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER) && !defined(_WIN32)
+#elif defined(EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER)
 // GCC or Clang using the LeakSanitizer integrated into AddressSanitizer.
 #define EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER 1
 #endif
@@ -807,14 +799,6 @@ static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #define EX_ACTOR_ABSL_INTERNAL_HAVE_ARM_NEON 1
 #endif
 
-#if EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_LINE) && EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_FILE)
-#define EX_ACTOR_ABSL_INTERNAL_HAVE_BUILTIN_LINE_FILE 1
-#elif defined(__GNUC__) && !defined(__clang__) && 5 <= __GNUC__ && __GNUC__ < 10
-#define EX_ACTOR_ABSL_INTERNAL_HAVE_BUILTIN_LINE_FILE 1
-#elif defined(_MSC_VER) && _MSC_VER >= 1926
-#define EX_ACTOR_ABSL_INTERNAL_HAVE_BUILTIN_LINE_FILE 1
-#endif
-
 // EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED is used for compile-time detection of
 // constant evaluation support through `ex_actor::embedded_3rd::absl::is_constant_evaluated`.
 #ifdef EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED
@@ -854,16 +838,16 @@ static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #endif
 #ifdef __EMSCRIPTEN__
 #include <emscripten/version.h>
-#ifdef __EMSCRIPTEN_MAJOR__
-#if __EMSCRIPTEN_MINOR__ >= 1000
-#error __EMSCRIPTEN_MINOR__ is too big to fit in EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
+#ifdef __EMSCRIPTEN_major__
+#if __EMSCRIPTEN_minor__ >= 1000
+#error __EMSCRIPTEN_minor__ is too big to fit in EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
 #endif
-#if __EMSCRIPTEN_TINY__ >= 1000
-#error __EMSCRIPTEN_TINY__ is too big to fit in EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
+#if __EMSCRIPTEN_tiny__ >= 1000
+#error __EMSCRIPTEN_tiny__ is too big to fit in EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
 #endif
 #define EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION                              \
-  ((__EMSCRIPTEN_MAJOR__) * 1000000 + (__EMSCRIPTEN_MINOR__) * 1000 + \
-   (__EMSCRIPTEN_TINY__))
+  ((__EMSCRIPTEN_major__) * 1000000 + (__EMSCRIPTEN_minor__) * 1000 + \
+   (__EMSCRIPTEN_tiny__))
 #endif
 #endif
 

--- a/include/ex_actor/3rd_lib/absl/base/config.h
+++ b/include/ex_actor/3rd_lib/absl/base/config.h
@@ -1,0 +1,870 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: config.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines a set of macros for checking the presence of
+// important compiler and platform features. Such macros can be used to
+// produce portable code by parameterizing compilation based on the presence or
+// lack of a given feature.
+//
+// We define a "feature" as some interface we wish to program to: for example,
+// a library function or system call. A value of `1` indicates support for
+// that feature; any other value indicates the feature support is undefined.
+//
+// Example:
+//
+// Suppose a programmer wants to write a program that uses the 'mmap()' system
+// call. The Abseil macro for that feature (`EX_ACTOR_ABSL_HAVE_MMAP`) allows you to
+// selectively include the `mmap.h` header and bracket code using that feature
+// in the macro:
+//
+//   #include "ex_actor/3rd_lib/absl/base/config.h"
+//
+//   #ifdef EX_ACTOR_ABSL_HAVE_MMAP
+//   #include "sys/mman.h"
+//   #endif  //EX_ACTOR_ABSL_HAVE_MMAP
+//
+//   ...
+//   #ifdef EX_ACTOR_ABSL_HAVE_MMAP
+//   void *ptr = mmap(...);
+//   ...
+//   #endif  // EX_ACTOR_ABSL_HAVE_MMAP
+
+#ifndef EX_ACTOR_ABSL_BASE_CONFIG_H_
+#define EX_ACTOR_ABSL_BASE_CONFIG_H_
+
+// Included for the __GLIBC__ macro (or similar macros on other systems).
+#include <limits.h>
+
+#ifdef __cplusplus
+// Included for __GLIBCXX__, _LIBCPP_VERSION
+#include <cstddef>
+#endif  // __cplusplus
+
+// EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG
+//
+// MSVC does not set the value of __cplusplus correctly, but instead uses
+// _MSVC_LANG as a stand-in.
+// https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+//
+// However, there are reports that MSVC even sets _MSVC_LANG incorrectly at
+// times, for example:
+// https://github.com/microsoft/vscode-cpptools/issues/1770
+// https://reviews.llvm.org/D70996
+//
+// For this reason, this symbol is considered INTERNAL and code outside of
+// Abseil must not use it.
+#if defined(_MSVC_LANG)
+#define EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG _MSVC_LANG
+#elif defined(__cplusplus)
+#define EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG __cplusplus
+#endif
+
+#if defined(EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG) && \
+    EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
+// Include library feature test macros.
+#include <version>
+#endif
+
+#if defined(__APPLE__)
+// Included for TARGET_OS_IPHONE, __IPHONE_OS_VERSION_MIN_REQUIRED,
+// __IPHONE_8_0.
+#include <Availability.h>
+#include <TargetConditionals.h>
+#endif
+
+#include "ex_actor/3rd_lib/absl/base/options.h"
+#include "ex_actor/3rd_lib/absl/base/policy_checks.h"
+
+// Abseil long-term support (LTS) releases will define
+// `EX_ACTOR_ABSL_LTS_RELEASE_VERSION` to the integer representing the date string of the
+// LTS release version, and will define `EX_ACTOR_ABSL_LTS_RELEASE_PATCH_LEVEL` to the
+// integer representing the patch-level for that release.
+//
+// For example, for LTS release version "20300401.2", this would give us
+// EX_ACTOR_ABSL_LTS_RELEASE_VERSION == 20300401 && EX_ACTOR_ABSL_LTS_RELEASE_PATCH_LEVEL == 2
+//
+// These symbols will not be defined in non-LTS code.
+//
+// Abseil recommends that clients live-at-head. Therefore, if you are using
+// these symbols to assert a minimum version requirement, we recommend you do it
+// as
+//
+// #if defined(EX_ACTOR_ABSL_LTS_RELEASE_VERSION) && EX_ACTOR_ABSL_LTS_RELEASE_VERSION < 20300401
+// #error Project foo requires Abseil LTS version >= 20300401
+// #endif
+//
+// The `defined(EX_ACTOR_ABSL_LTS_RELEASE_VERSION)` part of the check excludes
+// live-at-head clients from the minimum version assertion.
+//
+// See https://abseil.io/about/releases for more information on Abseil release
+// management.
+//
+// LTS releases can be obtained from
+// https://github.com/abseil/abseil-cpp/releases.
+#undef EX_ACTOR_ABSL_LTS_RELEASE_VERSION
+#undef EX_ACTOR_ABSL_LTS_RELEASE_PATCH_LEVEL
+
+// Helper macro to convert a CPP variable to a string literal.
+#define EX_ACTOR_ABSL_INTERNAL_DO_TOKEN_STR(x) #x
+#define EX_ACTOR_ABSL_INTERNAL_TOKEN_STR(x) EX_ACTOR_ABSL_INTERNAL_DO_TOKEN_STR(x)
+
+// -----------------------------------------------------------------------------
+// Abseil namespace annotations
+// -----------------------------------------------------------------------------
+
+// EX_ACTOR_ABSL_NAMESPACE_BEGIN/EX_ACTOR_ABSL_NAMESPACE_END
+//
+// An annotation placed at the beginning/end of each `namespace ex_actor::embedded_3rd::absl` scope.
+// This is used to inject an inline namespace.
+//
+// The proper way to write Abseil code in the `absl` namespace is:
+//
+// namespace ex_actor::embedded_3rd::absl {
+// EX_ACTOR_ABSL_NAMESPACE_BEGIN
+//
+// void Foo();  // ex_actor::embedded_3rd::absl::Foo().
+//
+// EX_ACTOR_ABSL_NAMESPACE_END
+// }  // namespace ex_actor::embedded_3rd::absl
+//
+// Users of Abseil should not use these macros, because users of Abseil should
+// not write `namespace ex_actor::embedded_3rd::absl {` in their own code for any reason.  (Abseil does
+// not support forward declarations of its own types, nor does it support
+// user-provided specialization of Abseil templates.  Code that violates these
+// rules may be broken without warning.)
+#if !defined(EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE) || \
+    !defined(EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME)
+#error options.h is misconfigured.
+#endif
+
+// Check that EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME is neither "head" nor ""
+#if defined(__cplusplus) && EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE == 1
+
+#define EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR \
+  EX_ACTOR_ABSL_INTERNAL_TOKEN_STR(EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME)
+
+static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != '\0',
+              "options.h misconfigured: EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME must "
+              "not be empty.");
+static_assert(EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
+                  EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[1] != 'e' ||
+                  EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[2] != 'a' ||
+                  EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[3] != 'd' ||
+                  EX_ACTOR_ABSL_INTERNAL_INLINE_NAMESPACE_STR[4] != '\0',
+              "options.h misconfigured: EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME must "
+              "be changed to a new, unique identifier name.");
+
+#endif
+
+#if EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE == 0
+#define EX_ACTOR_ABSL_NAMESPACE_BEGIN
+#define EX_ACTOR_ABSL_NAMESPACE_END
+#define EX_ACTOR_ABSL_INTERNAL_C_SYMBOL(x) x
+#elif EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE == 1
+#define EX_ACTOR_ABSL_NAMESPACE_BEGIN \
+  inline namespace EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME {
+#define EX_ACTOR_ABSL_NAMESPACE_END }
+#define EX_ACTOR_ABSL_INTERNAL_C_SYMBOL_HELPER_2(x, v) x##_##v
+#define EX_ACTOR_ABSL_INTERNAL_C_SYMBOL_HELPER_1(x, v) \
+  EX_ACTOR_ABSL_INTERNAL_C_SYMBOL_HELPER_2(x, v)
+#define EX_ACTOR_ABSL_INTERNAL_C_SYMBOL(x) \
+  EX_ACTOR_ABSL_INTERNAL_C_SYMBOL_HELPER_1(x, EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME)
+#else
+#error options.h is misconfigured.
+#endif
+
+// -----------------------------------------------------------------------------
+// Compiler Feature Checks
+// -----------------------------------------------------------------------------
+
+// EX_ACTOR_ABSL_HAVE_BUILTIN()
+//
+// Checks whether the compiler supports a Clang Feature Checking Macro, and if
+// so, checks whether it supports the provided builtin function "x" where x
+// is one of the functions noted in
+// https://clang.llvm.org/docs/LanguageExtensions.html
+//
+// Note: Use this macro to avoid an extra level of #ifdef __has_builtin check.
+// http://releases.llvm.org/3.3/tools/clang/docs/LanguageExtensions.html
+#ifdef __has_builtin
+#define EX_ACTOR_ABSL_HAVE_BUILTIN(x) __has_builtin(x)
+#else
+#define EX_ACTOR_ABSL_HAVE_BUILTIN(x) 0
+#endif
+
+#ifdef __has_feature
+#define EX_ACTOR_ABSL_HAVE_FEATURE(f) __has_feature(f)
+#else
+#define EX_ACTOR_ABSL_HAVE_FEATURE(f) 0
+#endif
+
+// Portable check for GCC minimum version:
+// https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
+#if defined(__GNUC__) && defined(__GNUC_MINOR__)
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_MIN_GNUC_VERSION(x, y) \
+  (__GNUC__ > (x) || __GNUC__ == (x) && __GNUC_MINOR__ >= (y))
+#else
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_MIN_GNUC_VERSION(x, y) 0
+#endif
+
+#if defined(__clang__) && defined(__clang_major__) && defined(__clang_minor__)
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_MIN_CLANG_VERSION(x, y) \
+  (__clang_major__ > (x) || __clang_major__ == (x) && __clang_minor__ >= (y))
+#else
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_MIN_CLANG_VERSION(x, y) 0
+#endif
+
+// EX_ACTOR_ABSL_HAVE_TLS is defined to 1 when __thread should be supported.
+// We assume __thread is supported on Linux when compiled with Clang or
+// compiled against libstdc++ with _GLIBCXX_HAVE_TLS defined.
+#ifdef EX_ACTOR_ABSL_HAVE_TLS
+#error EX_ACTOR_ABSL_HAVE_TLS cannot be directly set
+#elif (defined(__linux__)) && (defined(__clang__) || defined(_GLIBCXX_HAVE_TLS))
+#define EX_ACTOR_ABSL_HAVE_TLS 1
+#elif defined(__INTEL_LLVM_COMPILER)
+#define EX_ACTOR_ABSL_HAVE_TLS 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+//
+// Checks whether `std::is_trivially_destructible<T>` is supported.
+#ifdef EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+#error EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE cannot be directly set
+#define EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE
+//
+// Checks whether `std::is_trivially_default_constructible<T>` and
+// `std::is_trivially_copy_constructible<T>` are supported.
+#ifdef EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE
+#error EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE cannot be directly set
+#else
+#define EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+//
+// Checks whether `std::is_trivially_copy_assignable<T>` is supported.
+#ifdef EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+#error EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE cannot be directly set
+#else
+#define EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE
+//
+// Checks whether `std::is_trivially_copyable<T>` is supported.
+#ifdef EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE
+#error EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE cannot be directly set
+#define EX_ACTOR_ABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_THREAD_LOCAL
+//
+// Checks whether the `thread_local` storage duration specifier is supported.
+#ifdef EX_ACTOR_ABSL_HAVE_THREAD_LOCAL
+#error EX_ACTOR_ABSL_HAVE_THREAD_LOCAL cannot be directly set
+#elif !defined(__XTENSA__)
+#define EX_ACTOR_ABSL_HAVE_THREAD_LOCAL 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_INTRINSIC_INT128
+//
+// Checks whether the __int128 compiler extension for a 128-bit integral type is
+// supported.
+//
+// Note: __SIZEOF_INT128__ is defined by Clang and GCC when __int128 is
+// supported, but we avoid using it in certain cases:
+// * On Clang:
+//   * Building using Clang for Windows, where the Clang runtime library has
+//     128-bit support only on LP64 architectures, but Windows is LLP64.
+// * On Nvidia's nvcc:
+//   * nvcc also defines __GNUC__ and __SIZEOF_INT128__, but not all versions
+//     actually support __int128.
+#ifdef EX_ACTOR_ABSL_HAVE_INTRINSIC_INT128
+#error EX_ACTOR_ABSL_HAVE_INTRINSIC_INT128 cannot be directly set
+#elif defined(__SIZEOF_INT128__)
+#if (defined(__clang__) && !defined(_WIN32)) ||           \
+    (defined(__CUDACC__) && __CUDACC_VER_MAJOR__ >= 9) || \
+    (defined(__GNUC__) && !defined(__clang__) && !defined(__CUDACC__))
+#define EX_ACTOR_ABSL_HAVE_INTRINSIC_INT128 1
+#elif defined(__CUDACC__)
+// __CUDACC_VER__ is a full version number before CUDA 9, and is defined to a
+// string explaining that it has been removed starting with CUDA 9. We use
+// nested #ifs because there is no short-circuiting in the preprocessor.
+// NOTE: `__CUDACC__` could be undefined while `__CUDACC_VER__` is defined.
+#if __CUDACC_VER__ >= 70000
+#define EX_ACTOR_ABSL_HAVE_INTRINSIC_INT128 1
+#endif  // __CUDACC_VER__ >= 70000
+#endif  // defined(__CUDACC__)
+#endif  // EX_ACTOR_ABSL_HAVE_INTRINSIC_INT128
+
+// EX_ACTOR_ABSL_HAVE_EXCEPTIONS
+//
+// Checks whether the compiler both supports and enables exceptions. Many
+// compilers support a "no exceptions" mode that disables exceptions.
+//
+// Generally, when EX_ACTOR_ABSL_HAVE_EXCEPTIONS is not defined:
+//
+// * Code using `throw` and `try` may not compile.
+// * The `noexcept` specifier will still compile and behave as normal.
+// * The `noexcept` operator may still return `false`.
+//
+// For further details, consult the compiler's documentation.
+#ifdef EX_ACTOR_ABSL_HAVE_EXCEPTIONS
+#error EX_ACTOR_ABSL_HAVE_EXCEPTIONS cannot be directly set.
+#elif EX_ACTOR_ABSL_INTERNAL_HAVE_MIN_CLANG_VERSION(3, 6)
+// Clang >= 3.6
+#if EX_ACTOR_ABSL_HAVE_FEATURE(cxx_exceptions)
+#define EX_ACTOR_ABSL_HAVE_EXCEPTIONS 1
+#endif  // EX_ACTOR_ABSL_HAVE_FEATURE(cxx_exceptions)
+#elif defined(__clang__)
+// Clang < 3.6
+// http://releases.llvm.org/3.6.0/tools/clang/docs/ReleaseNotes.html#the-exceptions-macro
+#if defined(__EXCEPTIONS) && EX_ACTOR_ABSL_HAVE_FEATURE(cxx_exceptions)
+#define EX_ACTOR_ABSL_HAVE_EXCEPTIONS 1
+#endif  // defined(__EXCEPTIONS) && EX_ACTOR_ABSL_HAVE_FEATURE(cxx_exceptions)
+// Handle remaining special cases and default to exceptions being supported.
+#elif !(defined(__GNUC__) && !defined(__cpp_exceptions)) && \
+    !(defined(_MSC_VER) && !defined(_CPPUNWIND))
+#define EX_ACTOR_ABSL_HAVE_EXCEPTIONS 1
+#endif
+
+// -----------------------------------------------------------------------------
+// Platform Feature Checks
+// -----------------------------------------------------------------------------
+
+// Currently supported operating systems and associated preprocessor
+// symbols:
+//
+//   Linux and Linux-derived           __linux__
+//   Android                           __ANDROID__ (implies __linux__)
+//   Linux (non-Android)               __linux__ && !__ANDROID__
+//   Darwin (macOS and iOS)            __APPLE__
+//   Akaros (http://akaros.org)        __ros__
+//   Windows                           _WIN32
+//   AsmJS                             __asmjs__
+//   WebAssembly (Emscripten)          __EMSCRIPTEN__
+//   Fuchsia                           __Fuchsia__
+//   WebAssembly (WASI)                _WASI_EMULATED_MMAN (implies __wasi__)
+//
+// Note that since Android defines both __ANDROID__ and __linux__, one
+// may probe for either Linux or Android by simply testing for __linux__.
+
+// EX_ACTOR_ABSL_HAVE_MMAP
+//
+// Checks whether the platform has an mmap(2) implementation as defined in
+// POSIX.1-2001.
+#ifdef EX_ACTOR_ABSL_HAVE_MMAP
+#error EX_ACTOR_ABSL_HAVE_MMAP cannot be directly set
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
+    defined(_AIX) || defined(__ros__) || defined(__asmjs__) ||            \
+    defined(__EMSCRIPTEN__) || defined(__Fuchsia__) || defined(__sun) ||  \
+    defined(__myriad2__) || defined(__HAIKU__) || defined(__OpenBSD__) || \
+    defined(__NetBSD__) || defined(__QNX__) || defined(__VXWORKS__) ||    \
+    defined(__hexagon__) || defined(__XTENSA__) ||                        \
+    defined(_WASI_EMULATED_MMAN)
+#define EX_ACTOR_ABSL_HAVE_MMAP 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_PTHREAD_GETSCHEDPARAM
+//
+// Checks whether the platform implements the pthread_(get|set)schedparam(3)
+// functions as defined in POSIX.1-2001.
+#ifdef EX_ACTOR_ABSL_HAVE_PTHREAD_GETSCHEDPARAM
+#error EX_ACTOR_ABSL_HAVE_PTHREAD_GETSCHEDPARAM cannot be directly set
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || \
+    defined(_AIX) || defined(__ros__) || defined(__OpenBSD__) ||          \
+    defined(__NetBSD__) || defined(__VXWORKS__)
+#define EX_ACTOR_ABSL_HAVE_PTHREAD_GETSCHEDPARAM 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_SCHED_GETCPU
+//
+// Checks whether sched_getcpu is available.
+#ifdef EX_ACTOR_ABSL_HAVE_SCHED_GETCPU
+#error EX_ACTOR_ABSL_HAVE_SCHED_GETCPU cannot be directly set
+#elif defined(__linux__)
+#define EX_ACTOR_ABSL_HAVE_SCHED_GETCPU 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_SCHED_YIELD
+//
+// Checks whether the platform implements sched_yield(2) as defined in
+// POSIX.1-2001.
+#ifdef EX_ACTOR_ABSL_HAVE_SCHED_YIELD
+#error EX_ACTOR_ABSL_HAVE_SCHED_YIELD cannot be directly set
+#elif defined(__linux__) || defined(__ros__) || defined(__native_client__) || \
+    defined(__VXWORKS__)
+#define EX_ACTOR_ABSL_HAVE_SCHED_YIELD 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_SEMAPHORE_H
+//
+// Checks whether the platform supports the <semaphore.h> header and sem_init(3)
+// family of functions as standardized in POSIX.1-2001.
+//
+// Note: While Apple provides <semaphore.h> for both iOS and macOS, it is
+// explicitly deprecated and will cause build failures if enabled for those
+// platforms.  We side-step the issue by not defining it here for Apple
+// platforms.
+#ifdef EX_ACTOR_ABSL_HAVE_SEMAPHORE_H
+#error EX_ACTOR_ABSL_HAVE_SEMAPHORE_H cannot be directly set
+#elif defined(__linux__) || defined(__ros__) || defined(__VXWORKS__)
+#define EX_ACTOR_ABSL_HAVE_SEMAPHORE_H 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_ALARM
+//
+// Checks whether the platform supports the <signal.h> header and alarm(2)
+// function as standardized in POSIX.1-2001.
+#ifdef EX_ACTOR_ABSL_HAVE_ALARM
+#error EX_ACTOR_ABSL_HAVE_ALARM cannot be directly set
+#elif defined(__GOOGLE_GRTE_VERSION__)
+// feature tests for Google's GRTE
+#define EX_ACTOR_ABSL_HAVE_ALARM 1
+#elif defined(__GLIBC__)
+// feature test for glibc
+#define EX_ACTOR_ABSL_HAVE_ALARM 1
+#elif defined(_MSC_VER)
+// feature tests for Microsoft's library
+#elif defined(__MINGW32__)
+// mingw32 doesn't provide alarm(2):
+// https://osdn.net/projects/mingw/scm/git/mingw-org-wsl/blobs/5.2-trunk/mingwrt/include/unistd.h
+// mingw-w64 provides a no-op implementation:
+// https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-crt/misc/alarm.c
+#elif defined(__EMSCRIPTEN__)
+// emscripten doesn't support signals
+#elif defined(__wasi__)
+// WASI doesn't support signals
+#elif defined(__Fuchsia__)
+// Signals don't exist on fuchsia.
+#elif defined(__hexagon__)
+#else
+// other standard libraries
+#define EX_ACTOR_ABSL_HAVE_ALARM 1
+#endif
+
+// EX_ACTOR_ABSL_IS_LITTLE_ENDIAN
+// EX_ACTOR_ABSL_IS_BIG_ENDIAN
+//
+// Checks the endianness of the platform.
+//
+// Prefer using `std::endian` in C++20, or `ex_actor::embedded_3rd::absl::endian` from
+// absl/numeric/bits.h prior to C++20.
+//
+// Notes: uses the built in endian macros provided by GCC (since 4.6) and
+// Clang (since 3.2); see
+// https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html.
+// Otherwise, if _WIN32, assume little endian. Otherwise, bail with an error.
+#if defined(EX_ACTOR_ABSL_IS_BIG_ENDIAN)
+#error "EX_ACTOR_ABSL_IS_BIG_ENDIAN cannot be directly set."
+#endif
+#if defined(EX_ACTOR_ABSL_IS_LITTLE_ENDIAN)
+#error "EX_ACTOR_ABSL_IS_LITTLE_ENDIAN cannot be directly set."
+#endif
+
+#if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+     __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define EX_ACTOR_ABSL_IS_LITTLE_ENDIAN 1
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define EX_ACTOR_ABSL_IS_BIG_ENDIAN 1
+#elif defined(_WIN32)
+#define EX_ACTOR_ABSL_IS_LITTLE_ENDIAN 1
+#else
+#error "absl endian detection needs to be set up for your compiler"
+#endif
+
+// Deprecated macros for polyfill detection.
+#define EX_ACTOR_ABSL_HAVE_STD_ANY 1
+#define EX_ACTOR_ABSL_USES_STD_ANY 1
+#define EX_ACTOR_ABSL_HAVE_STD_OPTIONAL 1
+#define EX_ACTOR_ABSL_USES_STD_OPTIONAL 1
+#define EX_ACTOR_ABSL_HAVE_STD_STRING_VIEW 1
+#define EX_ACTOR_ABSL_USES_STD_STRING_VIEW 1
+#define EX_ACTOR_ABSL_HAVE_STD_VARIANT 1
+#define EX_ACTOR_ABSL_USES_STD_VARIANT 1
+
+// EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION
+//
+// Checks whether C++20 std::source_location is available.
+#ifdef EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION
+#error "EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION cannot be directly set."
+#elif (defined(__cpp_lib_source_location) &&    \
+       __cpp_lib_source_location >= 201907L) || \
+    (defined(EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG) &&   \
+     EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L)
+#ifdef __has_include
+#if __has_include(<source_location>)
+#define EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION 1
+#endif
+#else
+// No __has_include support, so just assume C++ language version is correct.
+#define EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION 1
+#endif
+#endif
+
+// EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION
+//
+// Indicates whether ex_actor::embedded_3rd::absl::SourceLocation is an alias for std::source_location.
+#if !defined(EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION)
+#error options.h is misconfigured.
+#elif EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 0 || \
+    (EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 2 &&  \
+     !defined(EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION))
+#undef EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION
+#elif EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 1 || \
+    (EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION == 2 &&  \
+     defined(EX_ACTOR_ABSL_HAVE_STD_SOURCE_LOCATION))
+#define EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION 1
+#else
+#error options.h is misconfigured.
+#endif
+
+// EX_ACTOR_ABSL_HAVE_STD_ORDERING
+//
+// Checks whether C++20 std::{partial,weak,strong}_ordering are available.
+//
+// __cpp_lib_three_way_comparison is missing on libc++
+// (https://github.com/llvm/llvm-project/issues/73953) so treat it as defined
+// when building in C++20 mode.
+#ifdef EX_ACTOR_ABSL_HAVE_STD_ORDERING
+#error "EX_ACTOR_ABSL_HAVE_STD_ORDERING cannot be directly set."
+#elif (defined(__cpp_lib_three_way_comparison) &&    \
+       __cpp_lib_three_way_comparison >= 201907L) || \
+    (defined(EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG) &&        \
+     EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L)
+#define EX_ACTOR_ABSL_HAVE_STD_ORDERING 1
+#endif
+
+// EX_ACTOR_ABSL_USES_STD_ORDERING
+//
+// Indicates whether ex_actor::embedded_3rd::absl::{partial,weak,strong}_ordering are aliases for the
+// std:: ordering types.
+#if !defined(EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING)
+#error options.h is misconfigured.
+#elif EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING == 0 || \
+    (EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING == 2 && !defined(EX_ACTOR_ABSL_HAVE_STD_ORDERING))
+#undef EX_ACTOR_ABSL_USES_STD_ORDERING
+#elif EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING == 1 || \
+    (EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING == 2 && defined(EX_ACTOR_ABSL_HAVE_STD_ORDERING))
+#define EX_ACTOR_ABSL_USES_STD_ORDERING 1
+#else
+#error options.h is misconfigured.
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_MANGLED_NS
+// EX_ACTOR_ABSL_INTERNAL_MANGLED_BACKREFERENCE
+//
+// Internal macros for building up mangled names in our internal fork of CCTZ.
+// This implementation detail is only needed and provided for the MSVC build.
+//
+// These macros both expand to string literals.  EX_ACTOR_ABSL_INTERNAL_MANGLED_NS is
+// the mangled spelling of the `absl` namespace, and
+// EX_ACTOR_ABSL_INTERNAL_MANGLED_BACKREFERENCE is a back-reference integer representing
+// the proper count to skip past the CCTZ fork namespace names.  (This number
+// is one larger when there is an inline namespace name to skip.)
+#if defined(_MSC_VER)
+#if EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE == 0
+#define EX_ACTOR_ABSL_INTERNAL_MANGLED_NS "absl"
+#define EX_ACTOR_ABSL_INTERNAL_MANGLED_BACKREFERENCE "5"
+#else
+#define EX_ACTOR_ABSL_INTERNAL_MANGLED_NS \
+  EX_ACTOR_ABSL_INTERNAL_TOKEN_STR(EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME) "@absl"
+#define EX_ACTOR_ABSL_INTERNAL_MANGLED_BACKREFERENCE "6"
+#endif
+#endif
+
+// EX_ACTOR_ABSL_DLL
+//
+// When building Abseil as a DLL, this macro expands to `__declspec(dllexport)`
+// so we can annotate symbols appropriately as being exported. When used in
+// headers consuming a DLL, this macro expands to `__declspec(dllimport)` so
+// that consumers know the symbol is defined inside the DLL. In all other cases,
+// the macro expands to nothing.
+#if defined(_MSC_VER)
+#if defined(EX_ACTOR_ABSL_BUILD_DLL)
+#define EX_ACTOR_ABSL_DLL __declspec(dllexport)
+#elif defined(EX_ACTOR_ABSL_CONSUME_DLL)
+#define EX_ACTOR_ABSL_DLL __declspec(dllimport)
+#else
+#define EX_ACTOR_ABSL_DLL
+#endif
+#else
+#define EX_ACTOR_ABSL_DLL
+#endif  // defined(_MSC_VER)
+
+#if defined(_MSC_VER)
+#if defined(EX_ACTOR_ABSL_BUILD_TEST_DLL)
+#define EX_ACTOR_ABSL_TEST_DLL __declspec(dllexport)
+#elif defined(EX_ACTOR_ABSL_CONSUME_TEST_DLL)
+#define EX_ACTOR_ABSL_TEST_DLL __declspec(dllimport)
+#else
+#define EX_ACTOR_ABSL_TEST_DLL
+#endif
+#else
+#define EX_ACTOR_ABSL_TEST_DLL
+#endif  // defined(_MSC_VER)
+
+// EX_ACTOR_ABSL_HAVE_MEMORY_SANITIZER
+//
+// MemorySanitizer (MSan) is a detector of uninitialized reads. It consists of
+// a compiler instrumentation module and a run-time library.
+#ifdef EX_ACTOR_ABSL_HAVE_MEMORY_SANITIZER
+#error "EX_ACTOR_ABSL_HAVE_MEMORY_SANITIZER cannot be directly set."
+#elif !defined(__native_client__) && EX_ACTOR_ABSL_HAVE_FEATURE(memory_sanitizer)
+#define EX_ACTOR_ABSL_HAVE_MEMORY_SANITIZER 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_THREAD_SANITIZER
+//
+// ThreadSanitizer (TSan) is a fast data race detector.
+#ifdef EX_ACTOR_ABSL_HAVE_THREAD_SANITIZER
+#error "EX_ACTOR_ABSL_HAVE_THREAD_SANITIZER cannot be directly set."
+#elif defined(__SANITIZE_THREAD__)
+#define EX_ACTOR_ABSL_HAVE_THREAD_SANITIZER 1
+#elif EX_ACTOR_ABSL_HAVE_FEATURE(thread_sanitizer)
+#define EX_ACTOR_ABSL_HAVE_THREAD_SANITIZER 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER
+//
+// AddressSanitizer (ASan) is a fast memory error detector.
+#ifdef EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER
+#error "EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER cannot be directly set."
+#elif defined(__SANITIZE_ADDRESS__)
+#define EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER 1
+#elif EX_ACTOR_ABSL_HAVE_FEATURE(address_sanitizer)
+#define EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_HWADDRESS_SANITIZER
+//
+// Hardware-Assisted AddressSanitizer (or HWASAN) is even faster than asan
+// memory error detector which can use CPU features like ARM TBI, Intel LAM or
+// AMD UAI.
+#ifdef EX_ACTOR_ABSL_HAVE_HWADDRESS_SANITIZER
+#error "EX_ACTOR_ABSL_HAVE_HWADDRESS_SANITIZER cannot be directly set."
+#elif defined(__SANITIZE_HWADDRESS__)
+#define EX_ACTOR_ABSL_HAVE_HWADDRESS_SANITIZER 1
+#elif EX_ACTOR_ABSL_HAVE_FEATURE(hwaddress_sanitizer)
+#define EX_ACTOR_ABSL_HAVE_HWADDRESS_SANITIZER 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_DATAFLOW_SANITIZER
+//
+// Dataflow Sanitizer (or DFSAN) is a generalised dynamic data flow analysis.
+#ifdef EX_ACTOR_ABSL_HAVE_DATAFLOW_SANITIZER
+#error "EX_ACTOR_ABSL_HAVE_DATAFLOW_SANITIZER cannot be directly set."
+#elif defined(DATAFLOW_SANITIZER)
+// GCC provides no method for detecting the presence of the standalone
+// DataFlowSanitizer (-fsanitize=dataflow), so GCC users of -fsanitize=dataflow
+// should also use -DDATAFLOW_SANITIZER.
+#define EX_ACTOR_ABSL_HAVE_DATAFLOW_SANITIZER 1
+#elif EX_ACTOR_ABSL_HAVE_FEATURE(dataflow_sanitizer)
+#define EX_ACTOR_ABSL_HAVE_DATAFLOW_SANITIZER 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER
+//
+// LeakSanitizer (or lsan) is a detector of memory leaks.
+// https://clang.llvm.org/docs/LeakSanitizer.html
+// https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer
+//
+// The macro EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER can be used to detect at compile-time
+// whether the LeakSanitizer is potentially available. However, just because the
+// LeakSanitizer is available does not mean it is active. Use the
+// always-available run-time interface in //absl/debugging/leak_check.h for
+// interacting with LeakSanitizer.
+#ifdef EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER
+#error "EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER cannot be directly set."
+#elif defined(LEAK_SANITIZER)
+// GCC provides no method for detecting the presence of the standalone
+// LeakSanitizer (-fsanitize=leak), so GCC users of -fsanitize=leak should also
+// use -DLEAK_SANITIZER.
+#define EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER 1
+// Clang standalone LeakSanitizer (-fsanitize=leak)
+#elif EX_ACTOR_ABSL_HAVE_FEATURE(leak_sanitizer)
+#define EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER 1
+#elif defined(EX_ACTOR_ABSL_HAVE_ADDRESS_SANITIZER) && !defined(_WIN32)
+// GCC or Clang using the LeakSanitizer integrated into AddressSanitizer.
+#define EX_ACTOR_ABSL_HAVE_LEAK_SANITIZER 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+//
+// Deprecated: always defined to 1.
+// Class template argument deduction is a language feature added in C++17,
+// which means all versions of C++ supported by Abseil have it.
+#ifdef EX_ACTOR_ABSL_HAVE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+#error "EX_ACTOR_ABSL_HAVE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION cannot be directly set."
+#else
+#define EX_ACTOR_ABSL_HAVE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION 1
+#endif
+
+// `EX_ACTOR_ABSL_INTERNAL_HAS_RTTI` determines whether abseil is being compiled with
+// RTTI support.
+#ifdef EX_ACTOR_ABSL_INTERNAL_HAS_RTTI
+#error EX_ACTOR_ABSL_INTERNAL_HAS_RTTI cannot be directly set
+#elif EX_ACTOR_ABSL_HAVE_FEATURE(cxx_rtti)
+#define EX_ACTOR_ABSL_INTERNAL_HAS_RTTI 1
+#elif defined(__GNUC__) && defined(__GXX_RTTI)
+#define EX_ACTOR_ABSL_INTERNAL_HAS_RTTI 1
+#elif defined(_MSC_VER) && defined(_CPPRTTI)
+#define EX_ACTOR_ABSL_INTERNAL_HAS_RTTI 1
+#elif !defined(__GNUC__) && !defined(_MSC_VER)
+// Unknown compiler, default to RTTI
+#define EX_ACTOR_ABSL_INTERNAL_HAS_RTTI 1
+#endif
+
+// `EX_ACTOR_ABSL_INTERNAL_HAS_CXA_DEMANGLE` determines whether `abi::__cxa_demangle` is
+// available.
+#ifdef EX_ACTOR_ABSL_INTERNAL_HAS_CXA_DEMANGLE
+#error EX_ACTOR_ABSL_INTERNAL_HAS_CXA_DEMANGLE cannot be directly set
+#elif defined(OS_ANDROID) && (defined(__i386__) || defined(__x86_64__))
+#undef EX_ACTOR_ABSL_INTERNAL_HAS_CXA_DEMANGLE
+#elif defined(__GNUC__)
+#define EX_ACTOR_ABSL_INTERNAL_HAS_CXA_DEMANGLE 1
+#elif defined(__clang__) && !defined(_MSC_VER)
+#define EX_ACTOR_ABSL_INTERNAL_HAS_CXA_DEMANGLE 1
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_HAVE_SSE is used for compile-time detection of SSE support.
+// See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html for an overview of
+// which architectures support the various x86 instruction sets.
+#ifdef EX_ACTOR_ABSL_INTERNAL_HAVE_SSE
+#error EX_ACTOR_ABSL_INTERNAL_HAVE_SSE cannot be directly set
+#elif defined(__SSE__)
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_SSE 1
+#elif (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1)) && \
+    !defined(_M_ARM64EC)
+// MSVC only defines _M_IX86_FP for x86 32-bit code, and _M_IX86_FP >= 1
+// indicates that at least SSE was targeted with the /arch:SSE option.
+// All x86-64 processors support SSE, so support can be assumed.
+// https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_SSE 1
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_HAVE_SSE2 is used for compile-time detection of SSE2 support.
+// See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html for an overview of
+// which architectures support the various x86 instruction sets.
+#ifdef EX_ACTOR_ABSL_INTERNAL_HAVE_SSE2
+#error EX_ACTOR_ABSL_INTERNAL_HAVE_SSE2 cannot be directly set
+#elif defined(__SSE2__)
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_SSE2 1
+#elif (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)) && \
+    !defined(_M_ARM64EC)
+// MSVC only defines _M_IX86_FP for x86 32-bit code, and _M_IX86_FP >= 2
+// indicates that at least SSE2 was targeted with the /arch:SSE2 option.
+// All x86-64 processors support SSE2, so support can be assumed.
+// https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_SSE2 1
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_HAVE_SSSE3 is used for compile-time detection of SSSE3 support.
+// See https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html for an overview of
+// which architectures support the various x86 instruction sets.
+//
+// MSVC does not have a mode that targets SSSE3 at compile-time. To use SSSE3
+// with MSVC requires either assuming that the code will only every run on CPUs
+// that support SSSE3, otherwise __cpuid() can be used to detect support at
+// runtime and fallback to a non-SSSE3 implementation when SSSE3 is unsupported
+// by the CPU.
+#ifdef EX_ACTOR_ABSL_INTERNAL_HAVE_SSSE3
+#error EX_ACTOR_ABSL_INTERNAL_HAVE_SSSE3 cannot be directly set
+#elif defined(__SSSE3__)
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_SSSE3 1
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_HAVE_ARM_NEON is used for compile-time detection of NEON (ARM
+// SIMD).
+//
+// If __CUDA_ARCH__ is defined, then we are compiling CUDA code in device mode.
+// In device mode, NEON intrinsics are not available, regardless of host
+// platform.
+// https://llvm.org/docs/CompileCudaWithLLVM.html#detecting-clang-vs-nvcc-from-code
+#ifdef EX_ACTOR_ABSL_INTERNAL_HAVE_ARM_NEON
+#error EX_ACTOR_ABSL_INTERNAL_HAVE_ARM_NEON cannot be directly set
+#elif defined(__ARM_NEON) && !(defined(__NVCC__) && defined(__CUDACC__))
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_ARM_NEON 1
+#endif
+
+#if EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_LINE) && EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_FILE)
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_BUILTIN_LINE_FILE 1
+#elif defined(__GNUC__) && !defined(__clang__) && 5 <= __GNUC__ && __GNUC__ < 10
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_BUILTIN_LINE_FILE 1
+#elif defined(_MSC_VER) && _MSC_VER >= 1926
+#define EX_ACTOR_ABSL_INTERNAL_HAVE_BUILTIN_LINE_FILE 1
+#endif
+
+// EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED is used for compile-time detection of
+// constant evaluation support through `ex_actor::embedded_3rd::absl::is_constant_evaluated`.
+#ifdef EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED
+#error EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED cannot be directly set
+#endif
+#ifdef __cpp_lib_is_constant_evaluated
+#define EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED 1
+#elif EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_is_constant_evaluated)
+#define EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED 1
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_CONSTEXPR_SINCE_CXXYY is used to conditionally define constexpr
+// for different C++ versions.
+//
+// These macros are an implementation detail and will be unconditionally removed
+// once the minimum supported C++ version catches up to a given version.
+//
+// For this reason, this symbol is considered INTERNAL and code outside of
+// Abseil must not use it.
+#if defined(EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG) && \
+    EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 201703L
+#define EX_ACTOR_ABSL_INTERNAL_CONSTEXPR_SINCE_CXX17 constexpr
+#else
+#define EX_ACTOR_ABSL_INTERNAL_CONSTEXPR_SINCE_CXX17
+#endif
+#if defined(EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG) && \
+    EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
+#define EX_ACTOR_ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20 constexpr
+#else
+#define EX_ACTOR_ABSL_INTERNAL_CONSTEXPR_SINCE_CXX20
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION combines Emscripten's three version macros
+// into an integer that can be compared against.
+#ifdef EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
+#error EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION cannot be directly set
+#endif
+#ifdef __EMSCRIPTEN__
+#include <emscripten/version.h>
+#ifdef __EMSCRIPTEN_MAJOR__
+#if __EMSCRIPTEN_MINOR__ >= 1000
+#error __EMSCRIPTEN_MINOR__ is too big to fit in EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
+#endif
+#if __EMSCRIPTEN_TINY__ >= 1000
+#error __EMSCRIPTEN_TINY__ is too big to fit in EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION
+#endif
+#define EX_ACTOR_ABSL_INTERNAL_EMSCRIPTEN_VERSION                              \
+  ((__EMSCRIPTEN_MAJOR__) * 1000000 + (__EMSCRIPTEN_MINOR__) * 1000 + \
+   (__EMSCRIPTEN_TINY__))
+#endif
+#endif
+
+#endif  // EX_ACTOR_ABSL_BASE_CONFIG_H_

--- a/include/ex_actor/3rd_lib/absl/base/macros.h
+++ b/include/ex_actor/3rd_lib/absl/base/macros.h
@@ -28,7 +28,6 @@
 #ifndef EX_ACTOR_ABSL_BASE_MACROS_H_
 #define EX_ACTOR_ABSL_BASE_MACROS_H_
 
-#include <atomic>
 #include <cassert>
 #include <cstddef>
 
@@ -54,39 +53,8 @@ namespace macros_internal {
 template <typename T, size_t N>
 auto ArraySizeHelper(const T (&array)[N]) -> char (&)[N];
 }  // namespace macros_internal
-
-namespace base_internal {
-#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::nomerge)
-[[clang::nomerge]]  // Needed when this function is not inlined
-#endif
-[[noreturn]] inline void HardeningAbort() {
-#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::nomerge)
-  [[clang::nomerge]]  // Needed when this function is inlined
-#endif
-  EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL();
-  EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL();
-}
-}  // namespace base_internal
 EX_ACTOR_ABSL_NAMESPACE_END
 }  // namespace ex_actor::embedded_3rd::absl
-
-// EX_ACTOR_ABSL_INTERNAL_UNEVALUATED()
-//
-// Expands into a no-op expression that contains the given expression. Used to
-// avoid unused-variable warnings in configurations that don't need to evaluate
-// the given expression (e.g., NDEBUG).
-#if EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
-// We use `decltype` here to avoid generating unnecessary code that the
-// optimizer then has to optimize away.
-// This not only improves compilation performance by reducing codegen bloat
-// and optimization work, but also guarantees fast run-time performance without
-// having to rely on the optimizer.
-#define EX_ACTOR_ABSL_INTERNAL_UNEVALUATED(expr) (decltype((void)(expr))())
-#else
-// Pre-C++20, lambdas can't be inside unevaluated operands, so we're forced to
-// rely on the optimizer.
-#define EX_ACTOR_ABSL_INTERNAL_UNEVALUATED(expr) (false ? (void)(expr) : void())
-#endif
 
 // EX_ACTOR_ABSL_BAD_CALL_IF()
 //
@@ -125,26 +93,33 @@ EX_ACTOR_ABSL_NAMESPACE_END
 // This macro is inspired by
 // https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions/
 #if defined(NDEBUG)
-#define EX_ACTOR_ABSL_ASSERT(expr) EX_ACTOR_ABSL_INTERNAL_UNEVALUATED((expr) ? void() : void())
+#if EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
+// We use `decltype` here to avoid generating unnecessary code that the
+// optimizer then has to optimize away.
+// This not only improves compilation performance by reducing codegen bloat
+// and optimization work, but also guarantees fast run-time performance without
+// having to rely on the optimizer.
+#define EX_ACTOR_ABSL_ASSERT(expr) (decltype((expr) ? void() : void())())
+#else
+// Pre-C++20, lambdas can't be inside unevaluated operands, so we're forced to
+// rely on the optimizer.
+#define EX_ACTOR_ABSL_ASSERT(expr) (false ? ((expr) ? void() : void()) : void())
+#endif
 #else
 #define EX_ACTOR_ABSL_ASSERT(expr)                           \
   (EX_ACTOR_ABSL_PREDICT_TRUE((expr)) ? static_cast<void>(0) \
-                             : assert(false && #expr))  // NOLINT
+                             : [] { assert(false && #expr); }())  // NOLINT
 #endif
 
 // `EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT()` controls how `EX_ACTOR_ABSL_HARDENING_ASSERT()`
 // aborts the program in release mode (when NDEBUG is defined). The
 // implementation should abort the program as quickly as possible and ideally it
 // should not be possible to ignore the abort request.
-#if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA__)
 #define EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT()   \
   do {                                    \
     EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL(); \
     EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL();     \
   } while (false)
-#else
-#define EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT() ::ex_actor::embedded_3rd::absl::base_internal::HardeningAbort()
-#endif
 
 // EX_ACTOR_ABSL_HARDENING_ASSERT()
 //
@@ -158,12 +133,9 @@ EX_ACTOR_ABSL_NAMESPACE_END
 // See `EX_ACTOR_ABSL_OPTION_HARDENED` in `absl/base/options.h` for more information on
 // hardened mode.
 #if (EX_ACTOR_ABSL_OPTION_HARDENED == 1 || EX_ACTOR_ABSL_OPTION_HARDENED == 2) && defined(NDEBUG)
- #define EX_ACTOR_ABSL_HARDENING_ASSERT(expr)    \
-   do {                                 \
-     if (!EX_ACTOR_ABSL_PREDICT_TRUE((expr))) {  \
-       EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT(); \
-     }                                  \
-   } while (false)
+#define EX_ACTOR_ABSL_HARDENING_ASSERT(expr)                 \
+  (EX_ACTOR_ABSL_PREDICT_TRUE((expr)) ? static_cast<void>(0) \
+                             : [] { EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT(); }())
 #else
 #define EX_ACTOR_ABSL_HARDENING_ASSERT(expr) EX_ACTOR_ABSL_ASSERT(expr)
 #endif
@@ -180,7 +152,9 @@ EX_ACTOR_ABSL_NAMESPACE_END
 // See `EX_ACTOR_ABSL_OPTION_HARDENED` in `absl/base/options.h` for more information on
 // hardened mode.
 #if EX_ACTOR_ABSL_OPTION_HARDENED == 1 && defined(NDEBUG)
-#define EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW(expr) EX_ACTOR_ABSL_HARDENING_ASSERT(expr)
+#define EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW(expr)            \
+  (EX_ACTOR_ABSL_PREDICT_TRUE((expr)) ? static_cast<void>(0) \
+                             : [] { EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT(); }())
 #else
 #define EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW(expr) EX_ACTOR_ABSL_ASSERT(expr)
 #endif

--- a/include/ex_actor/3rd_lib/absl/base/macros.h
+++ b/include/ex_actor/3rd_lib/absl/base/macros.h
@@ -1,0 +1,269 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: macros.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines the set of language macros used within Abseil code.
+// For the set of macros used to determine supported compilers and platforms,
+// see absl/base/config.h instead.
+//
+// This code is compiled directly on many platforms, including client
+// platforms like Windows, Mac, and embedded systems.  Before making
+// any changes here, make sure that you're not breaking any platforms.
+
+#ifndef EX_ACTOR_ABSL_BASE_MACROS_H_
+#define EX_ACTOR_ABSL_BASE_MACROS_H_
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+
+#include "ex_actor/3rd_lib/absl/base/attributes.h"
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/optimization.h"
+#include "ex_actor/3rd_lib/absl/base/options.h"
+#include "ex_actor/3rd_lib/absl/base/port.h"
+
+// EX_ACTOR_ABSL_ARRAYSIZE()
+//
+// Returns the number of elements in an array as a compile-time constant, which
+// can be used in defining new arrays. If you use this macro on a pointer by
+// mistake, you will get a compile-time error.
+#define EX_ACTOR_ABSL_ARRAYSIZE(array) \
+  (sizeof(::ex_actor::embedded_3rd::absl::macros_internal::ArraySizeHelper(array)))
+
+namespace ex_actor::embedded_3rd::absl {
+EX_ACTOR_ABSL_NAMESPACE_BEGIN
+namespace macros_internal {
+// Note: this internal template function declaration is used by EX_ACTOR_ABSL_ARRAYSIZE.
+// The function doesn't need a definition, as we only use its type.
+template <typename T, size_t N>
+auto ArraySizeHelper(const T (&array)[N]) -> char (&)[N];
+}  // namespace macros_internal
+
+namespace base_internal {
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::nomerge)
+[[clang::nomerge]]  // Needed when this function is not inlined
+#endif
+[[noreturn]] inline void HardeningAbort() {
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::nomerge)
+  [[clang::nomerge]]  // Needed when this function is inlined
+#endif
+  EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL();
+  EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL();
+}
+}  // namespace base_internal
+EX_ACTOR_ABSL_NAMESPACE_END
+}  // namespace ex_actor::embedded_3rd::absl
+
+// EX_ACTOR_ABSL_INTERNAL_UNEVALUATED()
+//
+// Expands into a no-op expression that contains the given expression. Used to
+// avoid unused-variable warnings in configurations that don't need to evaluate
+// the given expression (e.g., NDEBUG).
+#if EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
+// We use `decltype` here to avoid generating unnecessary code that the
+// optimizer then has to optimize away.
+// This not only improves compilation performance by reducing codegen bloat
+// and optimization work, but also guarantees fast run-time performance without
+// having to rely on the optimizer.
+#define EX_ACTOR_ABSL_INTERNAL_UNEVALUATED(expr) (decltype((void)(expr))())
+#else
+// Pre-C++20, lambdas can't be inside unevaluated operands, so we're forced to
+// rely on the optimizer.
+#define EX_ACTOR_ABSL_INTERNAL_UNEVALUATED(expr) (false ? (void)(expr) : void())
+#endif
+
+// EX_ACTOR_ABSL_BAD_CALL_IF()
+//
+// Used on a function overload to trap bad calls: any call that matches the
+// overload will cause a compile-time error. This macro uses a clang-specific
+// "enable_if" attribute, as described at
+// https://clang.llvm.org/docs/AttributeReference.html#enable-if
+//
+// Overloads which use this macro should be bracketed by
+// `#ifdef EX_ACTOR_ABSL_BAD_CALL_IF`.
+//
+// Example:
+//
+//   int isdigit(int c);
+//   #ifdef EX_ACTOR_ABSL_BAD_CALL_IF
+//   int isdigit(int c)
+//     EX_ACTOR_ABSL_BAD_CALL_IF(c <= -1 || c > 255,
+//                       "'c' must have the value of an unsigned char or EOF");
+//   #endif // EX_ACTOR_ABSL_BAD_CALL_IF
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(enable_if)
+#define EX_ACTOR_ABSL_BAD_CALL_IF(expr, msg) \
+  __attribute__((enable_if(expr, "Bad call trap"), unavailable(msg)))
+#endif
+
+// EX_ACTOR_ABSL_ASSERT()
+//
+// In C++11, `assert` can't be used portably within constexpr functions.
+// `assert` also generates spurious unused-symbol warnings.
+// EX_ACTOR_ABSL_ASSERT functions as a runtime assert but works in C++11 constexpr
+// functions, and maintains references to symbols.  Example:
+//
+// constexpr double Divide(double a, double b) {
+//   return EX_ACTOR_ABSL_ASSERT(b != 0), a / b;
+// }
+//
+// This macro is inspired by
+// https://akrzemi1.wordpress.com/2017/05/18/asserts-in-constexpr-functions/
+#if defined(NDEBUG)
+#define EX_ACTOR_ABSL_ASSERT(expr) EX_ACTOR_ABSL_INTERNAL_UNEVALUATED((expr) ? void() : void())
+#else
+#define EX_ACTOR_ABSL_ASSERT(expr)                           \
+  (EX_ACTOR_ABSL_PREDICT_TRUE((expr)) ? static_cast<void>(0) \
+                             : assert(false && #expr))  // NOLINT
+#endif
+
+// `EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT()` controls how `EX_ACTOR_ABSL_HARDENING_ASSERT()`
+// aborts the program in release mode (when NDEBUG is defined). The
+// implementation should abort the program as quickly as possible and ideally it
+// should not be possible to ignore the abort request.
+#if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA__)
+#define EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT()   \
+  do {                                    \
+    EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL(); \
+    EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL();     \
+  } while (false)
+#else
+#define EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT() ::ex_actor::embedded_3rd::absl::base_internal::HardeningAbort()
+#endif
+
+// EX_ACTOR_ABSL_HARDENING_ASSERT()
+//
+// `EX_ACTOR_ABSL_HARDENING_ASSERT()` is like `EX_ACTOR_ABSL_ASSERT()`, but used to implement
+// runtime assertions that should be enabled in hardened builds even when
+// `NDEBUG` is defined.
+//
+// When `NDEBUG` is not defined, `EX_ACTOR_ABSL_HARDENING_ASSERT()` is identical to
+// `EX_ACTOR_ABSL_ASSERT()`.
+//
+// See `EX_ACTOR_ABSL_OPTION_HARDENED` in `absl/base/options.h` for more information on
+// hardened mode.
+#if (EX_ACTOR_ABSL_OPTION_HARDENED == 1 || EX_ACTOR_ABSL_OPTION_HARDENED == 2) && defined(NDEBUG)
+ #define EX_ACTOR_ABSL_HARDENING_ASSERT(expr)    \
+   do {                                 \
+     if (!EX_ACTOR_ABSL_PREDICT_TRUE((expr))) {  \
+       EX_ACTOR_ABSL_INTERNAL_HARDENING_ABORT(); \
+     }                                  \
+   } while (false)
+#else
+#define EX_ACTOR_ABSL_HARDENING_ASSERT(expr) EX_ACTOR_ABSL_ASSERT(expr)
+#endif
+
+// EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW()
+//
+// `EX_ACTOR_ABSL_HARDENING_ASSERT()` is like `EX_ACTOR_ABSL_HARDENING_ASSERT()`,
+//  but specifically for assertions whose predicates are too slow
+//  to be enabled in many applications.
+//
+// When `NDEBUG` is not defined, `EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW()` is identical to
+// `EX_ACTOR_ABSL_ASSERT()`.
+//
+// See `EX_ACTOR_ABSL_OPTION_HARDENED` in `absl/base/options.h` for more information on
+// hardened mode.
+#if EX_ACTOR_ABSL_OPTION_HARDENED == 1 && defined(NDEBUG)
+#define EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW(expr) EX_ACTOR_ABSL_HARDENING_ASSERT(expr)
+#else
+#define EX_ACTOR_ABSL_HARDENING_ASSERT_SLOW(expr) EX_ACTOR_ABSL_ASSERT(expr)
+#endif
+
+#ifdef EX_ACTOR_ABSL_HAVE_EXCEPTIONS
+#define EX_ACTOR_ABSL_INTERNAL_TRY try
+#define EX_ACTOR_ABSL_INTERNAL_CATCH_ANY catch (...)
+#define EX_ACTOR_ABSL_INTERNAL_RETHROW do { throw; } while (false)
+#else  // EX_ACTOR_ABSL_HAVE_EXCEPTIONS
+#define EX_ACTOR_ABSL_INTERNAL_TRY if (true)
+#define EX_ACTOR_ABSL_INTERNAL_CATCH_ANY else if (false)
+#define EX_ACTOR_ABSL_INTERNAL_RETHROW do {} while (false)
+#endif  // EX_ACTOR_ABSL_HAVE_EXCEPTIONS
+
+// EX_ACTOR_ABSL_REFACTOR_INLINE
+//
+// Marks a function or type for automated refactoring by go/cpp-inliner. It can
+// be used on inline function definitions or type aliases in header files and
+// should be combined with the `[[deprecated]]` attribute.
+//
+// Using `EX_ACTOR_ABSL_REFACTOR_INLINE` differs from using the `[[deprecated]]` alone in
+// the following ways:
+//
+// 1. New uses of the function or type will be discouraged via Tricorder
+//    warnings.
+// 2. If enabled via `METADATA`, automated changes will be sent out inlining the
+//    functions's body or replacing the type where it is used.
+//
+// Examples:
+//
+// [[deprecated("Use NewFunc() instead")]] EX_ACTOR_ABSL_REFACTOR_INLINE
+// inline int OldFunc(int x) {
+//   return NewFunc(x, 0);
+// }
+//
+// using OldType [[deprecated("Use NewType instead")]] EX_ACTOR_ABSL_REFACTOR_INLINE =
+//     NewType;
+//
+// will mark `OldFunc` and `OldType` as deprecated, and the go/cpp-inliner
+// service will replace calls to `OldFunc(x)` with calls to `NewFunc(x, 0)` and
+// `OldType` with `NewType`. Once all replacements have been completed, the old
+// function or type can be deleted.
+//
+// See go/cpp-inliner for more information.
+//
+// Note: go/cpp-inliner is Google-internal service for automated refactoring.
+// While open-source users do not have access to this service, the macro is
+// provided for compatibility.
+#if EX_ACTOR_ABSL_HAVE_CPP_ATTRIBUTE(clang::annotate)
+#define EX_ACTOR_ABSL_REFACTOR_INLINE [[clang::annotate("inline-me")]]
+#else
+#define EX_ACTOR_ABSL_REFACTOR_INLINE
+#endif
+
+// EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
+//
+// This is the original macro used by go/cpp-inliner that combines
+// [[deprecated]] and EX_ACTOR_ABSL_REFACTOR_INLINE.
+//
+// Examples:
+//
+// EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() inline int OldFunc(int x) {
+//   return NewFunc(x, 0);
+// }
+//
+// using OldType EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = NewType;
+//
+// The combination of `[[deprecated("Use X instead")]]` and
+// `EX_ACTOR_ABSL_REFACTOR_INLINE` is preferred because it provides a more informative
+// deprecation message to developers, especially those that do not have access
+// to the automated refactoring capabilities of go/cpp-inliner.
+#define EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() [[deprecated]] EX_ACTOR_ABSL_REFACTOR_INLINE
+
+// Requires the compiler to prove that the size of the given object is at least
+// the expected amount.
+#if EX_ACTOR_ABSL_HAVE_ATTRIBUTE(diagnose_if) && EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_object_size)
+#define EX_ACTOR_ABSL_INTERNAL_NEED_MIN_SIZE(Obj, N)                     \
+  __attribute__((diagnose_if(__builtin_object_size(Obj, 0) < N, \
+                             "object size provably too small "  \
+                             "(this would corrupt memory)",     \
+                             "error")))
+#else
+#define EX_ACTOR_ABSL_INTERNAL_NEED_MIN_SIZE(Obj, N)
+#endif
+
+#endif  // EX_ACTOR_ABSL_BASE_MACROS_H_

--- a/include/ex_actor/3rd_lib/absl/base/nullability.h
+++ b/include/ex_actor/3rd_lib/absl/base/nullability.h
@@ -1,0 +1,318 @@
+// Copyright 2023 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: nullability.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines a set of annotations for designating the expected
+// nullability of pointers. These annotations allow you to designate pointers in
+// one of three classification states:
+//
+//  * "Non-null" (for pointers annotated `EX_ACTOR_absl_nonnull`), indicating that it is
+//    invalid for the given pointer to ever be null.
+//  * "Nullable" (for pointers annotated `EX_ACTOR_absl_nullable`), indicating that it is
+//    valid for the given pointer to be null.
+//  * "Unknown" (for pointers annotated `EX_ACTOR_absl_nullability_unknown`), indicating
+//    that the given pointer has not yet been classified as either nullable or
+//    non-null. This is the default state of unannotated pointers.
+//
+// NOTE: Unannotated pointers implicitly bear the annotation
+// `EX_ACTOR_absl_nullability_unknown`; you should rarely, if ever, see this annotation
+// used in the codebase explicitly.
+//
+// -----------------------------------------------------------------------------
+// Nullability and Contracts
+// -----------------------------------------------------------------------------
+//
+// These nullability annotations allow you to more clearly specify contracts on
+// software components by narrowing the *preconditions*, *postconditions*, and
+// *invariants* of pointer state(s) in any given interface. It then depends on
+// context who is responsible for fulfilling the annotation's requirements.
+//
+// For example, a function may receive a pointer argument. Designating that
+// pointer argument as "non-null" tightens the precondition of the contract of
+// that function. It is then the responsibility of anyone calling such a
+// function to ensure that the passed pointer is not null.
+//
+// Similarly, a function may have a pointer as a return value. Designating that
+// return value as "non-null" tightens the postcondition of the contract of that
+// function. In this case, however, it is the responsibility of the function
+// itself to ensure that the returned pointer is not null.
+//
+// Clearly defining these contracts allows providers (and consumers) of such
+// pointers to have more confidence in their null state. If a function declares
+// a return value as "non-null", for example, the caller should not need to
+// check whether the returned value is `nullptr`; it can simply assume the
+// pointer is valid.
+//
+// Of course most interfaces already have expectations on the nullability state
+// of pointers, and these expectations are, in effect, a contract; often,
+// however, those contracts are either poorly or partially specified, assumed,
+// or misunderstood. These nullability annotations are designed to allow you to
+// formalize those contracts within the codebase.
+//
+// -----------------------------------------------------------------------------
+// Annotation Syntax
+// -----------------------------------------------------------------------------
+//
+// The annotations should be positioned as a qualifier for the pointer type. For
+// example, the position of `const` when declaring a const pointer (not a
+// pointer to a const type) is the position you should also use for these
+// annotations.
+//
+// Example:
+//
+// // A const non-null pointer to an `Employee`.
+// Employee* EX_ACTOR_absl_nonnull const e;
+//
+// // A non-null pointer to a const `Employee`.
+// const Employee* EX_ACTOR_absl_nonnull e;
+//
+// // A non-null pointer to a const nullable pointer to an `Employee`.
+// Employee* EX_ACTOR_absl_nullable const* EX_ACTOR_absl_nonnull e;
+//
+// // A non-null function pointer.
+// void (*EX_ACTOR_absl_nonnull func)(int, double);
+//
+// // A non-null array of `Employee`s as a parameter.
+// void func(Employee employees[EX_ACTOR_absl_nonnull]);
+//
+// // A non-null std::unique_ptr to an `Employee`.
+// // As with `const`, it is possible to place the annotation on either side of
+// // a named type not ending in `*`, but placing it before the type it
+// // describes is preferred, unless inconsistent with surrounding code.
+// EX_ACTOR_absl_nonnull std::unique_ptr<Employee> employee;
+//
+// // Invalid annotation usage - this attempts to declare a pointer to a
+// // nullable `Employee`, which is meaningless.
+// EX_ACTOR_absl_nullable Employee* e;
+//
+// -----------------------------------------------------------------------------
+// Using Nullability Annotations
+// -----------------------------------------------------------------------------
+//
+// Each annotation acts as a form of documentation about the contract for the
+// given pointer. Each annotation requires providers or consumers of these
+// pointers across API boundaries to take appropriate steps when setting or
+// using these pointers:
+//
+// * "Non-null" pointers should never be null. It is the responsibility of the
+//   provider of this pointer to ensure that the pointer may never be set to
+//   null. Consumers of such pointers can treat such pointers as non-null.
+// * "Nullable" pointers may or may not be null. Consumers of such pointers
+//   should precede any usage of that pointer (e.g. a dereference operation)
+//   with a a `nullptr` check.
+// * "Unknown" pointers may be either "non-null" or "nullable" but have not been
+//   definitively determined to be in either classification state. Providers of
+//   such pointers across API boundaries should determine --  over time -- to
+//   annotate the pointer in either of the above two states. Consumers of such
+//   pointers across an API boundary should continue to treat such pointers as
+//   they currently do.
+//
+// Example:
+//
+// // PaySalary() requires the passed pointer to an `Employee` to be non-null.
+// void PaySalary(Employee* EX_ACTOR_absl_nonnull e) {
+//   pay(e->salary);  // OK to dereference
+// }
+//
+// // CompleteTransaction() guarantees the returned pointer to an `Account` to
+// // be non-null.
+// Account* EX_ACTOR_absl_nonnull CompleteTransaction(double fee) {
+// ...
+// }
+//
+// // Note that specifying a nullability annotation does not prevent someone
+// // from violating the contract:
+//
+// Employee* EX_ACTOR_absl_nullable find(Map& employees, std::string_view name);
+//
+// void g(Map& employees) {
+//   Employee *e = find(employees, "Pat");
+//   // `e` can now be null.
+//   PaySalary(e); // Violates contract, but compiles!
+// }
+//
+// Nullability annotations, in other words, are useful for defining and
+// narrowing contracts; *enforcement* of those contracts depends on use and any
+// additional (static or dynamic analysis) tooling.
+//
+// NOTE: The "unknown" annotation state indicates that a pointer's contract has
+// not yet been positively identified. The unknown state therefore acts as a
+// form of documentation of your technical debt, and a codebase that adopts
+// nullability annotations should aspire to annotate every pointer as either
+// "non-null" or "nullable".
+//
+// -----------------------------------------------------------------------------
+// Applicability of Nullability Annotations
+// -----------------------------------------------------------------------------
+//
+// By default, nullability annotations are applicable to raw and smart
+// pointers. User-defined types can indicate compatibility with nullability
+// annotations by adding the EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE attribute.
+//
+// // Example:
+// struct EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE MyPtr {
+//   ...
+// };
+//
+// Note: Compilers that don't support the `nullability_on_classes` feature will
+// allow nullability annotations to be applied to any type, not just ones
+// marked with `EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE`.
+//
+// DISCLAIMER:
+// ===========================================================================
+// These nullability annotations are primarily a human readable signal about the
+// intended contract of the pointer. They are not *types* and do not currently
+// provide any correctness guarantees. For example, a pointer annotated as
+// `EX_ACTOR_absl_nonnull` is *not guaranteed* to be non-null, and the compiler won't
+// alert or prevent assignment of a `T* EX_ACTOR_absl_nullable` to a `T* EX_ACTOR_absl_nonnull`.
+// ===========================================================================
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+#ifndef EX_ACTOR_ABSL_BASE_NULLABILITY_H_
+#define EX_ACTOR_ABSL_BASE_NULLABILITY_H_
+
+#include "ex_actor/3rd_lib/absl/base/config.h"
+
+// EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL
+//
+// This macro specifies that all unannotated pointer types within the given
+// file are designated as nonnull (instead of the default "unknown"). This macro
+// exists as a standalone statement and applies default nonnull behavior to all
+// subsequent pointers; as a result, place this macro as the first non-comment,
+// non-`#include` line in a file.
+//
+// Example:
+//
+//     #include "ex_actor/3rd_lib/absl/base/nullability.h"
+//
+//     EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL
+//
+//     void FillMessage(Message *m);                  // implicitly non-null
+//     T* EX_ACTOR_absl_nullable GetNullablePtr();           // explicitly nullable
+//     T* EX_ACTOR_absl_nullability_unknown GetUnknownPtr();  // explicitly unknown
+//
+// The macro can be safely used in header files - it will not affect any files
+// that include it.
+//
+// In files with the macro, plain `T*` syntax means `T* EX_ACTOR_absl_nonnull`, and the
+// exceptions (`EX_ACTOR_absl_nullable` and `EX_ACTOR_absl_nullability_unknown`) must be marked
+// explicitly. The same holds, correspondingly, for smart pointer types.
+//
+// For comparison, without the macro, all unannotated pointers would default to
+// unknown, and otherwise require explicit annotations to change this behavior:
+//
+//     #include "ex_actor/3rd_lib/absl/base/nullability.h"
+//
+//     void FillMessage(Message* EX_ACTOR_absl_nonnull m);  // explicitly non-null
+//     T* EX_ACTOR_absl_nullable GetNullablePtr();          // explicitly nullable
+//     T* GetUnknownPtr();                           // implicitly unknown
+//
+// No-op except for being a human readable signal.
+#define EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL
+
+#if defined(__clang__) && !defined(__OBJC__) && \
+    EX_ACTOR_ABSL_HAVE_FEATURE(nullability_on_classes)
+// EX_ACTOR_absl_nonnull (default with `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`)
+//
+// The indicated pointer is never null. It is the responsibility of the provider
+// of this pointer across an API boundary to ensure that the pointer is never
+// set to null. Consumers of this pointer across an API boundary may safely
+// dereference the pointer.
+//
+// Example:
+//
+// // `employee` is designated as not null.
+// void PaySalary(Employee* EX_ACTOR_absl_nonnull employee) {
+//   pay(*employee);  // OK to dereference
+// }
+#define EX_ACTOR_absl_nonnull _Nonnull
+
+// EX_ACTOR_absl_nullable
+//
+// The indicated pointer may, by design, be either null or non-null. Consumers
+// of this pointer across an API boundary should perform a `nullptr` check
+// before performing any operation using the pointer.
+//
+// Example:
+//
+// // `employee` may  be null.
+// void PaySalary(Employee* EX_ACTOR_absl_nullable employee) {
+//   if (employee != nullptr) {
+//     Pay(*employee);  // OK to dereference
+//   }
+// }
+#define EX_ACTOR_absl_nullable _Nullable
+
+// EX_ACTOR_absl_nullability_unknown  (default without `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`)
+//
+// The indicated pointer has not yet been determined to be definitively
+// "non-null" or "nullable." Providers of such pointers across API boundaries
+// should, over time, annotate such pointers as either "non-null" or "nullable."
+// Consumers of these pointers across an API boundary should treat such pointers
+// with the same caution they treat currently unannotated pointers. Most
+// existing code will have "unknown"  pointers, which should eventually be
+// migrated into one of the above two nullability states: `EX_ACTOR_absl_nonnull` or
+//  `EX_ACTOR_absl_nullable`.
+//
+// NOTE: For files that do not specify `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`,
+// because this annotation is the global default state, unannotated pointers are
+// are assumed to have "unknown" semantics. This assumption is designed to
+// minimize churn and reduce clutter within the codebase.
+//
+// Example:
+//
+// // `employee`s nullability state is unknown.
+// void PaySalary(Employee* EX_ACTOR_absl_nullability_unknown employee) {
+//   Pay(*employee); // Potentially dangerous. API provider should investigate.
+// }
+//
+// Note that a pointer without an annotation, by default, is assumed to have the
+// annotation `NullabilityUnknown`.
+//
+// // `employee`s nullability state is unknown.
+// void PaySalary(Employee* employee) {
+//   Pay(*employee); // Potentially dangerous. API provider should investigate.
+// }
+#define EX_ACTOR_absl_nullability_unknown _Null_unspecified
+#else
+// No-op for non-Clang compilers or Objective-C.
+#define EX_ACTOR_absl_nonnull
+// No-op for non-Clang compilers or Objective-C.
+#define EX_ACTOR_absl_nullable
+// No-op for non-Clang compilers or Objective-C.
+#define EX_ACTOR_absl_nullability_unknown
+#endif
+
+// EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE
+//
+// Indicates that a class is compatible with nullability annotations.
+//
+// For example:
+//
+// struct EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE MyPtr {
+//   ...
+// };
+//
+// Note: Compilers that don't support the `nullability_on_classes` feature will
+// allow nullability annotations to be applied to any type, not just ones marked
+// with `EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE`.
+#if EX_ACTOR_ABSL_HAVE_FEATURE(nullability_on_classes)
+#define EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE _Nullable
+#else
+#define EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE
+#endif
+
+#endif  // EX_ACTOR_ABSL_BASE_NULLABILITY_H_

--- a/include/ex_actor/3rd_lib/absl/base/nullability.h
+++ b/include/ex_actor/3rd_lib/absl/base/nullability.h
@@ -20,16 +20,16 @@
 // nullability of pointers. These annotations allow you to designate pointers in
 // one of three classification states:
 //
-//  * "Non-null" (for pointers annotated `EX_ACTOR_absl_nonnull`), indicating that it is
+//  * "Non-null" (for pointers annotated `absl_nonnull`), indicating that it is
 //    invalid for the given pointer to ever be null.
-//  * "Nullable" (for pointers annotated `EX_ACTOR_absl_nullable`), indicating that it is
+//  * "Nullable" (for pointers annotated `absl_nullable`), indicating that it is
 //    valid for the given pointer to be null.
-//  * "Unknown" (for pointers annotated `EX_ACTOR_absl_nullability_unknown`), indicating
+//  * "Unknown" (for pointers annotated `absl_nullability_unknown`), indicating
 //    that the given pointer has not yet been classified as either nullable or
 //    non-null. This is the default state of unannotated pointers.
 //
 // NOTE: Unannotated pointers implicitly bear the annotation
-// `EX_ACTOR_absl_nullability_unknown`; you should rarely, if ever, see this annotation
+// `absl_nullability_unknown`; you should rarely, if ever, see this annotation
 // used in the codebase explicitly.
 //
 // -----------------------------------------------------------------------------
@@ -75,29 +75,29 @@
 // Example:
 //
 // // A const non-null pointer to an `Employee`.
-// Employee* EX_ACTOR_absl_nonnull const e;
+// Employee* absl_nonnull const e;
 //
 // // A non-null pointer to a const `Employee`.
-// const Employee* EX_ACTOR_absl_nonnull e;
+// const Employee* absl_nonnull e;
 //
 // // A non-null pointer to a const nullable pointer to an `Employee`.
-// Employee* EX_ACTOR_absl_nullable const* EX_ACTOR_absl_nonnull e;
+// Employee* absl_nullable const* absl_nonnull e;
 //
 // // A non-null function pointer.
-// void (*EX_ACTOR_absl_nonnull func)(int, double);
+// void (*absl_nonnull func)(int, double);
 //
 // // A non-null array of `Employee`s as a parameter.
-// void func(Employee employees[EX_ACTOR_absl_nonnull]);
+// void func(Employee employees[absl_nonnull]);
 //
 // // A non-null std::unique_ptr to an `Employee`.
 // // As with `const`, it is possible to place the annotation on either side of
 // // a named type not ending in `*`, but placing it before the type it
 // // describes is preferred, unless inconsistent with surrounding code.
-// EX_ACTOR_absl_nonnull std::unique_ptr<Employee> employee;
+// absl_nonnull std::unique_ptr<Employee> employee;
 //
-// // Invalid annotation usage - this attempts to declare a pointer to a
+// // Invalid annotation usage – this attempts to declare a pointer to a
 // // nullable `Employee`, which is meaningless.
-// EX_ACTOR_absl_nullable Employee* e;
+// absl_nullable Employee* e;
 //
 // -----------------------------------------------------------------------------
 // Using Nullability Annotations
@@ -124,20 +124,20 @@
 // Example:
 //
 // // PaySalary() requires the passed pointer to an `Employee` to be non-null.
-// void PaySalary(Employee* EX_ACTOR_absl_nonnull e) {
+// void PaySalary(Employee* absl_nonnull e) {
 //   pay(e->salary);  // OK to dereference
 // }
 //
 // // CompleteTransaction() guarantees the returned pointer to an `Account` to
 // // be non-null.
-// Account* EX_ACTOR_absl_nonnull CompleteTransaction(double fee) {
+// Account* absl_nonnull balance CompleteTransaction(double fee) {
 // ...
 // }
 //
 // // Note that specifying a nullability annotation does not prevent someone
 // // from violating the contract:
 //
-// Employee* EX_ACTOR_absl_nullable find(Map& employees, std::string_view name);
+// Employee* absl_nullable find(Map& employees, std::string_view name);
 //
 // void g(Map& employees) {
 //   Employee *e = find(employees, "Pat");
@@ -177,10 +177,9 @@
 // These nullability annotations are primarily a human readable signal about the
 // intended contract of the pointer. They are not *types* and do not currently
 // provide any correctness guarantees. For example, a pointer annotated as
-// `EX_ACTOR_absl_nonnull` is *not guaranteed* to be non-null, and the compiler won't
-// alert or prevent assignment of a `T* EX_ACTOR_absl_nullable` to a `T* EX_ACTOR_absl_nonnull`.
+// `absl_nonnull` is *not guaranteed* to be non-null, and the compiler won't
+// alert or prevent assignment of a `T* absl_nullable` to a `T* absl_nonnull`.
 // ===========================================================================
-// SKIP_ABSL_INLINE_NAMESPACE_CHECK
 #ifndef EX_ACTOR_ABSL_BASE_NULLABILITY_H_
 #define EX_ACTOR_ABSL_BASE_NULLABILITY_H_
 
@@ -201,14 +200,14 @@
 //     EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL
 //
 //     void FillMessage(Message *m);                  // implicitly non-null
-//     T* EX_ACTOR_absl_nullable GetNullablePtr();           // explicitly nullable
-//     T* EX_ACTOR_absl_nullability_unknown GetUnknownPtr();  // explicitly unknown
+//     T* absl_nullable GetNullablePtr();           // explicitly nullable
+//     T* absl_nullability_unknown GetUnknownPtr();  // explicitly unknown
 //
-// The macro can be safely used in header files - it will not affect any files
+// The macro can be safely used in header files – it will not affect any files
 // that include it.
 //
-// In files with the macro, plain `T*` syntax means `T* EX_ACTOR_absl_nonnull`, and the
-// exceptions (`EX_ACTOR_absl_nullable` and `EX_ACTOR_absl_nullability_unknown`) must be marked
+// In files with the macro, plain `T*` syntax means `T* absl_nonnull`, and the
+// exceptions (`absl_nullable` and `absl_nullability_unknown`) must be marked
 // explicitly. The same holds, correspondingly, for smart pointer types.
 //
 // For comparison, without the macro, all unannotated pointers would default to
@@ -216,8 +215,8 @@
 //
 //     #include "ex_actor/3rd_lib/absl/base/nullability.h"
 //
-//     void FillMessage(Message* EX_ACTOR_absl_nonnull m);  // explicitly non-null
-//     T* EX_ACTOR_absl_nullable GetNullablePtr();          // explicitly nullable
+//     void FillMessage(Message* absl_nonnull m);  // explicitly non-null
+//     T* absl_nullable GetNullablePtr();          // explicitly nullable
 //     T* GetUnknownPtr();                           // implicitly unknown
 //
 // No-op except for being a human readable signal.
@@ -225,7 +224,7 @@
 
 #if defined(__clang__) && !defined(__OBJC__) && \
     EX_ACTOR_ABSL_HAVE_FEATURE(nullability_on_classes)
-// EX_ACTOR_absl_nonnull (default with `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`)
+// absl_nonnull (default with `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`)
 //
 // The indicated pointer is never null. It is the responsibility of the provider
 // of this pointer across an API boundary to ensure that the pointer is never
@@ -235,12 +234,12 @@
 // Example:
 //
 // // `employee` is designated as not null.
-// void PaySalary(Employee* EX_ACTOR_absl_nonnull employee) {
+// void PaySalary(Employee* absl_nonnull employee) {
 //   pay(*employee);  // OK to dereference
 // }
-#define EX_ACTOR_absl_nonnull _Nonnull
+#define absl_nonnull _Nonnull
 
-// EX_ACTOR_absl_nullable
+// absl_nullable
 //
 // The indicated pointer may, by design, be either null or non-null. Consumers
 // of this pointer across an API boundary should perform a `nullptr` check
@@ -249,14 +248,14 @@
 // Example:
 //
 // // `employee` may  be null.
-// void PaySalary(Employee* EX_ACTOR_absl_nullable employee) {
+// void PaySalary(Employee* absl_nullable employee) {
 //   if (employee != nullptr) {
 //     Pay(*employee);  // OK to dereference
 //   }
 // }
-#define EX_ACTOR_absl_nullable _Nullable
+#define absl_nullable _Nullable
 
-// EX_ACTOR_absl_nullability_unknown  (default without `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`)
+// absl_nullability_unknown  (default without `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`)
 //
 // The indicated pointer has not yet been determined to be definitively
 // "non-null" or "nullable." Providers of such pointers across API boundaries
@@ -264,8 +263,8 @@
 // Consumers of these pointers across an API boundary should treat such pointers
 // with the same caution they treat currently unannotated pointers. Most
 // existing code will have "unknown"  pointers, which should eventually be
-// migrated into one of the above two nullability states: `EX_ACTOR_absl_nonnull` or
-//  `EX_ACTOR_absl_nullable`.
+// migrated into one of the above two nullability states: `absl_nonnull` or
+//  `absl_nullable`.
 //
 // NOTE: For files that do not specify `EX_ACTOR_ABSL_POINTERS_DEFAULT_NONNULL`,
 // because this annotation is the global default state, unannotated pointers are
@@ -275,7 +274,7 @@
 // Example:
 //
 // // `employee`s nullability state is unknown.
-// void PaySalary(Employee* EX_ACTOR_absl_nullability_unknown employee) {
+// void PaySalary(Employee* absl_nullability_unknown employee) {
 //   Pay(*employee); // Potentially dangerous. API provider should investigate.
 // }
 //
@@ -286,14 +285,14 @@
 // void PaySalary(Employee* employee) {
 //   Pay(*employee); // Potentially dangerous. API provider should investigate.
 // }
-#define EX_ACTOR_absl_nullability_unknown _Null_unspecified
+#define absl_nullability_unknown _Null_unspecified
 #else
 // No-op for non-Clang compilers or Objective-C.
-#define EX_ACTOR_absl_nonnull
+#define absl_nonnull
 // No-op for non-Clang compilers or Objective-C.
-#define EX_ACTOR_absl_nullable
+#define absl_nullable
 // No-op for non-Clang compilers or Objective-C.
-#define EX_ACTOR_absl_nullability_unknown
+#define absl_nullability_unknown
 #endif
 
 // EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE

--- a/include/ex_actor/3rd_lib/absl/base/optimization.h
+++ b/include/ex_actor/3rd_lib/absl/base/optimization.h
@@ -31,7 +31,6 @@
 #define EX_ACTOR_ABSL_BASE_OPTIMIZATION_H_
 
 #include <assert.h>
-#include <stdlib.h>
 
 #ifdef __cplusplus
 // Included for std::unreachable()
@@ -218,12 +217,12 @@
 #elif defined(_MSC_VER)
 #define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() __assume(false)
 #else
-#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() ((void)0)
+#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL()
 #endif
 
 // `EX_ACTOR_ABSL_UNREACHABLE()` is an unreachable statement.  A program which reaches
 // one has undefined behavior, and the compiler may optimize accordingly.
-#if (EX_ACTOR_ABSL_OPTION_HARDENED == 1 || EX_ACTOR_ABSL_OPTION_HARDENED == 2) && defined(NDEBUG)
+#if EX_ACTOR_ABSL_OPTION_HARDENED == 1 && defined(NDEBUG)
 // Abort in hardened mode to avoid dangerous undefined behavior.
 #define EX_ACTOR_ABSL_UNREACHABLE()                \
   do {                                    \

--- a/include/ex_actor/3rd_lib/absl/base/optimization.h
+++ b/include/ex_actor/3rd_lib/absl/base/optimization.h
@@ -1,0 +1,311 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: optimization.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines portable macros for performance optimization.
+//
+// This header is included in both C++ code and legacy C code and thus must
+// remain compatible with both C and C++. C compatibility will be removed if
+// the legacy code is removed or converted to C++. Do not include this header in
+// new code that requires C compatibility or assume C compatibility will remain
+// indefinitely.
+
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+
+#ifndef EX_ACTOR_ABSL_BASE_OPTIMIZATION_H_
+#define EX_ACTOR_ABSL_BASE_OPTIMIZATION_H_
+
+#include <assert.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+// Included for std::unreachable()
+#include <utility>
+#endif  // __cplusplus
+
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/options.h"
+
+// EX_ACTOR_ABSL_BLOCK_TAIL_CALL_OPTIMIZATION
+//
+// Instructs the compiler to avoid optimizing tail-call recursion. This macro is
+// useful when you wish to preserve the existing function order within a stack
+// trace for logging, debugging, or profiling purposes.
+//
+// Example:
+//
+//   int f() {
+//     int result = g();
+//     EX_ACTOR_ABSL_BLOCK_TAIL_CALL_OPTIMIZATION();
+//     return result;
+//   }
+#if defined(__clang__)
+// Clang will not tail call given inline volatile assembly.
+#define EX_ACTOR_ABSL_BLOCK_TAIL_CALL_OPTIMIZATION() __asm__ __volatile__("")
+#elif defined(__GNUC__)
+// GCC will not tail call given inline volatile assembly.
+#define EX_ACTOR_ABSL_BLOCK_TAIL_CALL_OPTIMIZATION() __asm__ __volatile__("")
+#elif defined(_MSC_VER)
+#include <intrin.h>
+// The __nop() intrinsic blocks the optimisation.
+#define EX_ACTOR_ABSL_BLOCK_TAIL_CALL_OPTIMIZATION() __nop()
+#else
+#define EX_ACTOR_ABSL_BLOCK_TAIL_CALL_OPTIMIZATION() if (volatile int x = 0) { (void)x; }
+#endif
+
+// EX_ACTOR_ABSL_CACHELINE_SIZE
+//
+// Explicitly defines the size of the L1 cache for purposes of alignment.
+// Setting the cacheline size allows you to specify that certain objects be
+// aligned on a cacheline boundary with `EX_ACTOR_ABSL_CACHELINE_ALIGNED` declarations.
+// (See below.)
+//
+// NOTE: this macro should be replaced with the following C++17 features, when
+// those are generally available:
+//
+//   * `std::hardware_constructive_interference_size`
+//   * `std::hardware_destructive_interference_size`
+//
+// See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html
+// for more information.
+#if defined(__GNUC__)
+// Cache line alignment
+#if defined(__i386__) || defined(__x86_64__)
+#define EX_ACTOR_ABSL_CACHELINE_SIZE 64
+#elif defined(__powerpc64__)
+#define EX_ACTOR_ABSL_CACHELINE_SIZE 128
+#elif defined(__aarch64__)
+// We would need to read special register ctr_el0 to find out L1 dcache size.
+// This value is a good estimate based on a real aarch64 machine.
+#define EX_ACTOR_ABSL_CACHELINE_SIZE 64
+#elif defined(__arm__)
+// Cache line sizes for ARM: These values are not strictly correct since
+// cache line sizes depend on implementations, not architectures.  There
+// are even implementations with cache line sizes configurable at boot
+// time.
+#if defined(__ARM_ARCH_5T__)
+#define EX_ACTOR_ABSL_CACHELINE_SIZE 32
+#elif defined(__ARM_ARCH_7A__)
+#define EX_ACTOR_ABSL_CACHELINE_SIZE 64
+#endif
+#endif
+#endif
+
+#ifndef EX_ACTOR_ABSL_CACHELINE_SIZE
+// A reasonable default guess.  Note that overestimates tend to waste more
+// space, while underestimates tend to waste more time.
+#define EX_ACTOR_ABSL_CACHELINE_SIZE 64
+#endif
+
+// EX_ACTOR_ABSL_CACHELINE_ALIGNED
+//
+// Indicates that the declared object be cache aligned using
+// `EX_ACTOR_ABSL_CACHELINE_SIZE` (see above). Cacheline aligning objects allows you to
+// load a set of related objects in the L1 cache for performance improvements.
+// Cacheline aligning objects properly allows constructive memory sharing and
+// prevents destructive (or "false") memory sharing.
+//
+// NOTE: callers should replace uses of this macro with `alignas()` using
+// `std::hardware_constructive_interference_size` and/or
+// `std::hardware_destructive_interference_size` when C++17 becomes available to
+// them.
+//
+// See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html
+// for more information.
+//
+// On some compilers, `EX_ACTOR_ABSL_CACHELINE_ALIGNED` expands to an `__attribute__`
+// or `__declspec` attribute. For compilers where this is not known to work,
+// the macro expands to nothing.
+//
+// No further guarantees are made here. The result of applying the macro
+// to variables and types is always implementation-defined.
+//
+// WARNING: It is easy to use this attribute incorrectly, even to the point
+// of causing bugs that are difficult to diagnose, crash, etc. It does not
+// of itself guarantee that objects are aligned to a cache line.
+//
+// NOTE: Some compilers are picky about the locations of annotations such as
+// this attribute, so prefer to put it at the beginning of your declaration.
+// For example,
+//
+//   EX_ACTOR_ABSL_CACHELINE_ALIGNED static Foo* foo = ...
+//
+//   class EX_ACTOR_ABSL_CACHELINE_ALIGNED Bar { ...
+//
+// Recommendations:
+//
+// 1) Consult compiler documentation; this comment is not kept in sync as
+//    toolchains evolve.
+// 2) Verify your use has the intended effect. This often requires inspecting
+//    the generated machine code.
+// 3) Prefer applying this attribute to individual variables. Avoid
+//    applying it to types. This tends to localize the effect.
+#if defined(__clang__) || defined(__GNUC__)
+#define EX_ACTOR_ABSL_CACHELINE_ALIGNED __attribute__((aligned(EX_ACTOR_ABSL_CACHELINE_SIZE)))
+#elif defined(_MSC_VER)
+#define EX_ACTOR_ABSL_CACHELINE_ALIGNED __declspec(align(EX_ACTOR_ABSL_CACHELINE_SIZE))
+#else
+#define EX_ACTOR_ABSL_CACHELINE_ALIGNED
+#endif
+
+// EX_ACTOR_ABSL_PREDICT_TRUE, EX_ACTOR_ABSL_PREDICT_FALSE
+//
+// Enables the compiler to prioritize compilation using static analysis for
+// likely paths within a boolean branch.
+//
+// Example:
+//
+//   if (EX_ACTOR_ABSL_PREDICT_TRUE(expression)) {
+//     return result;                        // Faster if more likely
+//   } else {
+//     return 0;
+//   }
+//
+// Compilers can use the information that a certain branch is not likely to be
+// taken (for instance, a CHECK failure) to optimize for the common case in
+// the absence of better information (ie. compiling gcc with `-fprofile-arcs`).
+//
+// Recommendation: Modern CPUs dynamically predict branch execution paths,
+// typically with accuracy greater than 97%. As a result, annotating every
+// branch in a codebase is likely counterproductive; however, annotating
+// specific branches that are both hot and consistently mispredicted is likely
+// to yield performance improvements.
+#if EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_expect) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_PREDICT_FALSE(x) (__builtin_expect(false || (x), false))
+#define EX_ACTOR_ABSL_PREDICT_TRUE(x) (__builtin_expect(false || (x), true))
+#else
+#define EX_ACTOR_ABSL_PREDICT_FALSE(x) (x)
+#define EX_ACTOR_ABSL_PREDICT_TRUE(x) (x)
+#endif
+
+// `EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL()` aborts the program in the fastest
+// possible way, with no attempt at logging. One use is to implement hardening
+// aborts with EX_ACTOR_ABSL_OPTION_HARDENED.  Since this is an internal symbol, it
+// should not be used directly outside of Abseil.
+#if EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_trap) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL() __builtin_trap()
+#else
+#define EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL() abort()
+#endif
+
+// `EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL()` is the platform specific directive to
+// indicate that a statement is unreachable, and to allow the compiler to
+// optimize accordingly. Clients should use `EX_ACTOR_ABSL_UNREACHABLE()`, which is
+// defined below.
+#if defined(__cpp_lib_unreachable) && __cpp_lib_unreachable >= 202202L
+#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() std::unreachable()
+#elif defined(__GNUC__) || EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_unreachable)
+#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() __builtin_unreachable()
+#elif EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_assume)
+#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() __builtin_assume(false)
+#elif defined(_MSC_VER)
+#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() __assume(false)
+#else
+#define EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL() ((void)0)
+#endif
+
+// `EX_ACTOR_ABSL_UNREACHABLE()` is an unreachable statement.  A program which reaches
+// one has undefined behavior, and the compiler may optimize accordingly.
+#if (EX_ACTOR_ABSL_OPTION_HARDENED == 1 || EX_ACTOR_ABSL_OPTION_HARDENED == 2) && defined(NDEBUG)
+// Abort in hardened mode to avoid dangerous undefined behavior.
+#define EX_ACTOR_ABSL_UNREACHABLE()                \
+  do {                                    \
+    EX_ACTOR_ABSL_INTERNAL_IMMEDIATE_ABORT_IMPL(); \
+    EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL();     \
+  } while (false)
+#else
+// The assert only fires in debug mode to aid in debugging.
+// When NDEBUG is defined, reaching EX_ACTOR_ABSL_UNREACHABLE() is undefined behavior.
+#define EX_ACTOR_ABSL_UNREACHABLE()                       \
+  do {                                           \
+    /* NOLINTNEXTLINE: misc-static-assert */     \
+    assert(false && "EX_ACTOR_ABSL_UNREACHABLE reached"); \
+    EX_ACTOR_ABSL_INTERNAL_UNREACHABLE_IMPL();            \
+  } while (false)
+#endif
+
+// EX_ACTOR_ABSL_ASSUME(cond)
+//
+// Informs the compiler that a condition is always true and that it can assume
+// it to be true for optimization purposes.
+//
+// WARNING: If the condition is false, the program can produce undefined and
+// potentially dangerous behavior.
+//
+// In !NDEBUG mode, the condition is checked with an assert().
+//
+// NOTE: The expression must not have side effects, as it may only be evaluated
+// in some compilation modes and not others. Some compilers may issue a warning
+// if the compiler cannot prove the expression has no side effects. For example,
+// the expression should not use a function call since the compiler cannot prove
+// that a function call does not have side effects.
+//
+// Example:
+//
+//   int x = ...;
+//   EX_ACTOR_ABSL_ASSUME(x >= 0);
+//   // The compiler can optimize the division to a simple right shift using the
+//   // assumption specified above.
+//   int y = x / 16;
+//
+#if !defined(NDEBUG)
+#define EX_ACTOR_ABSL_ASSUME(cond) assert(cond)
+#elif EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_assume)
+#define EX_ACTOR_ABSL_ASSUME(cond) __builtin_assume(cond)
+#elif defined(_MSC_VER)
+#define EX_ACTOR_ABSL_ASSUME(cond) __assume(cond)
+#elif defined(__cpp_lib_unreachable) && __cpp_lib_unreachable >= 202202L
+#define EX_ACTOR_ABSL_ASSUME(cond) ((cond) ? void() : std::unreachable())
+#elif defined(__GNUC__) || EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_unreachable)
+#define EX_ACTOR_ABSL_ASSUME(cond) ((cond) ? void() : __builtin_unreachable())
+#elif EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
+// Unimplemented. Uses the same definition as EX_ACTOR_ABSL_ASSERT in the NDEBUG case.
+#define EX_ACTOR_ABSL_ASSUME(expr) (decltype((expr) ? void() : void())())
+#else
+#define EX_ACTOR_ABSL_ASSUME(expr) (false ? ((expr) ? void() : void()) : void())
+#endif
+
+// EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME(cond)
+// This macro forces small unique name on a static file level symbols like
+// static local variables or static functions. This is intended to be used in
+// macro definitions to optimize the cost of generated code. Do NOT use it on
+// symbols exported from translation unit since it may cause a link time
+// conflict.
+//
+// Example:
+//
+// #define MY_MACRO(txt)
+// namespace {
+//  char VeryVeryLongVarName[] EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME() = txt;
+//  const char* VeryVeryLongFuncName() EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME();
+//  const char* VeryVeryLongFuncName() { return txt; }
+// }
+//
+
+#if defined(__GNUC__)
+#define EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME2(x) #x
+#define EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME1(x) EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME2(x)
+#define EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME() \
+  asm(EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME1(.absl.__COUNTER__))
+#else
+#define EX_ACTOR_ABSL_INTERNAL_UNIQUE_SMALL_NAME()
+#endif
+
+#endif  // EX_ACTOR_ABSL_BASE_OPTIMIZATION_H_

--- a/include/ex_actor/3rd_lib/absl/base/options.h
+++ b/include/ex_actor/3rd_lib/absl/base/options.h
@@ -73,34 +73,6 @@
 // Type Compatibility Options
 // -----------------------------------------------------------------------------
 
-// EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION
-//
-// This option controls whether ex_actor::embedded_3rd::absl::SourceLocation is implemented as an alias
-// to the std::source_location type, or as an independent implementation.
-//
-// A value of 0 means to use Abseil's implementation.  This requires only C++17
-// support, and is expected to run on every toolchain we support, and to
-// properly capture source location information on every toolchain that supports
-// the necessary built-ins (such as `__builtin_LINE`).
-//
-// A value of 1 means to use aliases.  This requires that all code using Abseil
-// is built in C++20 mode or later.
-//
-// A value of 2 means to detect the C++ version being used to compile Abseil,
-// and use an alias only if working std::source_location types are available.
-// This option is useful when you are building your program from source.  It
-// should not be used otherwise -- for example, if you are distributing Abseil
-// in a binary package manager -- since in mode 2, they will name different
-// types, with different mangled names and binary layout, depending on the
-// compiler flags passed by the end user.  For more info, see
-// https://abseil.io/about/design/dropin-types.
-//
-// User code should not inspect this macro.  To check in the preprocessor if
-// the source location type is an alias of std::source_location type, use the
-// feature macro EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION.
-//
-#define EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION 2
-
 // EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING
 //
 // This option controls whether ex_actor::embedded_3rd::absl::{partial,weak,strong}_ordering are
@@ -151,7 +123,7 @@
 // allowed.
 
 #define EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE 0
-#define EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME head
+#define EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME lts_20260107
 
 // EX_ACTOR_ABSL_OPTION_HARDENED
 //
@@ -182,31 +154,5 @@
 // log additional information when `NDEBUG` is not defined.
 
 #define EX_ACTOR_ABSL_OPTION_HARDENED 0
-
-// EX_ACTOR_ABSL_OPTION_INLINE_HW_ACCEL_STRATEGY
-//
-// This option controls whether Abseil is allowed to use non-portable
-// hardware-accelerated implementations in headers (where they are typically
-// inlined into the caller's translation unit).
-//
-// Using such optimizations in headers can lead to One Definition Rule (ODR)
-// violations if different translation units are built with different CPU
-// architecture flags (e.g., -march=native vs -march=generic) and linked
-// together.
-//
-// A value of 0 means to use the portable software implementation in headers.
-// This provides the best ODR guarantees when linking code built with
-// inconsistent flags, but may be slower.
-//
-// A value of 1 means that the implementation requires the use of a
-// hardware-accelerated implementation. This requires the compiler environment
-// to support these instructions; otherwise, the build will fail.
-//
-// A value of 2 means to select the best available implementation based on
-// the compiler flags, but can't guarantee ODR safety if translation units are
-// built with inconsistent flags.
-//
-// User code should not inspect this macro.
-#define EX_ACTOR_ABSL_OPTION_INLINE_HW_ACCEL_STRATEGY 0
 
 #endif  // EX_ACTOR_ABSL_BASE_OPTIONS_H_

--- a/include/ex_actor/3rd_lib/absl/base/options.h
+++ b/include/ex_actor/3rd_lib/absl/base/options.h
@@ -1,0 +1,212 @@
+// Copyright 2019 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: options.h
+// -----------------------------------------------------------------------------
+//
+// This file contains Abseil configuration options for setting specific
+// implementations instead of letting Abseil determine which implementation to
+// use at compile-time. Setting these options may be useful for package or build
+// managers who wish to guarantee ABI stability within binary builds (which are
+// otherwise difficult to enforce).
+//
+// *** IMPORTANT NOTICE FOR PACKAGE MANAGERS:  It is important that
+// maintainers of package managers who wish to package Abseil read and
+// understand this file! ***
+//
+// Abseil contains a number of possible configuration endpoints, based on
+// parameters such as the detected platform, language version, or command-line
+// flags used to invoke the underlying binary. As is the case with all
+// libraries, binaries which contain Abseil code must ensure that separate
+// packages use the same compiled copy of Abseil to avoid a diamond dependency
+// problem, which can occur if two packages built with different Abseil
+// configuration settings are linked together. Diamond dependency problems in
+// C++ may manifest as violations to the One Definition Rule (ODR) (resulting in
+// linker errors), or undefined behavior (resulting in crashes).
+//
+// Diamond dependency problems can be avoided if all packages utilize the same
+// exact version of Abseil. Building from source code with the same compilation
+// parameters is the easiest way to avoid such dependency problems. However, for
+// package managers who cannot control such compilation parameters, we are
+// providing the file to allow you to inject ABI (Application Binary Interface)
+// stability across builds. Settings options in this file will neither change
+// API nor ABI, providing a stable copy of Abseil between packages.
+//
+// Care must be taken to keep options within these configurations isolated
+// from any other dynamic settings, such as command-line flags which could alter
+// these options. This file is provided specifically to help build and package
+// managers provide a stable copy of Abseil within their libraries and binaries;
+// other developers should not have need to alter the contents of this file.
+//
+// -----------------------------------------------------------------------------
+// Usage
+// -----------------------------------------------------------------------------
+//
+// For any particular package release, set the appropriate definitions within
+// this file to whatever value makes the most sense for your package(s). Note
+// that, by default, most of these options, at the moment, affect the
+// implementation of types; future options may affect other implementation
+// details.
+//
+// NOTE: the defaults within this file all assume that Abseil can select the
+// proper Abseil implementation at compile-time, which will not be sufficient
+// to guarantee ABI stability to package managers.
+
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+
+#ifndef EX_ACTOR_ABSL_BASE_OPTIONS_H_
+#define EX_ACTOR_ABSL_BASE_OPTIONS_H_
+
+// -----------------------------------------------------------------------------
+// Type Compatibility Options
+// -----------------------------------------------------------------------------
+
+// EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION
+//
+// This option controls whether ex_actor::embedded_3rd::absl::SourceLocation is implemented as an alias
+// to the std::source_location type, or as an independent implementation.
+//
+// A value of 0 means to use Abseil's implementation.  This requires only C++17
+// support, and is expected to run on every toolchain we support, and to
+// properly capture source location information on every toolchain that supports
+// the necessary built-ins (such as `__builtin_LINE`).
+//
+// A value of 1 means to use aliases.  This requires that all code using Abseil
+// is built in C++20 mode or later.
+//
+// A value of 2 means to detect the C++ version being used to compile Abseil,
+// and use an alias only if working std::source_location types are available.
+// This option is useful when you are building your program from source.  It
+// should not be used otherwise -- for example, if you are distributing Abseil
+// in a binary package manager -- since in mode 2, they will name different
+// types, with different mangled names and binary layout, depending on the
+// compiler flags passed by the end user.  For more info, see
+// https://abseil.io/about/design/dropin-types.
+//
+// User code should not inspect this macro.  To check in the preprocessor if
+// the source location type is an alias of std::source_location type, use the
+// feature macro EX_ACTOR_ABSL_USES_STD_SOURCE_LOCATION.
+//
+#define EX_ACTOR_ABSL_OPTION_USE_STD_SOURCE_LOCATION 2
+
+// EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING
+//
+// This option controls whether ex_actor::embedded_3rd::absl::{partial,weak,strong}_ordering are
+// implemented as aliases to the std:: ordering types, or as an independent
+// implementation.
+//
+// A value of 0 means to use Abseil's implementation.  This requires only C++11
+// support, and is expected to work on every toolchain we support.
+//
+// A value of 1 means to use aliases.  This requires that all code using Abseil
+// is built in C++20 mode or later.
+//
+// A value of 2 means to detect the C++ version being used to compile Abseil,
+// and use an alias only if working std:: ordering types are available.  This
+// option is useful when you are building your program from source.  It should
+// not be used otherwise -- for example, if you are distributing Abseil in a
+// binary package manager -- since in mode 2, they will name different types,
+// with different mangled names and binary layout, depending on the compiler
+// flags passed by the end user.  For more info, see
+// https://abseil.io/about/design/dropin-types.
+//
+// User code should not inspect this macro.  To check in the preprocessor if
+// the ordering types are aliases of std:: ordering types, use the feature macro
+// EX_ACTOR_ABSL_USES_STD_ORDERING.
+
+#define EX_ACTOR_ABSL_OPTION_USE_STD_ORDERING 2
+
+// EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE
+// EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME
+//
+// These options controls whether all entities in the absl namespace are
+// contained within an inner inline namespace.  This does not affect the
+// user-visible API of Abseil, but it changes the mangled names of all symbols.
+//
+// This can be useful as a version tag if you are distributing Abseil in
+// precompiled form.  This will prevent a binary library build of Abseil with
+// one inline namespace being used with headers configured with a different
+// inline namespace name.  Binary packagers are reminded that Abseil does not
+// guarantee any ABI stability in Abseil, so any update of Abseil or
+// configuration change in such a binary package should be combined with a
+// new, unique value for the inline namespace name.
+//
+// A value of 0 means not to use inline namespaces.
+//
+// A value of 1 means to use an inline namespace with the given name inside
+// namespace ex_actor::embedded_3rd::absl.  If this is set, EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME must also
+// be changed to a new, unique identifier name.  In particular "head" is not
+// allowed.
+
+#define EX_ACTOR_ABSL_OPTION_USE_INLINE_NAMESPACE 0
+#define EX_ACTOR_ABSL_OPTION_INLINE_NAMESPACE_NAME head
+
+// EX_ACTOR_ABSL_OPTION_HARDENED
+//
+// This option enables a "hardened" build in release mode (in this context,
+// release mode is defined as a build where the `NDEBUG` macro is defined).
+//
+// A value of 0 means that "hardened" mode is not enabled.
+//
+// A value of 1 means that "hardened" mode is enabled with all checks.
+//
+// A value of 2 means that "hardened" mode is partially enabled, with
+// only a subset of checks chosen to minimize performance impact.
+//
+// Hardened builds have additional security checks enabled when `NDEBUG` is
+// defined. Defining `NDEBUG` is normally used to turn `assert()` macro into a
+// no-op, as well as disabling other bespoke program consistency checks. By
+// defining EX_ACTOR_ABSL_OPTION_HARDENED to 1, a select set of checks remain enabled in
+// release mode. These checks guard against programming errors that may lead to
+// security vulnerabilities. In release mode, when one of these programming
+// errors is encountered, the program will immediately abort, possibly without
+// any attempt at logging.
+//
+// The checks enabled by this option are not free; they do incur runtime cost.
+//
+// The checks enabled by this option are always active when `NDEBUG` is not
+// defined, even in the case when EX_ACTOR_ABSL_OPTION_HARDENED is defined to 0. The
+// checks enabled by this option may abort the program in a different way and
+// log additional information when `NDEBUG` is not defined.
+
+#define EX_ACTOR_ABSL_OPTION_HARDENED 0
+
+// EX_ACTOR_ABSL_OPTION_INLINE_HW_ACCEL_STRATEGY
+//
+// This option controls whether Abseil is allowed to use non-portable
+// hardware-accelerated implementations in headers (where they are typically
+// inlined into the caller's translation unit).
+//
+// Using such optimizations in headers can lead to One Definition Rule (ODR)
+// violations if different translation units are built with different CPU
+// architecture flags (e.g., -march=native vs -march=generic) and linked
+// together.
+//
+// A value of 0 means to use the portable software implementation in headers.
+// This provides the best ODR guarantees when linking code built with
+// inconsistent flags, but may be slower.
+//
+// A value of 1 means that the implementation requires the use of a
+// hardware-accelerated implementation. This requires the compiler environment
+// to support these instructions; otherwise, the build will fail.
+//
+// A value of 2 means to select the best available implementation based on
+// the compiler flags, but can't guarantee ODR safety if translation units are
+// built with inconsistent flags.
+//
+// User code should not inspect this macro.
+#define EX_ACTOR_ABSL_OPTION_INLINE_HW_ACCEL_STRATEGY 0
+
+#endif  // EX_ACTOR_ABSL_BASE_OPTIONS_H_

--- a/include/ex_actor/3rd_lib/absl/base/policy_checks.h
+++ b/include/ex_actor/3rd_lib/absl/base/policy_checks.h
@@ -1,0 +1,115 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: policy_checks.h
+// -----------------------------------------------------------------------------
+//
+// This header enforces a minimum set of policies at build time, such as the
+// supported compiler and library versions. Unsupported configurations are
+// reported with `#error`. This enforcement is best effort, so successfully
+// compiling this header does not guarantee a supported configuration.
+
+// SKIP_ABSL_INLINE_NAMESPACE_CHECK
+
+#ifndef EX_ACTOR_ABSL_BASE_POLICY_CHECKS_H_
+#define EX_ACTOR_ABSL_BASE_POLICY_CHECKS_H_
+
+// Included for the __GLIBC_PREREQ macro used below.
+#include <limits.h>
+
+// Included for the _STLPORT_VERSION macro used below.
+#if defined(__cplusplus)
+#include <cstddef>
+#endif
+
+// -----------------------------------------------------------------------------
+// Operating System Check
+// -----------------------------------------------------------------------------
+
+#if defined(__CYGWIN__)
+#error "Cygwin is not supported."
+#endif
+
+// -----------------------------------------------------------------------------
+// Toolchain Check
+// -----------------------------------------------------------------------------
+
+// We support Visual Studio 2022 (MSVC++ 17.0) and later.
+// This minimum will go up.
+#if defined(_MSC_VER) && _MSC_VER < 1930 && !defined(__clang__)
+#error "This package requires Visual Studio 2022 (MSVC++ 17.0) or higher."
+#endif
+
+// We support GCC 7 and later.
+// This minimum will go up.
+#if defined(__GNUC__) && !defined(__clang__)
+#if __GNUC__ < 10
+#error "This package requires GCC 10 or higher."
+#endif
+#endif
+
+// We support Apple Xcode clang 4.2.1 (version 421.11.65) and later.
+// This corresponds to Apple Xcode version 4.5.
+// This minimum will go up.
+#if defined(__apple_build_version__) && __apple_build_version__ < 4211165
+#error "This package requires __apple_build_version__ of 4211165 or higher."
+#endif
+
+// -----------------------------------------------------------------------------
+// C++ Version Check
+// -----------------------------------------------------------------------------
+
+// Enforce C++17 as the minimum.
+#if defined(_MSVC_LANG)
+#if _MSVC_LANG < 201703L
+#error "C++ versions less than C++17 are not supported."
+#endif  // _MSVC_LANG < 201703L
+#elif defined(__cplusplus)
+#if __cplusplus < 201703L
+#error "C++ versions less than C++17 are not supported."
+#endif  // __cplusplus < 201703L
+#endif
+
+// -----------------------------------------------------------------------------
+// Standard Library Check
+// -----------------------------------------------------------------------------
+
+#if defined(_STLPORT_VERSION)
+#error "STLPort is not supported."
+#endif
+
+// -----------------------------------------------------------------------------
+// `char` Size Check
+// -----------------------------------------------------------------------------
+
+// Abseil currently assumes CHAR_BIT == 8. If you would like to use Abseil on a
+// platform where this is not the case, please provide us with the details about
+// your platform so we can consider relaxing this requirement.
+#if CHAR_BIT != 8
+#error "Abseil assumes CHAR_BIT == 8."
+#endif
+
+// -----------------------------------------------------------------------------
+// `int` Size Check
+// -----------------------------------------------------------------------------
+
+// Abseil currently assumes that an int is 4 bytes. If you would like to use
+// Abseil on a platform where this is not the case, please provide us with the
+// details about your platform so we can consider relaxing this requirement.
+#if INT_MAX < 2147483647
+#error "Abseil assumes that int is at least 4 bytes. "
+#endif
+
+#endif  // EX_ACTOR_ABSL_BASE_POLICY_CHECKS_H_

--- a/include/ex_actor/3rd_lib/absl/base/policy_checks.h
+++ b/include/ex_actor/3rd_lib/absl/base/policy_checks.h
@@ -46,17 +46,17 @@
 // Toolchain Check
 // -----------------------------------------------------------------------------
 
-// We support Visual Studio 2022 (MSVC++ 17.0) and later.
+// We support Visual Studio 2019 (MSVC++ 16.0) and later.
 // This minimum will go up.
-#if defined(_MSC_VER) && _MSC_VER < 1930 && !defined(__clang__)
-#error "This package requires Visual Studio 2022 (MSVC++ 17.0) or higher."
+#if defined(_MSC_VER) && _MSC_VER < 1920 && !defined(__clang__)
+#error "This package requires Visual Studio 2019 (MSVC++ 16.0) or higher."
 #endif
 
 // We support GCC 7 and later.
 // This minimum will go up.
 #if defined(__GNUC__) && !defined(__clang__)
-#if __GNUC__ < 10
-#error "This package requires GCC 10 or higher."
+#if __GNUC__ < 7
+#error "This package requires GCC 7 or higher."
 #endif
 #endif
 

--- a/include/ex_actor/3rd_lib/absl/base/port.h
+++ b/include/ex_actor/3rd_lib/absl/base/port.h
@@ -1,0 +1,25 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This files is a forwarding header for other headers containing various
+// portability macros and functions.
+
+#ifndef EX_ACTOR_ABSL_BASE_PORT_H_
+#define EX_ACTOR_ABSL_BASE_PORT_H_
+
+#include "ex_actor/3rd_lib/absl/base/attributes.h"
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/optimization.h"
+
+#endif  // EX_ACTOR_ABSL_BASE_PORT_H_

--- a/include/ex_actor/3rd_lib/absl/functional/any_invocable.h
+++ b/include/ex_actor/3rd_lib/absl/functional/any_invocable.h
@@ -191,7 +191,7 @@ class EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE EX_ACTOR_ABSL_ATTRIBUTE_OWNER AnyInvo
   // Upon construction, `*this` is only empty if `f` is a function pointer or
   // member pointer type and is null, or if `f` is an `AnyInvocable` that is
   // empty.
-  template <class F, typename = std::enable_if_t<
+  template <class F, typename = ex_actor::embedded_3rd::absl::enable_if_t<
                          internal_any_invocable::CanConvert<Sig, F>::value>>
   AnyInvocable(F&& f)  // NOLINT
       : Impl(internal_any_invocable::ConversionConstruct(),
@@ -203,27 +203,28 @@ class EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE EX_ACTOR_ABSL_ATTRIBUTE_OWNER AnyInvo
   // Example:
   //
   //   AnyInvocable<int(int)> func(
-  //       std::in_place_type<PossiblyImmovableType>, arg1, arg2);
+  //       ex_actor::embedded_3rd::absl::in_place_type<PossiblyImmovableType>, arg1, arg2);
   //
   template <class T, class... Args,
-            typename = std::enable_if_t<
+            typename = ex_actor::embedded_3rd::absl::enable_if_t<
                 internal_any_invocable::CanEmplace<Sig, T, Args...>::value>>
-  explicit AnyInvocable(std::in_place_type_t<T>, Args&&... args)
-      : Impl(std::in_place_type<std::decay_t<T>>, std::forward<Args>(args)...) {
-    static_assert(std::is_same<T, std::decay_t<T>>::value,
+  explicit AnyInvocable(ex_actor::embedded_3rd::absl::in_place_type_t<T>, Args&&... args)
+      : Impl(ex_actor::embedded_3rd::absl::in_place_type<ex_actor::embedded_3rd::absl::decay_t<T>>,
+             std::forward<Args>(args)...) {
+    static_assert(std::is_same<T, ex_actor::embedded_3rd::absl::decay_t<T>>::value,
                   "The explicit template argument of in_place_type is required "
                   "to be an unqualified object type.");
   }
 
   // Overload of the above constructor to support list-initialization.
   template <class T, class U, class... Args,
-            typename = std::enable_if_t<internal_any_invocable::CanEmplace<
+            typename = ex_actor::embedded_3rd::absl::enable_if_t<internal_any_invocable::CanEmplace<
                 Sig, T, std::initializer_list<U>&, Args...>::value>>
-  explicit AnyInvocable(std::in_place_type_t<T>, std::initializer_list<U> ilist,
-                        Args&&... args)
-      : Impl(std::in_place_type<std::decay_t<T>>, ilist,
+  explicit AnyInvocable(ex_actor::embedded_3rd::absl::in_place_type_t<T>,
+                        std::initializer_list<U> ilist, Args&&... args)
+      : Impl(ex_actor::embedded_3rd::absl::in_place_type<ex_actor::embedded_3rd::absl::decay_t<T>>, ilist,
              std::forward<Args>(args)...) {
-    static_assert(std::is_same<T, std::decay_t<T>>::value,
+    static_assert(std::is_same<T, ex_actor::embedded_3rd::absl::decay_t<T>>::value,
                   "The explicit template argument of in_place_type is required "
                   "to be an unqualified object type.");
   }
@@ -247,7 +248,7 @@ class EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE EX_ACTOR_ABSL_ATTRIBUTE_OWNER AnyInvo
   // Upon assignment, `*this` is only empty if `f` is a function pointer or
   // member pointer type and is null, or if `f` is an `AnyInvocable` that is
   // empty.
-  template <class F, typename = std::enable_if_t<
+  template <class F, typename = ex_actor::embedded_3rd::absl::enable_if_t<
                          internal_any_invocable::CanAssign<Sig, F>::value>>
   AnyInvocable& operator=(F&& f) {
     *this = AnyInvocable(std::forward<F>(f));
@@ -259,7 +260,7 @@ class EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE EX_ACTOR_ABSL_ATTRIBUTE_OWNER AnyInvo
   // `AnyInvocable` instance.
   template <
       class F,
-      typename = std::enable_if_t<
+      typename = ex_actor::embedded_3rd::absl::enable_if_t<
           internal_any_invocable::CanAssignReferenceWrapper<Sig, F>::value>>
   AnyInvocable& operator=(std::reference_wrapper<F> f) noexcept {
     *this = AnyInvocable(f);

--- a/include/ex_actor/3rd_lib/absl/functional/any_invocable.h
+++ b/include/ex_actor/3rd_lib/absl/functional/any_invocable.h
@@ -1,0 +1,335 @@
+// Copyright 2022 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// File: any_invocable.h
+// -----------------------------------------------------------------------------
+//
+// This header file defines an `ex_actor::embedded_3rd::absl::AnyInvocable` type that assumes ownership
+// and wraps an object of an invocable type. (Invocable types adhere to the
+// concept specified in https://en.cppreference.com/w/cpp/concepts/invocable.)
+//
+// In general, prefer `ex_actor::embedded_3rd::absl::AnyInvocable` when you need a type-erased
+// function parameter that needs to take ownership of the type.
+//
+// NOTE: `ex_actor::embedded_3rd::absl::AnyInvocable` is similar to the C++23 `std::move_only_function`
+// abstraction, but has a slightly different API and is not designed to be a
+// drop-in replacement or backfill of that type.
+//
+// Credits to Matt Calabrese (https://github.com/mattcalabrese) for the original
+// implementation.
+
+#ifndef EX_ACTOR_ABSL_FUNCTIONAL_ANY_INVOCABLE_H_
+#define EX_ACTOR_ABSL_FUNCTIONAL_ANY_INVOCABLE_H_
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
+
+#include "ex_actor/3rd_lib/absl/base/attributes.h"
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/nullability.h"
+#include "ex_actor/3rd_lib/absl/functional/internal/any_invocable.h"
+#include "ex_actor/3rd_lib/absl/meta/type_traits.h"
+#include "ex_actor/3rd_lib/absl/utility/utility.h"
+
+namespace ex_actor::embedded_3rd::absl {
+EX_ACTOR_ABSL_NAMESPACE_BEGIN
+
+// ex_actor::embedded_3rd::absl::AnyInvocable
+//
+// `ex_actor::embedded_3rd::absl::AnyInvocable` is a functional wrapper type, like `std::function`, that
+// assumes ownership of an invocable object. Unlike `std::function`, an
+// `ex_actor::embedded_3rd::absl::AnyInvocable` is more type-safe and provides the following additional
+// benefits:
+//
+// * Properly adheres to const correctness of the underlying type
+// * Is move-only so avoids concurrency problems with copied invocables and
+//   unnecessary copies in general.
+// * Supports reference qualifiers allowing it to perform unique actions (noted
+//   below).
+//
+// `ex_actor::embedded_3rd::absl::AnyInvocable` is a template, and an `ex_actor::embedded_3rd::absl::AnyInvocable` instantiation
+// may wrap any invocable object with a compatible function signature, e.g.
+// having arguments and return types convertible to types matching the
+// `ex_actor::embedded_3rd::absl::AnyInvocable` signature, and also matching any stated reference
+// qualifiers, as long as that type is moveable. It therefore provides broad
+// type erasure for functional objects.
+//
+// An `ex_actor::embedded_3rd::absl::AnyInvocable` is typically used as a type-erased function parameter
+// for accepting various functional objects:
+//
+// // Define a function taking an AnyInvocable parameter.
+// void my_func(ex_actor::embedded_3rd::absl::AnyInvocable<int()> f) {
+//   ...
+// };
+//
+// // That function can accept any invocable type:
+//
+// // Accept a function reference. We don't need to move a reference.
+// int func1() { return 0; };
+// my_func(func1);
+//
+// // Accept a lambda. We use std::move here because otherwise my_func would
+// // copy the lambda.
+// auto lambda = []() { return 0; };
+// my_func(std::move(lambda));
+//
+// // Accept a function pointer. We don't need to move a function pointer.
+// func2 = &func1;
+// my_func(func2);
+//
+// // Accept an std::function by moving it. Note that the lambda is copyable
+// // (satisfying std::function requirements) and moveable (satisfying
+// // ex_actor::embedded_3rd::absl::AnyInvocable requirements).
+// std::function<int()> func6 = []() { return 0; };
+// my_func(std::move(func6));
+//
+// `AnyInvocable` also properly respects `const` qualifiers, reference
+// qualifiers, and the `noexcept` specification  as part of the user-specified
+// function type (e.g. `AnyInvocable<void() const && noexcept>`). These
+// qualifiers will be applied to the `AnyInvocable` object's `operator()`, and
+// the underlying invocable must be compatible with those qualifiers.
+//
+// Comparison of const and non-const function types:
+//
+//   // Store a closure inside of `func` with the function type `int()`.
+//   // Note that we have made `func` itself `const`.
+//   const AnyInvocable<int()> func = [](){ return 0; };
+//
+//   func();  // Compile-error: the passed type `int()` isn't `const`.
+//
+//   // Store a closure inside of `const_func` with the function type
+//   // `int() const`.
+//   // Note that we have also made `const_func` itself `const`.
+//   const AnyInvocable<int() const> const_func = [](){ return 0; };
+//
+//   const_func();  // Fine: `int() const` is `const`.
+//
+// In the above example, the call `func()` would have compiled if
+// `std::function` were used even though the types are not const compatible.
+// This is a bug, and using `ex_actor::embedded_3rd::absl::AnyInvocable` properly detects that bug.
+//
+// In addition to affecting the signature of `operator()`, the `const` and
+// reference qualifiers of the function type also appropriately constrain which
+// kinds of invocable objects you are allowed to place into the `AnyInvocable`
+// instance. If you specify a function type that is const-qualified, then
+// anything that you attempt to put into the `AnyInvocable` must be callable on
+// a `const` instance of that type.
+//
+// Constraint example:
+//
+//   // Fine because the lambda is callable when `const`.
+//   AnyInvocable<int() const> func = [=](){ return 0; };
+//
+//   // This is a compile-error because the lambda isn't callable when `const`.
+//   AnyInvocable<int() const> error = [=]() mutable { return 0; };
+//
+// An `&&` qualifier can be used to express that an `ex_actor::embedded_3rd::absl::AnyInvocable`
+// instance should be invoked at most once:
+//
+//   // Invokes `continuation` with the logical result of an operation when
+//   // that operation completes (common in asynchronous code).
+//   void CallOnCompletion(AnyInvocable<void(int)&&> continuation) {
+//     int result_of_foo = foo();
+//
+//     // `std::move` is required because the `operator()` of `continuation` is
+//     // rvalue-reference qualified.
+//     std::move(continuation)(result_of_foo);
+//   }
+//
+// Attempting to call `ex_actor::embedded_3rd::absl::AnyInvocable` multiple times in such a case
+// results in undefined behavior.
+//
+// Invoking an empty `ex_actor::embedded_3rd::absl::AnyInvocable` results in undefined behavior:
+//
+//   // Create an empty instance using the default constructor.
+//   AnyInvocable<void()> empty;
+//   empty();  // WARNING: Undefined behavior!
+template <class Sig>
+class EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE EX_ACTOR_ABSL_ATTRIBUTE_OWNER AnyInvocable
+    : private internal_any_invocable::Impl<Sig> {
+ private:
+  static_assert(
+      std::is_function<Sig>::value,
+      "The template argument of AnyInvocable must be a function type.");
+
+  using Impl = internal_any_invocable::Impl<Sig>;
+
+ public:
+  // The return type of Sig
+  using result_type = typename Impl::result_type;
+  using absl_internal_is_view = std::false_type;
+
+  // Constructors
+
+  // Constructs the `AnyInvocable` in an empty state.
+  // Invoking it results in undefined behavior.
+  AnyInvocable() noexcept = default;
+  AnyInvocable(std::nullptr_t) noexcept {}  // NOLINT
+
+  // Constructs the `AnyInvocable` from an existing `AnyInvocable` by a move.
+  // Note that `f` is not guaranteed to be empty after move-construction,
+  // although it may be.
+  AnyInvocable(AnyInvocable&& /*f*/) noexcept = default;
+
+  // Constructs an `AnyInvocable` from an invocable object.
+  //
+  // Upon construction, `*this` is only empty if `f` is a function pointer or
+  // member pointer type and is null, or if `f` is an `AnyInvocable` that is
+  // empty.
+  template <class F, typename = std::enable_if_t<
+                         internal_any_invocable::CanConvert<Sig, F>::value>>
+  AnyInvocable(F&& f)  // NOLINT
+      : Impl(internal_any_invocable::ConversionConstruct(),
+             std::forward<F>(f)) {}
+
+  // Constructs an `AnyInvocable` that holds an invocable object of type `T`,
+  // which is constructed in-place from the given arguments.
+  //
+  // Example:
+  //
+  //   AnyInvocable<int(int)> func(
+  //       std::in_place_type<PossiblyImmovableType>, arg1, arg2);
+  //
+  template <class T, class... Args,
+            typename = std::enable_if_t<
+                internal_any_invocable::CanEmplace<Sig, T, Args...>::value>>
+  explicit AnyInvocable(std::in_place_type_t<T>, Args&&... args)
+      : Impl(std::in_place_type<std::decay_t<T>>, std::forward<Args>(args)...) {
+    static_assert(std::is_same<T, std::decay_t<T>>::value,
+                  "The explicit template argument of in_place_type is required "
+                  "to be an unqualified object type.");
+  }
+
+  // Overload of the above constructor to support list-initialization.
+  template <class T, class U, class... Args,
+            typename = std::enable_if_t<internal_any_invocable::CanEmplace<
+                Sig, T, std::initializer_list<U>&, Args...>::value>>
+  explicit AnyInvocable(std::in_place_type_t<T>, std::initializer_list<U> ilist,
+                        Args&&... args)
+      : Impl(std::in_place_type<std::decay_t<T>>, ilist,
+             std::forward<Args>(args)...) {
+    static_assert(std::is_same<T, std::decay_t<T>>::value,
+                  "The explicit template argument of in_place_type is required "
+                  "to be an unqualified object type.");
+  }
+
+  // Assignment Operators
+
+  // Assigns an `AnyInvocable` through move-assignment.
+  // Note that `f` is not guaranteed to be empty after move-assignment
+  // although it may be.
+  AnyInvocable& operator=(AnyInvocable&& /*f*/) noexcept = default;
+
+  // Assigns an `AnyInvocable` from a nullptr, clearing the `AnyInvocable`. If
+  // not empty, destroys the target, putting `*this` into an empty state.
+  AnyInvocable& operator=(std::nullptr_t) noexcept {
+    this->Clear();
+    return *this;
+  }
+
+  // Assigns an `AnyInvocable` from an existing `AnyInvocable` instance.
+  //
+  // Upon assignment, `*this` is only empty if `f` is a function pointer or
+  // member pointer type and is null, or if `f` is an `AnyInvocable` that is
+  // empty.
+  template <class F, typename = std::enable_if_t<
+                         internal_any_invocable::CanAssign<Sig, F>::value>>
+  AnyInvocable& operator=(F&& f) {
+    *this = AnyInvocable(std::forward<F>(f));
+    return *this;
+  }
+
+  // Assigns an `AnyInvocable` from a reference to an invocable object.
+  // Upon assignment, stores a reference to the invocable object in the
+  // `AnyInvocable` instance.
+  template <
+      class F,
+      typename = std::enable_if_t<
+          internal_any_invocable::CanAssignReferenceWrapper<Sig, F>::value>>
+  AnyInvocable& operator=(std::reference_wrapper<F> f) noexcept {
+    *this = AnyInvocable(f);
+    return *this;
+  }
+
+  // Destructor
+
+  // If not empty, destroys the target.
+  ~AnyInvocable() = default;
+
+  // ex_actor::embedded_3rd::absl::AnyInvocable::swap()
+  //
+  // Exchanges the targets of `*this` and `other`.
+  void swap(AnyInvocable& other) noexcept { std::swap(*this, other); }
+
+  // ex_actor::embedded_3rd::absl::AnyInvocable::operator bool()
+  //
+  // Returns `true` if `*this` is not empty.
+  //
+  // WARNING: An `AnyInvocable` that wraps an empty `std::function` is not
+  // itself empty. This behavior is consistent with the standard equivalent
+  // `std::move_only_function`. In the following example, `a()` will actually
+  // invoke `f()`, leading to an `std::bad_function_call` exception:
+  //   std::function<void()> f;  // empty
+  //   ex_actor::embedded_3rd::absl::AnyInvocable<void()> a = f;  // not empty
+  //
+  // Invoking an empty `AnyInvocable` results in undefined behavior.
+  explicit operator bool() const noexcept { return this->HasValue(); }
+
+  // Invokes the target object of `*this`. `*this` must not be empty.
+  //
+  // Note: The signature of this function call operator is the same as the
+  //       template parameter `Sig`.
+  using Impl::operator();
+
+  // Equality operators
+
+  // Returns `true` if `f` is empty.
+  friend bool operator==(const AnyInvocable& f, std::nullptr_t) noexcept {
+    return !f.HasValue();
+  }
+
+  // Returns `true` if `f` is empty.
+  friend bool operator==(std::nullptr_t, const AnyInvocable& f) noexcept {
+    return !f.HasValue();
+  }
+
+  // Returns `false` if `f` is empty.
+  friend bool operator!=(const AnyInvocable& f, std::nullptr_t) noexcept {
+    return f.HasValue();
+  }
+
+  // Returns `false` if `f` is empty.
+  friend bool operator!=(std::nullptr_t, const AnyInvocable& f) noexcept {
+    return f.HasValue();
+  }
+
+  // swap()
+  //
+  // Exchanges the targets of `f1` and `f2`.
+  friend void swap(AnyInvocable& f1, AnyInvocable& f2) noexcept { f1.swap(f2); }
+
+ private:
+  // Friending other instantiations is necessary for conversions.
+  template <bool /*SigIsNoexcept*/, class /*ReturnType*/, class... /*P*/>
+  friend class internal_any_invocable::CoreImpl;
+};
+
+EX_ACTOR_ABSL_NAMESPACE_END
+}  // namespace ex_actor::embedded_3rd::absl
+
+#endif  // EX_ACTOR_ABSL_FUNCTIONAL_ANY_INVOCABLE_H_

--- a/include/ex_actor/3rd_lib/absl/functional/internal/any_invocable.h
+++ b/include/ex_actor/3rd_lib/absl/functional/internal/any_invocable.h
@@ -1,0 +1,787 @@
+// Copyright 2022 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Implementation details for `ex_actor::embedded_3rd::absl::AnyInvocable`
+
+#ifndef EX_ACTOR_ABSL_FUNCTIONAL_INTERNAL_ANY_INVOCABLE_H_
+#define EX_ACTOR_ABSL_FUNCTIONAL_INTERNAL_ANY_INVOCABLE_H_
+
+////////////////////////////////////////////////////////////////////////////////
+//                                                                            //
+// This implementation chooses between local storage and remote storage for   //
+// the contained target object based on the target object's size, alignment   //
+// requirements, and whether or not it has a nothrow move constructor.        //
+// Additional optimizations are performed when the object is a trivially      //
+// copyable type [basic.types].                                               //
+//                                                                            //
+// There are three datamembers per `AnyInvocable` instance                    //
+//                                                                            //
+// 1) A union containing either                                               //
+//        - A pointer to the target object referred to via a void*, or        //
+//        - the target object, emplaced into a raw char buffer                //
+//                                                                            //
+// 2) A function pointer to a "manager" function operation that takes a       //
+//    discriminator and logically branches to either perform a move operation //
+//    or destroy operation based on that discriminator.                       //
+//                                                                            //
+// 3) A function pointer to an "invoker" function operation that invokes the  //
+//    target object, directly returning the result.                           //
+//                                                                            //
+// When in the logically empty state, the manager function is an empty        //
+// function and the invoker function is one that would be undefined behavior  //
+// to call.                                                                   //
+//                                                                            //
+// An additional optimization is performed when converting from one           //
+// AnyInvocable to another where only the noexcept specification and/or the   //
+// cv/ref qualifiers of the function type differ. In these cases, the         //
+// conversion works by "moving the guts", similar to if they were the same    //
+// exact type, as opposed to having to perform an additional layer of         //
+// wrapping through remote storage.                                           //
+//                                                                            //
+////////////////////////////////////////////////////////////////////////////////
+
+// IWYU pragma: private, include "absl/functional/any_invocable.h"
+
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "ex_actor/3rd_lib/absl/base/attributes.h"
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/macros.h"
+#include "ex_actor/3rd_lib/absl/base/nullability.h"
+#include "ex_actor/3rd_lib/absl/base/optimization.h"
+#include "ex_actor/3rd_lib/absl/meta/type_traits.h"
+#include "ex_actor/3rd_lib/absl/utility/utility.h"
+
+namespace ex_actor::embedded_3rd::absl {
+EX_ACTOR_ABSL_NAMESPACE_BEGIN
+
+// Defined in functional/any_invocable.h
+template <class Sig>
+class EX_ACTOR_ABSL_NULLABILITY_COMPATIBLE AnyInvocable;
+
+namespace internal_any_invocable {
+
+// Constants relating to the small-object-storage for AnyInvocable
+enum StorageProperty : std::size_t {
+  kAlignment = alignof(std::max_align_t),  // The alignment of the storage
+  kStorageSize = sizeof(void*) * 2         // The size of the storage
+};
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// A metafunction for checking if a type is an AnyInvocable instantiation.
+// This is used during conversion operations.
+template <class T>
+struct IsAnyInvocable : std::false_type {};
+
+template <class Sig>
+struct IsAnyInvocable<AnyInvocable<Sig>> : std::true_type {};
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// A metafunction that tells us whether or not a target function type should be
+// stored locally in the small object optimization storage
+template <class T>
+constexpr bool IsStoredLocally() {
+  if constexpr (sizeof(T) <= kStorageSize && alignof(T) <= kAlignment &&
+                kAlignment % alignof(T) == 0) {
+    return std::is_nothrow_move_constructible<T>::value;
+  }
+  return false;
+}
+
+// An implementation of std::remove_cvref_t of C++20.
+template <class T>
+using RemoveCVRef =
+    typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+// An implementation of std::invoke_r of C++23.
+template <class ReturnType, class F, class... P>
+ReturnType InvokeR(F&& f, P&&... args) {
+  if constexpr (std::is_void_v<ReturnType>) {
+    std::invoke(std::forward<F>(f), std::forward<P>(args)...);
+  } else {
+    return std::invoke(std::forward<F>(f), std::forward<P>(args)...);
+  }
+}
+
+//
+////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////
+///
+// A metafunction that takes a "T" corresponding to a parameter type of the
+// user's specified function type, and yields the parameter type to use for the
+// type-erased invoker. In order to prevent observable moves, this must be
+// either a reference or, if the type is trivial, the original parameter type
+// itself. Since the parameter type may be incomplete at the point that this
+// metafunction is used, we can only do this optimization for scalar types
+// rather than for any trivial type.
+template <typename T>
+T ForwardImpl(std::true_type);
+
+template <typename T>
+T&& ForwardImpl(std::false_type);
+
+// NOTE: We deliberately use an intermediate struct instead of a direct alias,
+// as a workaround for b/206991861 on MSVC versions < 1924.
+template <class T>
+struct ForwardedParameter {
+  using type = decltype((
+      ForwardImpl<T>)(std::integral_constant<bool,
+                                             std::is_scalar<T>::value>()));
+};
+
+template <class T>
+using ForwardedParameterType = typename ForwardedParameter<T>::type;
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// A discriminator when calling the "manager" function that describes operation
+// type-erased operation should be invoked.
+//
+// "dispose" specifies that the manager should perform a destroy.
+//
+// "relocate_from_to" specifies that the manager should perform a move.
+//
+// "relocate_from_to_and_query_rust" is identical to "relocate_from_to" for C++
+// managers, but instructs Rust managers to perform a special operation that
+// can be detected by the caller.
+enum class FunctionToCall : unsigned char {
+  dispose,
+  relocate_from_to,
+  relocate_from_to_and_query_rust,
+};
+
+// The portion of `AnyInvocable` state that contains either a pointer to the
+// target object or the object itself in local storage
+union TypeErasedState {
+  struct {
+    // A pointer to the type-erased object when remotely stored
+    void* target;
+    // The size of the object for `RemoteManagerTrivial`
+    std::size_t size;
+  } remote;
+
+  // Local-storage for the type-erased object when small and trivial enough
+  alignas(kAlignment) unsigned char storage[kStorageSize];
+};
+
+// A typed accessor for the object in `TypeErasedState` storage
+template <class T>
+T& ObjectInLocalStorage(TypeErasedState* const state) {
+  // We launder here because the storage may be reused with the same type.
+  return *std::launder(reinterpret_cast<T*>(&state->storage));
+}
+
+// The type for functions issuing lifetime-related operations: move and dispose
+// A pointer to such a function is contained in each `AnyInvocable` instance.
+// NOTE: When specifying `FunctionToCall::`dispose, the same state must be
+// passed as both "from" and "to".
+using ManagerType = void(FunctionToCall /*operation*/,
+                         TypeErasedState* /*from*/,
+                         TypeErasedState* /*to*/) noexcept(true);
+
+// The type for functions issuing the actual invocation of the object
+// A pointer to such a function is contained in each AnyInvocable instance.
+template <bool SigIsNoexcept, class ReturnType, class... P>
+using InvokerType = ReturnType(
+    TypeErasedState*, ForwardedParameterType<P>...) noexcept(SigIsNoexcept);
+
+// The manager that is used when AnyInvocable is empty
+inline void EmptyManager(FunctionToCall /*operation*/,
+                         TypeErasedState* /*from*/,
+                         TypeErasedState* /*to*/) noexcept {}
+
+// The manager that is used when a target function is in local storage and is
+// a trivially copyable type.
+inline void LocalManagerTrivial(FunctionToCall /*operation*/,
+                                TypeErasedState* const from,
+                                TypeErasedState* const to) noexcept {
+  // This single statement without branching handles both possible operations.
+  //
+  // For FunctionToCall::dispose, "from" and "to" point to the same state, and
+  // so this assignment logically would do nothing.
+  //
+  // Note: Correctness here relies on http://wg21.link/p0593, which has only
+  // become standard in C++20, though implementations do not break it in
+  // practice for earlier versions of C++.
+  //
+  // The correct way to do this without that paper is to first placement-new a
+  // default-constructed T in "to->storage" prior to the memmove, but doing so
+  // requires a different function to be created for each T that is stored
+  // locally, which can cause unnecessary bloat and be less cache friendly.
+  *to = *from;
+
+  // Note: Because the type is trivially copyable, the destructor does not need
+  // to be called ("trivially copyable" requires a trivial destructor).
+}
+
+// The manager that is used when a target function is in local storage and is
+// not a trivially copyable type.
+template <class T>
+void LocalManagerNontrivial(FunctionToCall operation,
+                            TypeErasedState* const from,
+                            TypeErasedState* const to) noexcept {
+  static_assert(IsStoredLocally<T>(),
+                "Local storage must only be used for supported types.");
+  static_assert(!std::is_trivially_copyable<T>::value,
+                "Locally stored types must be trivially copyable.");
+
+  T& from_object = (ObjectInLocalStorage<T>)(from);
+
+  switch (operation) {
+    case FunctionToCall::relocate_from_to:
+    case FunctionToCall::relocate_from_to_and_query_rust:
+      // NOTE: Requires that the left-hand operand is already empty.
+      ::new (static_cast<void*>(&to->storage)) T(std::move(from_object));
+      EX_ACTOR_ABSL_FALLTHROUGH_INTENDED;
+    case FunctionToCall::dispose:
+      from_object.~T();  // Must not throw. // NOLINT
+      return;
+  }
+  EX_ACTOR_ABSL_UNREACHABLE();
+}
+
+// The invoker that is used when a target function is in local storage
+// Note: QualTRef here is the target function type along with cv and reference
+// qualifiers that must be used when calling the function.
+template <bool SigIsNoexcept, class ReturnType, class QualTRef, class... P>
+ReturnType LocalInvoker(
+    TypeErasedState* const state,
+    ForwardedParameterType<P>... args) noexcept(SigIsNoexcept) {
+  using RawT = RemoveCVRef<QualTRef>;
+  static_assert(
+      IsStoredLocally<RawT>(),
+      "Target object must be in local storage in order to be invoked from it.");
+
+  auto& f = (ObjectInLocalStorage<RawT>)(state);
+  return (InvokeR<ReturnType>)(static_cast<QualTRef>(f),
+                               static_cast<ForwardedParameterType<P>>(args)...);
+}
+
+// The manager that is used when a target function is in remote storage and it
+// has a trivial destructor
+inline void RemoteManagerTrivial(FunctionToCall operation,
+                                 TypeErasedState* const from,
+                                 TypeErasedState* const to) noexcept {
+  switch (operation) {
+    case FunctionToCall::relocate_from_to:
+    case FunctionToCall::relocate_from_to_and_query_rust:
+      // NOTE: Requires that the left-hand operand is already empty.
+      to->remote = from->remote;
+      return;
+    case FunctionToCall::dispose:
+#if defined(__cpp_sized_deallocation)
+      ::operator delete(from->remote.target, from->remote.size);
+#else   // __cpp_sized_deallocation
+      ::operator delete(from->remote.target);
+#endif  // __cpp_sized_deallocation
+      return;
+  }
+  EX_ACTOR_ABSL_UNREACHABLE();
+}
+
+// The manager that is used when a target function is in remote storage and the
+// destructor of the type is not trivial
+template <class T>
+void RemoteManagerNontrivial(FunctionToCall operation,
+                             TypeErasedState* const from,
+                             TypeErasedState* const to) noexcept {
+  static_assert(!IsStoredLocally<T>(),
+                "Remote storage must only be used for types that do not "
+                "qualify for local storage.");
+
+  switch (operation) {
+    case FunctionToCall::relocate_from_to:
+    case FunctionToCall::relocate_from_to_and_query_rust:
+      // NOTE: Requires that the left-hand operand is already empty.
+      to->remote.target = from->remote.target;
+      return;
+    case FunctionToCall::dispose:
+      ::delete static_cast<T*>(from->remote.target);  // Must not throw.
+      return;
+  }
+  EX_ACTOR_ABSL_UNREACHABLE();
+}
+
+// The invoker that is used when a target function is in remote storage
+template <bool SigIsNoexcept, class ReturnType, class QualTRef, class... P>
+ReturnType RemoteInvoker(
+    TypeErasedState* const state,
+    ForwardedParameterType<P>... args) noexcept(SigIsNoexcept) {
+  using RawT = RemoveCVRef<QualTRef>;
+  static_assert(!IsStoredLocally<RawT>(),
+                "Target object must be in remote storage in order to be "
+                "invoked from it.");
+
+  auto& f = *static_cast<RawT*>(state->remote.target);
+  return (InvokeR<ReturnType>)(static_cast<QualTRef>(f),
+                               static_cast<ForwardedParameterType<P>>(args)...);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// A metafunction that checks if a type T is an instantiation of
+// std::in_place_type_t (needed for constructor constraints of AnyInvocable).
+template <class T>
+struct IsInPlaceType : std::false_type {};
+
+template <class T>
+struct IsInPlaceType<std::in_place_type_t<T>> : std::true_type {};
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// A constructor name-tag used with CoreImpl (below) to request the
+// conversion-constructor. QualDecayedTRef is the decayed-type of the object to
+// wrap, along with the cv and reference qualifiers that must be applied when
+// performing an invocation of the wrapped object.
+template <class QualDecayedTRef>
+struct TypedConversionConstruct {};
+
+// A helper base class for all core operations of AnyInvocable. Most notably,
+// this class creates the function call operator and constraint-checkers so that
+// the top-level class does not have to be a series of partial specializations.
+//
+// Note: This definition exists (as opposed to being a declaration) so that if
+// the user of the top-level template accidentally passes a template argument
+// that is not a function type, they will get a static_assert in AnyInvocable's
+// class body rather than an error stating that Impl is not defined.
+template <class Sig>
+class Impl {};  // Note: This is partially-specialized later.
+
+// A std::unique_ptr deleter that deletes memory allocated via ::operator new.
+#if defined(__cpp_sized_deallocation)
+class TrivialDeleter {
+ public:
+  explicit TrivialDeleter(std::size_t size) : size_(size) {}
+
+  void operator()(void* target) const {
+    ::operator delete(target, size_);
+  }
+
+ private:
+  std::size_t size_;
+};
+#else   // __cpp_sized_deallocation
+class TrivialDeleter {
+ public:
+  explicit TrivialDeleter(std::size_t) {}
+
+  void operator()(void* target) const { ::operator delete(target); }
+};
+#endif  // __cpp_sized_deallocation
+
+template <bool SigIsNoexcept, class ReturnType, class... P>
+class CoreImpl;
+
+constexpr bool IsCompatibleConversion(void*, void*) { return false; }
+template <bool NoExceptSrc, bool NoExceptDest, class... T>
+constexpr bool IsCompatibleConversion(CoreImpl<NoExceptSrc, T...>*,
+                                      CoreImpl<NoExceptDest, T...>*) {
+  return !NoExceptDest || NoExceptSrc;
+}
+
+// A helper base class for all core operations of AnyInvocable that do not
+// depend on the cv/ref qualifiers of the function type.
+template <bool SigIsNoexcept, class ReturnType, class... P>
+class CoreImpl {
+ public:
+  using result_type = ReturnType;
+
+  CoreImpl() noexcept : manager_(EmptyManager), invoker_(nullptr) {}
+
+  // Note: QualDecayedTRef here includes the cv-ref qualifiers associated with
+  // the invocation of the Invocable. The unqualified type is the target object
+  // type to be stored.
+  template <class QualDecayedTRef, class F>
+  explicit CoreImpl(TypedConversionConstruct<QualDecayedTRef>, F&& f) {
+    using DecayedT = RemoveCVRef<QualDecayedTRef>;
+
+    if constexpr (std::is_pointer<DecayedT>::value ||
+                  std::is_member_pointer<DecayedT>::value) {
+      // This condition handles types that decay into pointers. This includes
+      // function references, which cannot be null. GCC warns against comparing
+      // their decayed form with nullptr (https://godbolt.org/z/9r9TMTcPK).
+      // We could work around this warning with constexpr programming, using
+      // std::is_function_v<std::remove_reference_t<F>>, but we choose to ignore
+      // it instead of writing more code.
+#if !defined(__clang__) && defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Waddress"
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+      if (static_cast<DecayedT>(f) == nullptr) {
+#if !defined(__clang__) && defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+        manager_ = EmptyManager;
+        invoker_ = nullptr;
+      } else {
+        InitializeStorage<QualDecayedTRef>(std::forward<F>(f));
+      }
+    } else if constexpr (IsCompatibleAnyInvocable<DecayedT>::value) {
+      // In this case we can "steal the guts" of the other AnyInvocable.
+      f.manager_(FunctionToCall::relocate_from_to, &f.state_, &state_);
+      manager_ = f.manager_;
+      invoker_ = f.invoker_;
+
+      f.manager_ = EmptyManager;
+      f.invoker_ = nullptr;
+    } else if constexpr (IsAnyInvocable<DecayedT>::value) {
+      if (f.HasValue()) {
+        InitializeStorage<QualDecayedTRef>(std::forward<F>(f));
+      } else {
+        manager_ = EmptyManager;
+        invoker_ = nullptr;
+      }
+    } else {
+      InitializeStorage<QualDecayedTRef>(std::forward<F>(f));
+    }
+  }
+
+  // Note: QualTRef here includes the cv-ref qualifiers associated with the
+  // invocation of the Invocable. The unqualified type is the target object
+  // type to be stored.
+  template <class QualTRef, class... Args>
+  explicit CoreImpl(std::in_place_type_t<QualTRef>, Args&&... args) {
+    InitializeStorage<QualTRef>(std::forward<Args>(args)...);
+  }
+
+  CoreImpl(CoreImpl&& other) noexcept {
+    other.manager_(FunctionToCall::relocate_from_to, &other.state_, &state_);
+    manager_ = other.manager_;
+    invoker_ = other.invoker_;
+    other.manager_ = EmptyManager;
+    other.invoker_ = nullptr;
+  }
+
+  CoreImpl& operator=(CoreImpl&& other) noexcept {
+    // Put the left-hand operand in an empty state.
+    //
+    // Note: A full reset that leaves us with an object that has its invariants
+    // intact is necessary in order to handle self-move. This is required by
+    // types that are used with certain operations of the standard library, such
+    // as the default definition of std::swap when both operands target the same
+    // object.
+    Clear();
+
+    // Perform the actual move/destroy operation on the target function.
+    other.manager_(FunctionToCall::relocate_from_to, &other.state_, &state_);
+    manager_ = other.manager_;
+    invoker_ = other.invoker_;
+    other.manager_ = EmptyManager;
+    other.invoker_ = nullptr;
+
+    return *this;
+  }
+
+  ~CoreImpl() { manager_(FunctionToCall::dispose, &state_, &state_); }
+
+  // Check whether or not the AnyInvocable is in the empty state.
+  bool HasValue() const { return invoker_ != nullptr; }
+
+  // Effects: Puts the object into its empty state.
+  void Clear() {
+    manager_(FunctionToCall::dispose, &state_, &state_);
+    manager_ = EmptyManager;
+    invoker_ = nullptr;
+  }
+
+  // Use local (inline) storage for applicable target object types.
+  template <class QualTRef, class... Args>
+  void InitializeStorage(Args&&... args) {
+    using RawT = RemoveCVRef<QualTRef>;
+    if constexpr (IsStoredLocally<RawT>()) {
+      ::new (static_cast<void*>(&state_.storage))
+          RawT(std::forward<Args>(args)...);
+      invoker_ = LocalInvoker<SigIsNoexcept, ReturnType, QualTRef, P...>;
+      // We can simplify our manager if we know the type is trivially copyable.
+      if constexpr (std::is_trivially_copyable_v<RawT>) {
+        manager_ = LocalManagerTrivial;
+      } else {
+        manager_ = LocalManagerNontrivial<RawT>;
+      }
+    } else {
+      InitializeRemoteManager<RawT>(std::forward<Args>(args)...);
+      // This is set after everything else in case an exception is thrown in an
+      // earlier step of the initialization.
+      invoker_ = RemoteInvoker<SigIsNoexcept, ReturnType, QualTRef, P...>;
+    }
+  }
+
+  template <class T, class... Args>
+  void InitializeRemoteManager(Args&&... args) {
+    if constexpr (std::is_trivially_destructible_v<T> &&
+                  alignof(T) <= EX_ACTOR_ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT) {
+      // unique_ptr is used for exception-safety in case construction throws.
+      std::unique_ptr<void, TrivialDeleter> uninitialized_target(
+          ::operator new(sizeof(T)), TrivialDeleter(sizeof(T)));
+      ::new (uninitialized_target.get()) T(std::forward<Args>(args)...);
+      state_.remote.target = uninitialized_target.release();
+      state_.remote.size = sizeof(T);
+      manager_ = RemoteManagerTrivial;
+    } else {
+      state_.remote.target = ::new T(std::forward<Args>(args)...);
+      manager_ = RemoteManagerNontrivial<T>;
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  //
+  // Type trait to determine if the template argument is an AnyInvocable whose
+  // function type is compatible enough with ours such that we can
+  // "move the guts" out of it when moving, rather than having to place a new
+  // object into remote storage.
+
+  template <typename Other>
+  struct IsCompatibleAnyInvocable {
+    static constexpr bool value = false;
+  };
+
+  template <typename Sig>
+  struct IsCompatibleAnyInvocable<AnyInvocable<Sig>> {
+    static constexpr bool value =
+        (IsCompatibleConversion)(static_cast<
+                                     typename AnyInvocable<Sig>::CoreImpl*>(
+                                     nullptr),
+                                 static_cast<CoreImpl*>(nullptr));
+  };
+
+  //
+  //////////////////////////////////////////////////////////////////////////////
+
+  TypeErasedState state_;
+  ManagerType* manager_;
+  InvokerType<SigIsNoexcept, ReturnType, P...>* invoker_;
+};
+
+// A constructor name-tag used with Impl to request the
+// conversion-constructor
+struct ConversionConstruct {};
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// A metafunction that is normally an identity metafunction except that when
+// given a std::reference_wrapper<T>, it yields T&. This is necessary because
+// currently std::reference_wrapper's operator() is not conditionally noexcept,
+// so when checking if such an Invocable is nothrow-invocable, we must pull out
+// the underlying type.
+template <class T>
+struct UnwrapStdReferenceWrapperImpl {
+  using type = T;
+};
+
+template <class T>
+struct UnwrapStdReferenceWrapperImpl<std::reference_wrapper<T>> {
+  using type = T&;
+};
+
+template <class T>
+using UnwrapStdReferenceWrapper =
+    typename UnwrapStdReferenceWrapperImpl<T>::type;
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// An alias that always yields std::true_type (used with constraints) where
+// substitution failures happen when forming the template arguments.
+template <class... T>
+using TrueAlias =
+    std::integral_constant<bool, sizeof(ex_actor::embedded_3rd::absl::void_t<T...>*) != 0>;
+
+/*SFINAE constraints for the conversion-constructor.*/
+template <class Sig, class F,
+          class = std::enable_if_t<
+              !std::is_same<RemoveCVRef<F>, AnyInvocable<Sig>>::value>>
+using CanConvert = TrueAlias<
+    std::enable_if_t<!IsInPlaceType<RemoveCVRef<F>>::value>,
+    std::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    std::enable_if_t<
+        Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
+    std::enable_if_t<std::is_constructible<std::decay_t<F>, F>::value>>;
+
+/*SFINAE constraints for the std::in_place constructors.*/
+template <class Sig, class F, class... Args>
+using CanEmplace = TrueAlias<
+    std::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    std::enable_if_t<
+        Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
+    std::enable_if_t<std::is_constructible<std::decay_t<F>, Args...>::value>>;
+
+/*SFINAE constraints for the conversion-assign operator.*/
+template <class Sig, class F,
+          class = std::enable_if_t<
+              !std::is_same<RemoveCVRef<F>, AnyInvocable<Sig>>::value>>
+using CanAssign = TrueAlias<
+    std::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    std::enable_if_t<
+        Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
+    std::enable_if_t<std::is_constructible<std::decay_t<F>, F>::value>>;
+
+/*SFINAE constraints for the reference-wrapper conversion-assign operator.*/
+template <class Sig, class F>
+using CanAssignReferenceWrapper = TrueAlias<
+    std::enable_if_t<
+        Impl<Sig>::template CallIsValid<std::reference_wrapper<F>>::value>,
+    std::enable_if_t<Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<
+        std::reference_wrapper<F>>::value>>;
+
+// The constraint for checking whether or not a call meets the noexcept
+// callability requirements. We use a preprocessor macro because specifying it
+// this way as opposed to a disjunction/branch can improve the user-side error
+// messages and avoids an instantiation of std::is_nothrow_invocable_r in the
+// cases where the user did not specify a noexcept function type.
+//
+// The disjunction below is because we can't rely on std::is_nothrow_invocable_r
+// to give the right result when ReturnType is non-moveable in toolchains that
+// don't treat non-moveable result types correctly. For example this was the
+// case in libc++ before commit c3a24882 (2022-05).
+#define EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_true(inv_quals)      \
+  std::enable_if_t<std::disjunction<                                       \
+      std::is_nothrow_invocable_r<                                           \
+          ReturnType, UnwrapStdReferenceWrapper<std::decay_t<F>> inv_quals, \
+          P...>,                                                             \
+      std::conjunction<                                                      \
+          std::is_nothrow_invocable<                                         \
+              UnwrapStdReferenceWrapper<std::decay_t<F>> inv_quals, P...>,  \
+          std::is_same<                                                      \
+              ReturnType,                                                    \
+              std::invoke_result_t<                                          \
+                  UnwrapStdReferenceWrapper<std::decay_t<F>> inv_quals,     \
+                  P...>>>>::value>
+
+#define EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_false(inv_quals)
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// A macro to generate partial specializations of Impl with the different
+// combinations of supported cv/reference qualifiers and noexcept specifier.
+//
+// Here, `cv` are the cv-qualifiers if any, `ref` is the ref-qualifier if any,
+// inv_quals is the reference type to be used when invoking the target, and
+// noex is "true" if the function type is noexcept, or false if it is not.
+//
+// The CallIsValid condition is more complicated than simply using
+// std::is_invocable_r because we can't rely on it to give the right result
+// when ReturnType is non-moveable in toolchains that don't treat non-moveable
+// result types correctly. For example this was the case in libc++ before commit
+// c3a24882 (2022-05).
+#define EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL_(cv, ref, inv_quals, noex)            \
+  template <class ReturnType, class... P>                                      \
+  class Impl<ReturnType(P...) cv ref noexcept(noex)>                           \
+      : public CoreImpl<noex, ReturnType, P...> {                              \
+   public:                                                                     \
+    /*The base class, which contains the datamembers and core operations*/     \
+    using Core = CoreImpl<noex, ReturnType, P...>;                             \
+                                                                               \
+    /*SFINAE constraint to check if F is invocable with the proper signature*/ \
+    template <class F>                                                         \
+    using CallIsValid = TrueAlias<std::enable_if_t<std::disjunction<           \
+        std::is_invocable_r<ReturnType, std::decay_t<F> inv_quals, P...>,      \
+        std::is_same<ReturnType,                                               \
+                     std::invoke_result_t<std::decay_t<F> inv_quals, P...>>>:: \
+                                                       value>>;                \
+                                                                               \
+    /*SFINAE constraint to check if F is nothrow-invocable when necessary*/    \
+    template <class F>                                                         \
+    using CallIsNoexceptIfSigIsNoexcept =                                      \
+        TrueAlias<EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_##noex(      \
+            inv_quals)>;                                                       \
+                                                                               \
+    /*Put the AnyInvocable into an empty state.*/                              \
+    Impl() = default;                                                          \
+                                                                               \
+    /*The implementation of a conversion-constructor from "f*/                 \
+    /*This forwards to Core, attaching inv_quals so that the base class*/      \
+    /*knows how to properly type-erase the invocation.*/                       \
+    template <class F>                                                         \
+    explicit Impl(ConversionConstruct, F&& f)                                  \
+        : Core(TypedConversionConstruct<                                       \
+                   typename std::decay<F>::type inv_quals>(),                  \
+               std::forward<F>(f)) {}                                          \
+                                                                               \
+    /*Forward along the in-place construction parameters.*/                    \
+    template <class T, class... Args>                                          \
+    explicit Impl(std::in_place_type_t<T>, Args&&... args)                     \
+        : Core(std::in_place_type<std::decay_t<T> inv_quals>,                  \
+               std::forward<Args>(args)...) {}                                 \
+                                                                               \
+    /*Raises a fatal error when the AnyInvocable is invoked after a move*/     \
+    static ReturnType InvokedAfterMove(                                        \
+        TypeErasedState*, ForwardedParameterType<P>...) noexcept(noex) {       \
+      EX_ACTOR_ABSL_HARDENING_ASSERT(false && "AnyInvocable use-after-move");           \
+      std::terminate();                                                        \
+    }                                                                          \
+                                                                               \
+    InvokerType<noex, ReturnType, P...>* ExtractInvoker() cv {                 \
+      using QualifiedTestType = int cv ref;                                    \
+      auto* invoker = this->invoker_;                                          \
+      if (!std::is_const<QualifiedTestType>::value &&                          \
+          std::is_rvalue_reference<QualifiedTestType>::value) {                \
+        EX_ACTOR_ABSL_ASSERT([this]() {                                                 \
+          /* We checked that this isn't const above, so const_cast is safe */  \
+          const_cast<Impl*>(this)->invoker_ = InvokedAfterMove;                \
+          return this->HasValue();                                             \
+        }());                                                                  \
+      }                                                                        \
+      return invoker;                                                          \
+    }                                                                          \
+                                                                               \
+    /*The actual invocation operation with the proper signature*/              \
+    ReturnType operator()(P... args) cv ref noexcept(noex) {                   \
+      assert(this->invoker_ != nullptr);                                       \
+      return this->ExtractInvoker()(                                           \
+          const_cast<TypeErasedState*>(&this->state_),                         \
+          static_cast<ForwardedParameterType<P>>(args)...);                    \
+    }                                                                          \
+  }
+
+// A convenience macro that defines specializations for the noexcept(true) and
+// noexcept(false) forms, given the other properties.
+#define EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(cv, ref, inv_quals)    \
+  EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL_(cv, ref, inv_quals, false); \
+  EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL_(cv, ref, inv_quals, true)
+
+// Non-ref-qualified partial specializations
+EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(, , &);
+EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(const, , const&);
+
+// Lvalue-ref-qualified partial specializations
+EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(, &, &);
+EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(const, &, const&);
+
+// Rvalue-ref-qualified partial specializations
+EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(, &&, &&);
+EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL(const, &&, const&&);
+
+// Undef the detail-only macros.
+#undef EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL
+#undef EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_IMPL_
+#undef EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_false
+#undef EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_true
+
+}  // namespace internal_any_invocable
+EX_ACTOR_ABSL_NAMESPACE_END
+}  // namespace ex_actor::embedded_3rd::absl
+
+#endif  // EX_ACTOR_ABSL_FUNCTIONAL_INTERNAL_ANY_INVOCABLE_H_

--- a/include/ex_actor/3rd_lib/absl/functional/internal/any_invocable.h
+++ b/include/ex_actor/3rd_lib/absl/functional/internal/any_invocable.h
@@ -342,12 +342,12 @@ ReturnType RemoteInvoker(
 ////////////////////////////////////////////////////////////////////////////////
 //
 // A metafunction that checks if a type T is an instantiation of
-// std::in_place_type_t (needed for constructor constraints of AnyInvocable).
+// ex_actor::embedded_3rd::absl::in_place_type_t (needed for constructor constraints of AnyInvocable).
 template <class T>
 struct IsInPlaceType : std::false_type {};
 
 template <class T>
-struct IsInPlaceType<std::in_place_type_t<T>> : std::true_type {};
+struct IsInPlaceType<ex_actor::embedded_3rd::absl::in_place_type_t<T>> : std::true_type {};
 //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -464,7 +464,7 @@ class CoreImpl {
   // invocation of the Invocable. The unqualified type is the target object
   // type to be stored.
   template <class QualTRef, class... Args>
-  explicit CoreImpl(std::in_place_type_t<QualTRef>, Args&&... args) {
+  explicit CoreImpl(ex_actor::embedded_3rd::absl::in_place_type_t<QualTRef>, Args&&... args) {
     InitializeStorage<QualTRef>(std::forward<Args>(args)...);
   }
 
@@ -611,39 +611,39 @@ using TrueAlias =
 
 /*SFINAE constraints for the conversion-constructor.*/
 template <class Sig, class F,
-          class = std::enable_if_t<
+          class = ex_actor::embedded_3rd::absl::enable_if_t<
               !std::is_same<RemoveCVRef<F>, AnyInvocable<Sig>>::value>>
 using CanConvert = TrueAlias<
-    std::enable_if_t<!IsInPlaceType<RemoveCVRef<F>>::value>,
-    std::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
-    std::enable_if_t<
+    ex_actor::embedded_3rd::absl::enable_if_t<!IsInPlaceType<RemoveCVRef<F>>::value>,
+    ex_actor::embedded_3rd::absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    ex_actor::embedded_3rd::absl::enable_if_t<
         Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
-    std::enable_if_t<std::is_constructible<std::decay_t<F>, F>::value>>;
+    ex_actor::embedded_3rd::absl::enable_if_t<std::is_constructible<ex_actor::embedded_3rd::absl::decay_t<F>, F>::value>>;
 
 /*SFINAE constraints for the std::in_place constructors.*/
 template <class Sig, class F, class... Args>
 using CanEmplace = TrueAlias<
-    std::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
-    std::enable_if_t<
+    ex_actor::embedded_3rd::absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    ex_actor::embedded_3rd::absl::enable_if_t<
         Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
-    std::enable_if_t<std::is_constructible<std::decay_t<F>, Args...>::value>>;
+    ex_actor::embedded_3rd::absl::enable_if_t<std::is_constructible<ex_actor::embedded_3rd::absl::decay_t<F>, Args...>::value>>;
 
 /*SFINAE constraints for the conversion-assign operator.*/
 template <class Sig, class F,
-          class = std::enable_if_t<
+          class = ex_actor::embedded_3rd::absl::enable_if_t<
               !std::is_same<RemoveCVRef<F>, AnyInvocable<Sig>>::value>>
 using CanAssign = TrueAlias<
-    std::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
-    std::enable_if_t<
+    ex_actor::embedded_3rd::absl::enable_if_t<Impl<Sig>::template CallIsValid<F>::value>,
+    ex_actor::embedded_3rd::absl::enable_if_t<
         Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<F>::value>,
-    std::enable_if_t<std::is_constructible<std::decay_t<F>, F>::value>>;
+    ex_actor::embedded_3rd::absl::enable_if_t<std::is_constructible<ex_actor::embedded_3rd::absl::decay_t<F>, F>::value>>;
 
 /*SFINAE constraints for the reference-wrapper conversion-assign operator.*/
 template <class Sig, class F>
 using CanAssignReferenceWrapper = TrueAlias<
-    std::enable_if_t<
+    ex_actor::embedded_3rd::absl::enable_if_t<
         Impl<Sig>::template CallIsValid<std::reference_wrapper<F>>::value>,
-    std::enable_if_t<Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<
+    ex_actor::embedded_3rd::absl::enable_if_t<Impl<Sig>::template CallIsNoexceptIfSigIsNoexcept<
         std::reference_wrapper<F>>::value>>;
 
 // The constraint for checking whether or not a call meets the noexcept
@@ -657,17 +657,17 @@ using CanAssignReferenceWrapper = TrueAlias<
 // don't treat non-moveable result types correctly. For example this was the
 // case in libc++ before commit c3a24882 (2022-05).
 #define EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_true(inv_quals)      \
-  std::enable_if_t<std::disjunction<                                       \
+  ex_actor::embedded_3rd::absl::enable_if_t<ex_actor::embedded_3rd::absl::disjunction<                                       \
       std::is_nothrow_invocable_r<                                           \
-          ReturnType, UnwrapStdReferenceWrapper<std::decay_t<F>> inv_quals, \
+          ReturnType, UnwrapStdReferenceWrapper<ex_actor::embedded_3rd::absl::decay_t<F>> inv_quals, \
           P...>,                                                             \
       std::conjunction<                                                      \
           std::is_nothrow_invocable<                                         \
-              UnwrapStdReferenceWrapper<std::decay_t<F>> inv_quals, P...>,  \
+              UnwrapStdReferenceWrapper<ex_actor::embedded_3rd::absl::decay_t<F>> inv_quals, P...>,  \
           std::is_same<                                                      \
               ReturnType,                                                    \
               std::invoke_result_t<                                          \
-                  UnwrapStdReferenceWrapper<std::decay_t<F>> inv_quals,     \
+                  UnwrapStdReferenceWrapper<ex_actor::embedded_3rd::absl::decay_t<F>> inv_quals,     \
                   P...>>>>::value>
 
 #define EX_ACTOR_ABSL_INTERNAL_ANY_INVOCABLE_NOEXCEPT_CONSTRAINT_false(inv_quals)
@@ -696,11 +696,11 @@ using CanAssignReferenceWrapper = TrueAlias<
                                                                                \
     /*SFINAE constraint to check if F is invocable with the proper signature*/ \
     template <class F>                                                         \
-    using CallIsValid = TrueAlias<std::enable_if_t<std::disjunction<           \
-        std::is_invocable_r<ReturnType, std::decay_t<F> inv_quals, P...>,      \
-        std::is_same<ReturnType,                                               \
-                     std::invoke_result_t<std::decay_t<F> inv_quals, P...>>>:: \
-                                                       value>>;                \
+    using CallIsValid = TrueAlias<ex_actor::embedded_3rd::absl::enable_if_t<ex_actor::embedded_3rd::absl::disjunction<         \
+        std::is_invocable_r<ReturnType, ex_actor::embedded_3rd::absl::decay_t<F> inv_quals, P...>,     \
+        std::is_same<                                                          \
+            ReturnType,                                                        \
+            std::invoke_result_t<ex_actor::embedded_3rd::absl::decay_t<F> inv_quals, P...>>>::value>>; \
                                                                                \
     /*SFINAE constraint to check if F is nothrow-invocable when necessary*/    \
     template <class F>                                                         \
@@ -722,8 +722,8 @@ using CanAssignReferenceWrapper = TrueAlias<
                                                                                \
     /*Forward along the in-place construction parameters.*/                    \
     template <class T, class... Args>                                          \
-    explicit Impl(std::in_place_type_t<T>, Args&&... args)                     \
-        : Core(std::in_place_type<std::decay_t<T> inv_quals>,                  \
+    explicit Impl(ex_actor::embedded_3rd::absl::in_place_type_t<T>, Args&&... args)                    \
+        : Core(ex_actor::embedded_3rd::absl::in_place_type<ex_actor::embedded_3rd::absl::decay_t<T> inv_quals>,                \
                std::forward<Args>(args)...) {}                                 \
                                                                                \
     /*Raises a fatal error when the AnyInvocable is invoked after a move*/     \

--- a/include/ex_actor/3rd_lib/absl/meta/type_traits.h
+++ b/include/ex_actor/3rd_lib/absl/meta/type_traits.h
@@ -45,7 +45,6 @@
 
 #include "ex_actor/3rd_lib/absl/base/attributes.h"
 #include "ex_actor/3rd_lib/absl/base/config.h"
-#include "ex_actor/3rd_lib/absl/base/macros.h"
 
 #ifdef __cpp_lib_span
 #include <span>  // NOLINT(build/c++20)
@@ -104,10 +103,9 @@ struct is_detected : is_detected_impl<void, Op, Args...>::type {};
 // metafunction allows you to create a general case that maps to `void` while
 // allowing specializations that map to specific types.
 //
-// This metafunction is a workaround for some implementations of `std::void_t`
-// that evaluate to `void` prematurely, causing partial specializations to
-// appear duplicated (and thus invalid) to the compiler prior to substitution
-// taking place. Whenever possible, use `std::void_t` instead.
+// This metafunction is not 100% compatible with the C++17 `std::void_t`
+// metafunction. It has slightly different behavior, such as when ordering
+// partial specializations. It is recommended to use `std::void_t` instead.
 template <typename... Ts>
 using void_t = typename type_traits_internal::VoidTImpl<Ts...>::type;
 
@@ -117,115 +115,38 @@ using void_t = typename type_traits_internal::VoidTImpl<Ts...>::type;
 //
 // See the documentation for the STL <type_traits> header for more information:
 // https://en.cppreference.com/w/cpp/header/type_traits
-
-template <class T>
-using add_const_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_const_t<T>;
-
-template <class T>
-using add_cv_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_cv_t<T>;
-
-template <class T>
-using add_lvalue_reference_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::add_lvalue_reference_t<T>;
-
-template <class T>
-using add_pointer_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_pointer_t<T>;
-
-template <class T>
-using add_rvalue_reference_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::add_rvalue_reference_t<T>;
-
-template <class T>
-using add_volatile_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_volatile_t<T>;
-
-template <class... T>
-using common_type_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::common_type_t<T...>;
-
-template <bool C, class T, class F>
-using conditional_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::conditional_t<C, T, F>;
-
-template <class... T>
-using conjunction EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::conjunction<T...>;
-
-template <class T>
-using decay_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::decay_t<T>;
-
-template <bool C, class T = void>
-using enable_if_t [[deprecated("Use std::enable_if_t instead.")]] =
-    std::enable_if_t<C, T>;
-
-template <class... T>
-using disjunction EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::disjunction<T...>;
-
-template <class T>
-using is_copy_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_copy_assignable<T>;
-
-template <class T>
-using is_function EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::is_function<T>;
-
-template <class T>
-using is_move_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_move_assignable<T>;
-
-template <class T>
-using is_trivially_copy_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_trivially_copy_assignable<T>;
-
-template <class T>
-using is_trivially_copy_constructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_trivially_copy_constructible<T>;
-
-template <class T>
-using is_trivially_default_constructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_trivially_default_constructible<T>;
-
-template <class T>
-using is_trivially_destructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_trivially_destructible<T>;
-
-template <class T>
-using is_trivially_move_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_trivially_move_assignable<T>;
-
-template <class T>
-using is_trivially_move_constructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::is_trivially_move_constructible<T>;
-
-template <class T>
-using make_signed_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::make_signed_t<T>;
-
-template <class T>
-using make_unsigned_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::make_unsigned_t<T>;
-
-template <class T>
-using negation EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::negation<T>;
-
-template <class T>
-using remove_all_extents_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::remove_all_extents_t<T>;
-
-template <class T>
-using remove_const_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_const_t<T>;
-
-template <class T>
-using remove_cv_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_cv_t<T>;
-
-template <class T>
-using remove_extent_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_extent_t<T>;
-
-template <class T>
-using remove_pointer_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_pointer_t<T>;
-
-template <class T>
-using remove_reference_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::remove_reference_t<T>;
-
-template <class T>
-using remove_volatile_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_volatile_t<T>;
-
-template <class T>
-using underlying_type_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::underlying_type_t<T>;
+using std::add_const_t;
+using std::add_cv_t;
+using std::add_lvalue_reference_t;
+using std::add_pointer_t;
+using std::add_rvalue_reference_t;
+using std::add_volatile_t;
+using std::common_type_t;
+using std::conditional_t;
+using std::conjunction;
+using std::decay_t;
+using std::enable_if_t;
+using std::disjunction;
+using std::is_copy_assignable;
+using std::is_function;
+using std::is_move_assignable;
+using std::is_trivially_copy_assignable;
+using std::is_trivially_copy_constructible;
+using std::is_trivially_default_constructible;
+using std::is_trivially_destructible;
+using std::is_trivially_move_assignable;
+using std::is_trivially_move_constructible;
+using std::make_signed_t;
+using std::make_unsigned_t;
+using std::negation;
+using std::remove_all_extents_t;
+using std::remove_const_t;
+using std::remove_cv_t;
+using std::remove_extent_t;
+using std::remove_pointer_t;
+using std::remove_reference_t;
+using std::remove_volatile_t;
+using std::underlying_type_t;
 
 #if defined(__cpp_lib_remove_cvref) && __cpp_lib_remove_cvref >= 201711L
 template <typename T>
@@ -290,16 +211,31 @@ template <typename F>
 using result_of_t = typename type_traits_internal::result_of<F>::type;
 
 namespace type_traits_internal {
+// In MSVC we can't probe std::hash or stdext::hash because it triggers a
+// static_assert instead of failing substitution. Libc++ prior to 4.0
+// also used a static_assert.
+//
+#if defined(_MSC_VER) || (defined(_LIBCPP_VERSION) && \
+                          _LIBCPP_VERSION < 4000 && _LIBCPP_STD_VER > 11)
+#define EX_ACTOR_ABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_ 0
+#else
+#define EX_ACTOR_ABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_ 1
+#endif
 
+#if !EX_ACTOR_ABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_
+template <typename Key, typename = size_t>
+struct IsHashable : std::true_type {};
+#else   // EX_ACTOR_ABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_
 template <typename Key, typename = void>
 struct IsHashable : std::false_type {};
 
 template <typename Key>
 struct IsHashable<
     Key,
-    std::enable_if_t<std::is_convertible<
+    ex_actor::embedded_3rd::absl::enable_if_t<std::is_convertible<
         decltype(std::declval<std::hash<Key>&>()(std::declval<Key const&>())),
         std::size_t>::value>> : std::true_type {};
+#endif  // !EX_ACTOR_ABSL_META_INTERNAL_STD_HASH_SFINAE_FRIENDLY_
 
 struct AssertHashEnabledHelper {
  private:
@@ -322,7 +258,7 @@ struct AssertHashEnabledHelper {
     static_assert(
         std::is_copy_constructible<std::hash<Key>>::value,
         "std::hash<Key> must be copy constructible when it is enabled");
-    static_assert(std::is_copy_assignable<std::hash<Key>>::value,
+    static_assert(ex_actor::embedded_3rd::absl::is_copy_assignable<std::hash<Key>>::value,
                   "std::hash<Key> must be copy assignable when it is enabled");
     // is_destructible is unchecked as it's implied by each of the
     // is_constructible checks.
@@ -385,7 +321,7 @@ struct IsNothrowSwappable
 //
 // Performs the swap idiom from a namespace where valid candidates may only be
 // found in `std` or via ADL.
-template <class T, std::enable_if_t<IsSwappable<T>::value, int> = 0>
+template <class T, ex_actor::embedded_3rd::absl::enable_if_t<IsSwappable<T>::value, int> = 0>
 void Swap(T& lhs, T& rhs) noexcept(IsNothrowSwappable<T>::value) {
   swap(lhs, rhs);
 }
@@ -554,7 +490,7 @@ template <typename T>
 struct IsOwnerImpl<
     T,
     std::enable_if_t<std::is_class<typename T::absl_internal_is_view>::value>>
-    : std::negation<typename T::absl_internal_is_view> {};
+    : ex_actor::embedded_3rd::absl::negation<typename T::absl_internal_is_view> {};
 
 // A trait to determine whether a type is an owner.
 // Do *not* depend on the correctness of this trait for correct code behavior.
@@ -634,7 +570,7 @@ struct IsView<std::span<T>> : std::true_type {};
 // Until then, we consider an assignment from an "owner" (such as std::string)
 // to a "view" (such as std::string_view) to be a lifetime-bound assignment.
 template <typename T, typename U>
-using IsLifetimeBoundAssignment = std::conjunction<
+using IsLifetimeBoundAssignment = ex_actor::embedded_3rd::absl::conjunction<
     std::integral_constant<bool, !std::is_lvalue_reference<U>::value>,
     IsOwner<ex_actor::embedded_3rd::absl::remove_cvref_t<U>>, IsView<ex_actor::embedded_3rd::absl::remove_cvref_t<T>>>;
 

--- a/include/ex_actor/3rd_lib/absl/meta/type_traits.h
+++ b/include/ex_actor/3rd_lib/absl/meta/type_traits.h
@@ -1,0 +1,646 @@
+//
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// -----------------------------------------------------------------------------
+// type_traits.h
+// -----------------------------------------------------------------------------
+//
+// This file contains C++11-compatible versions of standard <type_traits> API
+// functions for determining the characteristics of types. Such traits can
+// support type inference, classification, and transformation, as well as
+// make it easier to write templates based on generic type behavior.
+//
+// See https://en.cppreference.com/w/cpp/header/type_traits
+//
+// WARNING: use of many of the constructs in this header will count as "complex
+// template metaprogramming", so before proceeding, please carefully consider
+// https://google.github.io/styleguide/cppguide.html#Template_metaprogramming
+//
+// WARNING: using template metaprogramming to detect or depend on API
+// features is brittle and not guaranteed. Neither the standard library nor
+// Abseil provides any guarantee that APIs are stable in the face of template
+// metaprogramming. Use with caution.
+#ifndef EX_ACTOR_ABSL_META_TYPE_TRAITS_H_
+#define EX_ACTOR_ABSL_META_TYPE_TRAITS_H_
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "ex_actor/3rd_lib/absl/base/attributes.h"
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/macros.h"
+
+#ifdef __cpp_lib_span
+#include <span>  // NOLINT(build/c++20)
+#endif
+
+// Defines the default alignment. `__STDCPP_DEFAULT_NEW_ALIGNMENT__` is a C++17
+// feature.
+#if defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
+#define EX_ACTOR_ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
+#else  // defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
+#define EX_ACTOR_ABSL_INTERNAL_DEFAULT_NEW_ALIGNMENT alignof(std::max_align_t)
+#endif  // defined(__STDCPP_DEFAULT_NEW_ALIGNMENT__)
+
+namespace ex_actor::embedded_3rd::absl {
+EX_ACTOR_ABSL_NAMESPACE_BEGIN
+
+namespace type_traits_internal {
+
+template <typename... Ts>
+struct VoidTImpl {
+  using type = void;
+};
+
+////////////////////////////////
+// Library Fundamentals V2 TS //
+////////////////////////////////
+
+// NOTE: The `is_detected` family of templates here differ from the library
+// fundamentals specification in that for library fundamentals, `Op<Args...>` is
+// evaluated as soon as the type `is_detected<Op, Args...>` undergoes
+// substitution, regardless of whether or not the `::value` is accessed. That
+// is inconsistent with all other standard traits and prevents lazy evaluation
+// in larger contexts (such as if the `is_detected` check is a trailing argument
+// of a `conjunction`. This implementation opts to instead be lazy in the same
+// way that the standard traits are (this "defect" of the detection idiom
+// specifications has been reported).
+
+template <class Enabler, template <class...> class Op, class... Args>
+struct is_detected_impl {
+  using type = std::false_type;
+};
+
+template <template <class...> class Op, class... Args>
+struct is_detected_impl<typename VoidTImpl<Op<Args...>>::type, Op, Args...> {
+  using type = std::true_type;
+};
+
+template <template <class...> class Op, class... Args>
+struct is_detected : is_detected_impl<void, Op, Args...>::type {};
+
+}  // namespace type_traits_internal
+
+// void_t()
+//
+// Ignores the type of any its arguments and returns `void`. In general, this
+// metafunction allows you to create a general case that maps to `void` while
+// allowing specializations that map to specific types.
+//
+// This metafunction is a workaround for some implementations of `std::void_t`
+// that evaluate to `void` prematurely, causing partial specializations to
+// appear duplicated (and thus invalid) to the compiler prior to substitution
+// taking place. Whenever possible, use `std::void_t` instead.
+template <typename... Ts>
+using void_t = typename type_traits_internal::VoidTImpl<Ts...>::type;
+
+// Historical note: Abseil once provided implementations of these type traits
+// for platforms that lacked full support. New code should prefer to use the
+// std variants.
+//
+// See the documentation for the STL <type_traits> header for more information:
+// https://en.cppreference.com/w/cpp/header/type_traits
+
+template <class T>
+using add_const_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_const_t<T>;
+
+template <class T>
+using add_cv_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_cv_t<T>;
+
+template <class T>
+using add_lvalue_reference_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::add_lvalue_reference_t<T>;
+
+template <class T>
+using add_pointer_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_pointer_t<T>;
+
+template <class T>
+using add_rvalue_reference_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::add_rvalue_reference_t<T>;
+
+template <class T>
+using add_volatile_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::add_volatile_t<T>;
+
+template <class... T>
+using common_type_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::common_type_t<T...>;
+
+template <bool C, class T, class F>
+using conditional_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::conditional_t<C, T, F>;
+
+template <class... T>
+using conjunction EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::conjunction<T...>;
+
+template <class T>
+using decay_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::decay_t<T>;
+
+template <bool C, class T = void>
+using enable_if_t [[deprecated("Use std::enable_if_t instead.")]] =
+    std::enable_if_t<C, T>;
+
+template <class... T>
+using disjunction EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::disjunction<T...>;
+
+template <class T>
+using is_copy_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_copy_assignable<T>;
+
+template <class T>
+using is_function EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::is_function<T>;
+
+template <class T>
+using is_move_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_move_assignable<T>;
+
+template <class T>
+using is_trivially_copy_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_trivially_copy_assignable<T>;
+
+template <class T>
+using is_trivially_copy_constructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_trivially_copy_constructible<T>;
+
+template <class T>
+using is_trivially_default_constructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_trivially_default_constructible<T>;
+
+template <class T>
+using is_trivially_destructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_trivially_destructible<T>;
+
+template <class T>
+using is_trivially_move_assignable EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_trivially_move_assignable<T>;
+
+template <class T>
+using is_trivially_move_constructible EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::is_trivially_move_constructible<T>;
+
+template <class T>
+using make_signed_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::make_signed_t<T>;
+
+template <class T>
+using make_unsigned_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::make_unsigned_t<T>;
+
+template <class T>
+using negation EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::negation<T>;
+
+template <class T>
+using remove_all_extents_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::remove_all_extents_t<T>;
+
+template <class T>
+using remove_const_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_const_t<T>;
+
+template <class T>
+using remove_cv_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_cv_t<T>;
+
+template <class T>
+using remove_extent_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_extent_t<T>;
+
+template <class T>
+using remove_pointer_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_pointer_t<T>;
+
+template <class T>
+using remove_reference_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::remove_reference_t<T>;
+
+template <class T>
+using remove_volatile_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::remove_volatile_t<T>;
+
+template <class T>
+using underlying_type_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::underlying_type_t<T>;
+
+#if defined(__cpp_lib_remove_cvref) && __cpp_lib_remove_cvref >= 201711L
+template <typename T>
+using remove_cvref = std::remove_cvref<T>;
+
+template <typename T>
+using remove_cvref_t = typename std::remove_cvref<T>::type;
+#else
+// remove_cvref()
+//
+// C++11 compatible implementation of std::remove_cvref which was added in
+// C++20.
+template <typename T>
+struct remove_cvref {
+  using type =
+      typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+};
+
+template <typename T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+#endif
+
+#if defined(__cpp_lib_type_identity) && __cpp_lib_type_identity >= 201806L
+template <typename T>
+using type_identity = std::type_identity<T>;
+
+template <typename T>
+using type_identity_t = std::type_identity_t<T>;
+#else
+// type_identity
+//
+// Back-fill of C++20's `std::type_identity`.
+template <typename T>
+struct type_identity {
+  typedef T type;
+};
+
+// type_identity_t
+//
+// Back-fill of C++20's `std::type_identity_t`.
+template <typename T>
+using type_identity_t = typename type_identity<T>::type;
+#endif
+
+namespace type_traits_internal {
+
+#if (defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703L) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+// std::result_of is deprecated (C++17) or removed (C++20)
+template <typename>
+struct result_of;
+template <typename F, typename... Args>
+struct result_of<F(Args...)> : std::invoke_result<F, Args...> {};
+#else
+template <typename F>
+using result_of = std::result_of<F>;
+#endif
+
+}  // namespace type_traits_internal
+
+template <typename F>
+using result_of_t = typename type_traits_internal::result_of<F>::type;
+
+namespace type_traits_internal {
+
+template <typename Key, typename = void>
+struct IsHashable : std::false_type {};
+
+template <typename Key>
+struct IsHashable<
+    Key,
+    std::enable_if_t<std::is_convertible<
+        decltype(std::declval<std::hash<Key>&>()(std::declval<Key const&>())),
+        std::size_t>::value>> : std::true_type {};
+
+struct AssertHashEnabledHelper {
+ private:
+  static void Sink(...) {}
+  struct NAT {};
+
+  template <class Key>
+  static auto GetReturnType(int)
+      -> decltype(std::declval<std::hash<Key>>()(std::declval<Key const&>()));
+  template <class Key>
+  static NAT GetReturnType(...);
+
+  template <class Key>
+  static std::nullptr_t DoIt() {
+    static_assert(IsHashable<Key>::value,
+                  "std::hash<Key> does not provide a call operator");
+    static_assert(
+        std::is_default_constructible<std::hash<Key>>::value,
+        "std::hash<Key> must be default constructible when it is enabled");
+    static_assert(
+        std::is_copy_constructible<std::hash<Key>>::value,
+        "std::hash<Key> must be copy constructible when it is enabled");
+    static_assert(std::is_copy_assignable<std::hash<Key>>::value,
+                  "std::hash<Key> must be copy assignable when it is enabled");
+    // is_destructible is unchecked as it's implied by each of the
+    // is_constructible checks.
+    using ReturnType = decltype(GetReturnType<Key>(0));
+    static_assert(std::is_same<ReturnType, NAT>::value ||
+                      std::is_same<ReturnType, size_t>::value,
+                  "std::hash<Key> must return size_t");
+    return nullptr;
+  }
+
+  template <class... Ts>
+  friend void AssertHashEnabled();
+};
+
+template <class... Ts>
+inline void AssertHashEnabled() {
+  using Helper = AssertHashEnabledHelper;
+  Helper::Sink(Helper::DoIt<Ts>()...);
+}
+
+}  // namespace type_traits_internal
+
+// An internal namespace that is required to implement the C++17 swap traits.
+// It is not further nested in type_traits_internal to avoid long symbol names.
+namespace swap_internal {
+
+// Necessary for the traits.
+using std::swap;
+
+// This declaration prevents global `swap` and `ex_actor::embedded_3rd::absl::swap` overloads from being
+// considered unless ADL picks them up.
+void swap();
+
+template <class T>
+using IsSwappableImpl = decltype(swap(std::declval<T&>(), std::declval<T&>()));
+
+// NOTE: This dance with the default template parameter is for MSVC.
+template <class T,
+          class IsNoexcept = std::integral_constant<
+              bool, noexcept(swap(std::declval<T&>(), std::declval<T&>()))>>
+using IsNothrowSwappableImpl = typename std::enable_if<IsNoexcept::value>::type;
+
+// IsSwappable
+//
+// Determines whether the standard swap idiom is a valid expression for
+// arguments of type `T`.
+template <class T>
+struct IsSwappable
+    : ex_actor::embedded_3rd::absl::type_traits_internal::is_detected<IsSwappableImpl, T> {};
+
+// IsNothrowSwappable
+//
+// Determines whether the standard swap idiom is a valid expression for
+// arguments of type `T` and is noexcept.
+template <class T>
+struct IsNothrowSwappable
+    : ex_actor::embedded_3rd::absl::type_traits_internal::is_detected<IsNothrowSwappableImpl, T> {};
+
+// Swap()
+//
+// Performs the swap idiom from a namespace where valid candidates may only be
+// found in `std` or via ADL.
+template <class T, std::enable_if_t<IsSwappable<T>::value, int> = 0>
+void Swap(T& lhs, T& rhs) noexcept(IsNothrowSwappable<T>::value) {
+  swap(lhs, rhs);
+}
+
+// StdSwapIsUnconstrained
+//
+// Some standard library implementations are broken in that they do not
+// constrain `std::swap`. This will effectively tell us if we are dealing with
+// one of those implementations.
+using StdSwapIsUnconstrained = IsSwappable<void()>;
+
+}  // namespace swap_internal
+
+namespace type_traits_internal {
+
+// Make the swap-related traits/function accessible from this namespace.
+using swap_internal::IsNothrowSwappable;
+using swap_internal::IsSwappable;
+using swap_internal::StdSwapIsUnconstrained;
+using swap_internal::Swap;
+
+}  // namespace type_traits_internal
+
+// ex_actor::embedded_3rd::absl::is_trivially_relocatable<T>
+//
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2786r11.html
+//
+// Detects whether a type is known to be "trivially relocatable" -- meaning it
+// can be relocated from one place to another as if by memcpy/memmove.
+// This implies that its object representation doesn't depend on its address,
+// and also none of its special member functions do anything strange.
+//
+// Note that when relocating the caller code should ensure that if the object is
+// polymorphic, the dynamic type is of the most derived type. Padding bytes
+// should not be copied.
+//
+// This trait is conservative. If it's true then the type is definitely
+// trivially relocatable, but if it's false then the type may or may not be. For
+// example, std::vector<int> is trivially relocatable on every known STL
+// implementation, but ex_actor::embedded_3rd::absl::is_trivially_relocatable<std::vector<int>> remains
+// false.
+//
+// Example:
+//
+// if constexpr (ex_actor::embedded_3rd::absl::is_trivially_relocatable<T>::value) {
+//   memcpy(new_location, old_location, sizeof(T));
+// } else {
+//   new(new_location) T(std::move(*old_location));
+//   old_location->~T();
+// }
+//
+// Upstream documentation:
+//
+// https://clang.llvm.org/docs/LanguageExtensions.html#:~:text=__builtin_is_cpp_trivially_relocatable
+//
+// Clang on Windows has the builtin, but it falsely claims types with a
+// user-provided destructor are trivial (http://b/275003464). So we opt out
+// there.
+//
+// TODO(b/275003464): remove the opt-out once the bug is fixed.
+//
+// Starting with Xcode 15, the Apple compiler will falsely say a type
+// with a user-provided move constructor is trivially relocatable
+// (b/324278148). We will opt out without a version check, due to
+// the fluidity of Apple versions.
+//
+// TODO(b/324278148): If all versions we use have the bug fixed, then
+// remove the condition.
+//
+// Clang on all platforms fails to detect that a type with a user-provided
+// move-assignment operator is not trivially relocatable so we also check for
+// is_trivially_move_assignable for Clang.
+//
+// TODO(b/325479096): Remove the Clang is_trivially_move_assignable version once
+// Clang's behavior is fixed.
+//
+// According to https://github.com/abseil/abseil-cpp/issues/1479, this does not
+// work with NVCC either.
+#if EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_is_cpp_trivially_relocatable)
+// https://github.com/llvm/llvm-project/pull/127636#pullrequestreview-2637005293
+// In the current implementation, __builtin_is_cpp_trivially_relocatable will
+// only return true for types that are trivially relocatable according to the
+// standard. Notably, this means that marking a type [[clang::trivial_abi]] aka
+// EX_ACTOR_ABSL_HAVE_ATTRIBUTE_TRIVIAL_ABI will have no effect on this trait.
+template <class T>
+struct is_trivially_relocatable
+    : std::integral_constant<bool, __builtin_is_cpp_trivially_relocatable(T)> {
+};
+#elif EX_ACTOR_ABSL_HAVE_BUILTIN(__is_trivially_relocatable) && defined(__clang__) && \
+    !(defined(_WIN32) || defined(_WIN64)) && !defined(__APPLE__) &&          \
+    !defined(__NVCC__)
+// https://github.com/llvm/llvm-project/pull/139061
+//  __is_trivially_relocatable is deprecated.
+// TODO(b/325479096): Remove this case.
+template <class T>
+struct is_trivially_relocatable
+    : std::integral_constant<
+          bool, std::is_trivially_copyable<T>::value ||
+                    (__is_trivially_relocatable(T) &&
+                     std::is_trivially_move_assignable<T>::value)> {};
+#else
+// Otherwise we use a fallback that detects only those types we can feasibly
+// detect. Any type that is trivially copyable is by definition trivially
+// relocatable.
+template <class T>
+struct is_trivially_relocatable : std::is_trivially_copyable<T> {};
+#endif
+
+// ex_actor::embedded_3rd::absl::is_constant_evaluated()
+//
+// Detects whether the function call occurs within a constant-evaluated context.
+// Returns true if the evaluation of the call occurs within the evaluation of an
+// expression or conversion that is manifestly constant-evaluated; otherwise
+// returns false.
+//
+// This function is implemented in terms of `std::is_constant_evaluated` for
+// c++20 and up. For older c++ versions, the function is implemented in terms
+// of `__builtin_is_constant_evaluated` if available, otherwise the function
+// will fail to compile.
+//
+// Applications can inspect `EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED` at compile time
+// to check if this function is supported.
+//
+// Example:
+//
+// constexpr MyClass::MyClass(int param) {
+// #ifdef EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED
+//   if (!ex_actor::embedded_3rd::absl::is_constant_evaluated()) {
+//     EX_ACTOR_ABSL_LOG(INFO) << "MyClass(" << param << ")";
+//   }
+// #endif  // EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED
+// }
+//
+// Upstream documentation:
+//
+// http://en.cppreference.com/w/cpp/types/is_constant_evaluated
+// http://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html#:~:text=__builtin_is_constant_evaluated
+//
+#if defined(EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED)
+constexpr bool is_constant_evaluated() noexcept {
+#ifdef __cpp_lib_is_constant_evaluated
+  return std::is_constant_evaluated();
+#elif EX_ACTOR_ABSL_HAVE_BUILTIN(__builtin_is_constant_evaluated)
+  return __builtin_is_constant_evaluated();
+#endif
+}
+#endif  // EX_ACTOR_ABSL_HAVE_CONSTANT_EVALUATED
+
+namespace type_traits_internal {
+
+// Detects if a class's definition has declared itself to be an owner by
+// declaring
+//   using absl_internal_is_view = std::false_type;
+// as a member.
+// Types that don't want either must either omit this declaration entirely, or
+// (if e.g. inheriting from a base class) define the member to something that
+// isn't a Boolean trait class, such as `void`.
+// Do not specialize or use this directly. It's an implementation detail.
+template <typename T, typename = void>
+struct IsOwnerImpl : std::false_type {
+  static_assert(std::is_same<T, ex_actor::embedded_3rd::absl::remove_cvref_t<T>>::value,
+                "type must lack qualifiers");
+};
+
+template <typename T>
+struct IsOwnerImpl<
+    T,
+    std::enable_if_t<std::is_class<typename T::absl_internal_is_view>::value>>
+    : std::negation<typename T::absl_internal_is_view> {};
+
+// A trait to determine whether a type is an owner.
+// Do *not* depend on the correctness of this trait for correct code behavior.
+// It is only a safety feature and its value may change in the future.
+// Do not specialize this; instead, define the member trait inside your type so
+// that it can be auto-detected, and to prevent ODR violations.
+// If it ever becomes possible to detect [[gsl::Owner]], we should leverage it:
+// https://wg21.link/p1179
+template <typename T>
+struct IsOwner : IsOwnerImpl<T> {};
+
+// This allows incomplete types to be used for associative containers, and also
+// expands the set of types we can handle to include std::pair.
+template <typename T1, typename T2>
+struct IsOwner<std::pair<T1, T2>>
+    : std::integral_constant<
+          bool, std::conditional_t<std::is_reference_v<T1>, std::false_type,
+                                   IsOwner<std::remove_cv_t<T1>>>::value &&
+                    std::conditional_t<std::is_reference_v<T2>, std::false_type,
+                                       IsOwner<std::remove_cv_t<T2>>>::value> {
+};
+
+template <typename T, typename Traits, typename Alloc>
+struct IsOwner<std::basic_string<T, Traits, Alloc>> : std::true_type {};
+
+template <typename T, typename Alloc>
+struct IsOwner<std::vector<T, Alloc>> : std::true_type {};
+
+// Detects if a class's definition has declared itself to be a view by declaring
+//   using absl_internal_is_view = std::true_type;
+// as a member.
+// Do not specialize or use this directly.
+template <typename T, typename = void>
+struct IsViewImpl : std::false_type {
+  static_assert(std::is_same<T, ex_actor::embedded_3rd::absl::remove_cvref_t<T>>::value,
+                "type must lack qualifiers");
+};
+
+template <typename T>
+struct IsViewImpl<
+    T,
+    std::enable_if_t<std::is_class<typename T::absl_internal_is_view>::value>>
+    : T::absl_internal_is_view {};
+
+// A trait to determine whether a type is a view.
+// Do *not* depend on the correctness of this trait for correct code behavior.
+// It is only a safety feature, and its value may change in the future.
+// Do not specialize this trait. Instead, define the member
+//   using absl_internal_is_view = std::true_type;
+// in your class to allow its detection while preventing ODR violations.
+// If it ever becomes possible to detect [[gsl::Pointer]], we should leverage
+// it: https://wg21.link/p1179
+template <typename T>
+struct IsView : std::integral_constant<bool, std::is_pointer<T>::value ||
+                                                 IsViewImpl<T>::value> {};
+
+// This allows incomplete types to be used for associative containers, and also
+// expands the set of types we can handle to include std::pair.
+template <typename T1, typename T2>
+struct IsView<std::pair<T1, T2>>
+    : std::integral_constant<bool, IsView<std::remove_cv_t<T1>>::value &&
+                                       IsView<std::remove_cv_t<T2>>::value> {};
+
+template <typename Char, typename Traits>
+struct IsView<std::basic_string_view<Char, Traits>> : std::true_type {};
+
+#ifdef __cpp_lib_span
+template <typename T>
+struct IsView<std::span<T>> : std::true_type {};
+#endif
+
+// Determines whether the assignment of the given types is lifetime-bound.
+// Do *not* depend on the correctness of this trait for correct code behavior.
+// It is only a safety feature and its value may change in the future.
+// If it ever becomes possible to detect [[clang::lifetimebound]] directly,
+// we should change the implementation to leverage that.
+// Until then, we consider an assignment from an "owner" (such as std::string)
+// to a "view" (such as std::string_view) to be a lifetime-bound assignment.
+template <typename T, typename U>
+using IsLifetimeBoundAssignment = std::conjunction<
+    std::integral_constant<bool, !std::is_lvalue_reference<U>::value>,
+    IsOwner<ex_actor::embedded_3rd::absl::remove_cvref_t<U>>, IsView<ex_actor::embedded_3rd::absl::remove_cvref_t<T>>>;
+
+}  // namespace type_traits_internal
+
+EX_ACTOR_ABSL_NAMESPACE_END
+}  // namespace ex_actor::embedded_3rd::absl
+
+#endif  // EX_ACTOR_ABSL_META_TYPE_TRAITS_H_

--- a/include/ex_actor/3rd_lib/absl/utility/utility.h
+++ b/include/ex_actor/3rd_lib/absl/utility/utility.h
@@ -1,0 +1,151 @@
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef EX_ACTOR_ABSL_UTILITY_UTILITY_H_
+#define EX_ACTOR_ABSL_UTILITY_UTILITY_H_
+
+#include <cstddef>
+#include <cstdlib>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "ex_actor/3rd_lib/absl/base/attributes.h"
+#include "ex_actor/3rd_lib/absl/base/config.h"
+#include "ex_actor/3rd_lib/absl/base/macros.h"
+
+// TODO(b/290784225): Include what you use cleanup required.
+#include "ex_actor/3rd_lib/absl/meta/type_traits.h"
+
+// TODO(b/509512528): Deprecate the C++14/C++17 symbols publicly, in all files.
+
+namespace ex_actor::embedded_3rd::absl {
+EX_ACTOR_ABSL_NAMESPACE_BEGIN
+
+// Historical note: Abseil once provided implementations of these
+// abstractions for platforms that had not yet provided them. Those
+// platforms are no longer supported. New code should simply use the
+// the ones from std directly.
+template <class F, class T>
+EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
+constexpr decltype(auto)
+    apply(F&& f, T&& t) noexcept(noexcept(std::apply(std::declval<F>(),
+                                                     std::declval<T>()))) {
+  return std::apply(std::forward<F>(f), std::forward<T>(t));
+}
+
+template <class T1, class T2 = T1>
+EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
+constexpr T1 exchange(T1& obj, T2&& new_value) noexcept(
+    noexcept(std::exchange(std::declval<T1&>(), std::declval<T2>()))) {
+  return std::exchange(obj, std::forward<T2>(new_value));
+}
+
+template <class T>
+[[deprecated("Use std::forward instead.")]] [[nodiscard]] constexpr T&& forward(
+    std::remove_reference_t<T>& arg EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
+  // NOLINTNEXTLINE: Avoid warnings about T not being the spelled type of arg.
+  return std::forward<T>(arg);
+}
+
+template <class T>
+[[deprecated("Use std::forward instead.")]] [[nodiscard]] constexpr T&& forward(
+    std::remove_reference_t<T>&& arg EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
+  // NOLINTNEXTLINE: Avoid warnings about T not being the spelled type of arg.
+  return std::forward<T>(arg);
+}
+
+inline constexpr const std::in_place_t& in_place EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
+    std::in_place;
+
+template <size_t I>
+inline constexpr const std::in_place_index_t<I>& in_place_index
+    [[deprecated("Use std::in_place_index<I> instead.")]] =
+        std::in_place_index<I>;
+
+template <size_t I>
+using in_place_index_t [[deprecated("Use std::in_place_index_t<I> instead.")]] =
+    std::in_place_index_t<I>;
+
+using in_place_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::in_place_t;
+
+template <class T>
+inline constexpr const std::in_place_type_t<T>& in_place_type
+EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::in_place_type<T>;
+
+template <class T>
+using in_place_type_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::in_place_type_t<T>;
+
+template <size_t... I>
+using index_sequence [[deprecated("Use std::index_sequence instead.")]] =
+    std::index_sequence<I...>;
+
+template <class T, T... I>
+using integer_sequence [[deprecated("Use std::integer_sequence instead.")]] =
+    std::integer_sequence<T, I...>;
+
+template <class... T>
+using index_sequence_for
+    [[deprecated("Use std::index_sequence_for instead.")]] =
+        std::index_sequence_for<T...>;
+
+template <class T, class Tuple>
+EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
+[[nodiscard]] constexpr decltype(std::make_from_tuple<T>(std::declval<Tuple>()))
+    make_from_tuple(Tuple&& arg) noexcept(
+        noexcept(std::make_from_tuple<T>(std::declval<Tuple>()))) {
+  return std::make_from_tuple<T>(std::forward<Tuple>(arg));
+}
+
+template <size_t N>
+using make_index_sequence
+    [[deprecated("Use std::make_index_sequence instead.")]] =
+        std::make_index_sequence<N>;
+
+template <class T, T N>
+using make_integer_sequence
+    [[deprecated("Use std::make_integer_sequence instead.")]] =
+        std::make_integer_sequence<T, N>;
+
+template <class It, class OutIt>
+[[deprecated("Use std::move instead.")]]
+constexpr OutIt move(It&& begin, It&& end, OutIt&& output) {
+  return std::move(std::forward<It>(begin), std::forward<It>(end),
+                   std::forward<OutIt>(output));
+}
+
+template <class T>
+[[deprecated("Use std::move instead.")]]
+[[nodiscard]] constexpr std::remove_reference_t<T>&&
+move(T&& arg EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
+  return std::move(arg);  // NOLINT(bugprone-move-forwarding-reference)
+}
+
+#if EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
+// Backfill for std::nontype_t. An instance of this class can be provided as a
+// disambiguation tag to `ex_actor::embedded_3rd::absl::function_ref` to pass the address of a known
+// callable at compile time.
+// Requires C++20 due to `auto` template parameter.
+template <auto>
+struct nontype_t {
+  explicit nontype_t() = default;
+};
+template <auto V>
+constexpr nontype_t<V> nontype{};
+#endif
+
+EX_ACTOR_ABSL_NAMESPACE_END
+}  // namespace ex_actor::embedded_3rd::absl
+
+#endif  // EX_ACTOR_ABSL_UTILITY_UTILITY_H_

--- a/include/ex_actor/3rd_lib/absl/utility/utility.h
+++ b/include/ex_actor/3rd_lib/absl/utility/utility.h
@@ -18,17 +18,12 @@
 #include <cstddef>
 #include <cstdlib>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 
-#include "ex_actor/3rd_lib/absl/base/attributes.h"
 #include "ex_actor/3rd_lib/absl/base/config.h"
-#include "ex_actor/3rd_lib/absl/base/macros.h"
 
 // TODO(b/290784225): Include what you use cleanup required.
 #include "ex_actor/3rd_lib/absl/meta/type_traits.h"
-
-// TODO(b/509512528): Deprecate the C++14/C++17 symbols publicly, in all files.
 
 namespace ex_actor::embedded_3rd::absl {
 EX_ACTOR_ABSL_NAMESPACE_BEGIN
@@ -37,100 +32,22 @@ EX_ACTOR_ABSL_NAMESPACE_BEGIN
 // abstractions for platforms that had not yet provided them. Those
 // platforms are no longer supported. New code should simply use the
 // the ones from std directly.
-template <class F, class T>
-EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
-constexpr decltype(auto)
-    apply(F&& f, T&& t) noexcept(noexcept(std::apply(std::declval<F>(),
-                                                     std::declval<T>()))) {
-  return std::apply(std::forward<F>(f), std::forward<T>(t));
-}
-
-template <class T1, class T2 = T1>
-EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
-constexpr T1 exchange(T1& obj, T2&& new_value) noexcept(
-    noexcept(std::exchange(std::declval<T1&>(), std::declval<T2>()))) {
-  return std::exchange(obj, std::forward<T2>(new_value));
-}
-
-template <class T>
-[[deprecated("Use std::forward instead.")]] [[nodiscard]] constexpr T&& forward(
-    std::remove_reference_t<T>& arg EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
-  // NOLINTNEXTLINE: Avoid warnings about T not being the spelled type of arg.
-  return std::forward<T>(arg);
-}
-
-template <class T>
-[[deprecated("Use std::forward instead.")]] [[nodiscard]] constexpr T&& forward(
-    std::remove_reference_t<T>&& arg EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
-  // NOLINTNEXTLINE: Avoid warnings about T not being the spelled type of arg.
-  return std::forward<T>(arg);
-}
-
-inline constexpr const std::in_place_t& in_place EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() =
-    std::in_place;
-
-template <size_t I>
-inline constexpr const std::in_place_index_t<I>& in_place_index
-    [[deprecated("Use std::in_place_index<I> instead.")]] =
-        std::in_place_index<I>;
-
-template <size_t I>
-using in_place_index_t [[deprecated("Use std::in_place_index_t<I> instead.")]] =
-    std::in_place_index_t<I>;
-
-using in_place_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::in_place_t;
-
-template <class T>
-inline constexpr const std::in_place_type_t<T>& in_place_type
-EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::in_place_type<T>;
-
-template <class T>
-using in_place_type_t EX_ACTOR_ABSL_DEPRECATE_AND_INLINE() = std::in_place_type_t<T>;
-
-template <size_t... I>
-using index_sequence [[deprecated("Use std::index_sequence instead.")]] =
-    std::index_sequence<I...>;
-
-template <class T, T... I>
-using integer_sequence [[deprecated("Use std::integer_sequence instead.")]] =
-    std::integer_sequence<T, I...>;
-
-template <class... T>
-using index_sequence_for
-    [[deprecated("Use std::index_sequence_for instead.")]] =
-        std::index_sequence_for<T...>;
-
-template <class T, class Tuple>
-EX_ACTOR_ABSL_DEPRECATE_AND_INLINE()
-[[nodiscard]] constexpr decltype(std::make_from_tuple<T>(std::declval<Tuple>()))
-    make_from_tuple(Tuple&& arg) noexcept(
-        noexcept(std::make_from_tuple<T>(std::declval<Tuple>()))) {
-  return std::make_from_tuple<T>(std::forward<Tuple>(arg));
-}
-
-template <size_t N>
-using make_index_sequence
-    [[deprecated("Use std::make_index_sequence instead.")]] =
-        std::make_index_sequence<N>;
-
-template <class T, T N>
-using make_integer_sequence
-    [[deprecated("Use std::make_integer_sequence instead.")]] =
-        std::make_integer_sequence<T, N>;
-
-template <class It, class OutIt>
-[[deprecated("Use std::move instead.")]]
-constexpr OutIt move(It&& begin, It&& end, OutIt&& output) {
-  return std::move(std::forward<It>(begin), std::forward<It>(end),
-                   std::forward<OutIt>(output));
-}
-
-template <class T>
-[[deprecated("Use std::move instead.")]]
-[[nodiscard]] constexpr std::remove_reference_t<T>&&
-move(T&& arg EX_ACTOR_ABSL_ATTRIBUTE_LIFETIME_BOUND) noexcept {
-  return std::move(arg);  // NOLINT(bugprone-move-forwarding-reference)
-}
+using std::apply;
+using std::exchange;
+using std::forward;
+using std::in_place;
+using std::in_place_index;
+using std::in_place_index_t;
+using std::in_place_t;
+using std::in_place_type;
+using std::in_place_type_t;
+using std::index_sequence;
+using std::index_sequence_for;
+using std::integer_sequence;
+using std::make_from_tuple;
+using std::make_index_sequence;
+using std::make_integer_sequence;
+using std::move;
 
 #if EX_ACTOR_ABSL_INTERNAL_CPLUSPLUS_LANG >= 202002L
 // Backfill for std::nontype_t. An instance of this class can be provided as a

--- a/include/ex_actor/3rd_lib/daking/MPSC_queue.h
+++ b/include/ex_actor/3rd_lib/daking/MPSC_queue.h
@@ -26,68 +26,68 @@ SOFTWARE.
 #pragma once
 #endif
 
-#ifndef DAKING_MPSC_QUEUE_HPP
-#define DAKING_MPSC_QUEUE_HPP
+#ifndef EX_ACTOR_DAKING_MPSC_QUEUE_HPP
+#define EX_ACTOR_DAKING_MPSC_QUEUE_HPP
 
-#ifndef DAKING_HAS_TSAN
+#ifndef EX_ACTOR_DAKING_HAS_TSAN
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
 #include <sanitizer/tsan_interface.h>
 extern "C" {
 void AnnotateBenignRaceSized(const char* f, int l, const volatile void* mem, unsigned int size, const char* desc);
 }
-#define DAKING_HAS_TSAN 1
-#define DAKING_NO_TSAN __attribute__((no_sanitize("thread")))
-#define DAKING_TSAN_ANNOTATE_IGNORED(mem, size, desc) AnnotateBenignRaceSized(__FILE__, __LINE__, mem, size, desc)
-#define DAKING_TSAN_ANNOTATE_ACQUIRE(mem) __tsan_acquire(mem)
-#define DAKING_TSAN_ANNOTATE_RELEASE(mem) __tsan_release(mem)
+#define EX_ACTOR_DAKING_HAS_TSAN 1
+#define EX_ACTOR_DAKING_NO_TSAN __attribute__((no_sanitize("thread")))
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_IGNORED(mem, size, desc) AnnotateBenignRaceSized(__FILE__, __LINE__, mem, size, desc)
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_ACQUIRE(mem) __tsan_acquire(mem)
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_RELEASE(mem) __tsan_release(mem)
 #else
-#define DAKING_HAS_TSAN 0
-#define DAKING_NO_TSAN
-#define DAKING_TSAN_ANNOTATE_IGNORED(mem, size, desc)
-#define DAKING_TSAN_ANNOTATE_ACQUIRE(mem)
-#define DAKING_TSAN_ANNOTATE_RELEASE(mem)
+#define EX_ACTOR_DAKING_HAS_TSAN 0
+#define EX_ACTOR_DAKING_NO_TSAN
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_IGNORED(mem, size, desc)
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_ACQUIRE(mem)
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_RELEASE(mem)
 #endif
 #else
-#define DAKING_HAS_TSAN 0
-#define DAKING_NO_TSAN
-#define DAKING_TSAN_ANNOTATE_IGNORED(mem, size, desc)
-#define DAKING_TSAN_ANNOTATE_ACQUIRE(mem)
-#define DAKING_TSAN_ANNOTATE_RELEASE(mem)
+#define EX_ACTOR_DAKING_HAS_TSAN 0
+#define EX_ACTOR_DAKING_NO_TSAN
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_IGNORED(mem, size, desc)
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_ACQUIRE(mem)
+#define EX_ACTOR_DAKING_TSAN_ANNOTATE_RELEASE(mem)
 #endif
-#endif  // !DAKING_HAS_TSAN
+#endif  // !EX_ACTOR_DAKING_HAS_TSAN
 
-#ifndef DAKING_HAS_CXX20_OR_ABOVE
+#ifndef EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
 #if defined(_MSC_VER)
-#define DAKING_HAS_CXX20_OR_ABOVE _MSVC_LANG >= 202002L
+#define EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE _MSVC_LANG >= 202002L
 #else
-#define DAKING_HAS_CXX20_OR_ABOVE __cplusplus >= 202002L
+#define EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE __cplusplus >= 202002L
 #endif
-#endif  // !DAKING_HAS_CXX20_OR_ABOVE
+#endif  // !EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
 
-#ifndef DAKING_ALWAYS_INLINE
+#ifndef EX_ACTOR_DAKING_ALWAYS_INLINE
 #if defined(_MSC_VER)
-#define DAKING_ALWAYS_INLINE [[msvc::forceinline]]
+#define EX_ACTOR_DAKING_ALWAYS_INLINE [[msvc::forceinline]]
 #else
-#define DAKING_ALWAYS_INLINE [[gnu::always_inline]]
+#define EX_ACTOR_DAKING_ALWAYS_INLINE [[gnu::always_inline]]
 #endif
-#endif  // !DAKING_ALWAYS_INLINE
+#endif  // !EX_ACTOR_DAKING_ALWAYS_INLINE
 
-#ifndef DAKING_LIKELY
-#if DAKING_HAS_CXX20_OR_ABOVE
-#define DAKING_LIKELY [[likely]]
+#ifndef EX_ACTOR_DAKING_LIKELY
+#if EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
+#define EX_ACTOR_DAKING_LIKELY [[likely]]
 #else
-#define DAKING_LIKELY
+#define EX_ACTOR_DAKING_LIKELY
 #endif
-#endif  // !DAKING_LIKELY
+#endif  // !EX_ACTOR_DAKING_LIKELY
 
-#ifndef DAKING_UNLIKELY
-#if DAKING_HAS_CXX20_OR_ABOVE
-#define DAKING_UNLIKELY [[unlikely]]
+#ifndef EX_ACTOR_DAKING_UNLIKELY
+#if EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
+#define EX_ACTOR_DAKING_UNLIKELY [[unlikely]]
 #else
-#define DAKING_UNLIKELY
+#define EX_ACTOR_DAKING_UNLIKELY
 #endif
-#endif  // !DAKING_UNLIKELY
+#endif  // !EX_ACTOR_DAKING_UNLIKELY
 
 #include <atomic>
 #include <cstddef>
@@ -195,9 +195,9 @@ struct MPSC_chunk_stack {
   MPSC_chunk_stack() = default;
   ~MPSC_chunk_stack() = default;
 
-  DAKING_ALWAYS_INLINE void reset() noexcept { top_.store(tagged_ptr {nullptr, 0}); }
+  EX_ACTOR_DAKING_ALWAYS_INLINE void reset() noexcept { top_.store(tagged_ptr {nullptr, 0}); }
 
-  DAKING_ALWAYS_INLINE void push(node_t* chunk) noexcept /* Pointer Swap */ {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void push(node_t* chunk) noexcept /* Pointer Swap */ {
     tagged_ptr new_top {chunk, 0};
     tagged_ptr old_top = top_.load(std::memory_order_relaxed);
     // If TB read old_top, and TA pop the old_top then
@@ -210,7 +210,7 @@ struct MPSC_chunk_stack {
     } while (!top_.compare_exchange_weak(old_top, new_top, std::memory_order_acq_rel, std::memory_order_relaxed));
   }
 
-  DAKING_ALWAYS_INLINE bool try_pop(node_t*& chunk) noexcept /* Pointer Swap */ {
+  EX_ACTOR_DAKING_ALWAYS_INLINE bool try_pop(node_t*& chunk) noexcept /* Pointer Swap */ {
     tagged_ptr old_top = top_.load(std::memory_order_acquire);
     tagged_ptr new_top {};
 
@@ -218,7 +218,7 @@ struct MPSC_chunk_stack {
       if (!old_top.node_) {
         return false;
       }
-      DAKING_TSAN_ANNOTATE_IGNORED(&old_top.node_->next_chunk_, sizeof(node_t*), "Reason: healthy data race");
+      EX_ACTOR_DAKING_TSAN_ANNOTATE_IGNORED(&old_top.node_->next_chunk_, sizeof(node_t*), "Reason: healthy data race");
       new_top.node_ = old_top.node_->next_chunk_;
       new_top.tag_ = old_top.tag_ + 1;
       // If TA and TB reach here at the same time
@@ -257,9 +257,9 @@ struct MPSC_thread_hook {
     }
   }
 
-  DAKING_ALWAYS_INLINE node_t*& node_list() noexcept { return pair_->first; }
+  EX_ACTOR_DAKING_ALWAYS_INLINE node_t*& node_list() noexcept { return pair_->first; }
 
-  DAKING_ALWAYS_INLINE size_type& node_size() noexcept { return pair_->second; }
+  EX_ACTOR_DAKING_ALWAYS_INLINE size_type& node_size() noexcept { return pair_->second; }
 
   std::thread::id tid_;
   thread_local_t* pair_;
@@ -321,7 +321,7 @@ struct MPSC_manager : public std::allocator_traits<Alloc>::template rebind_alloc
 
     for (size_type i = 0; i < count; i++) {
       new_nodes[i].next_ = new_nodes + i + 1;  // seq_cst
-      if ((i & (Queue::thread_local_capacity - 1)) == Queue::thread_local_capacity - 1) DAKING_UNLIKELY {
+      if ((i & (Queue::thread_local_capacity - 1)) == Queue::thread_local_capacity - 1) EX_ACTOR_DAKING_UNLIKELY {
           // chunk_count = count / ThreadLocalCapacity
           new_nodes[i].next_ = nullptr;
           std::atomic_thread_fence(std::memory_order_acq_rel);
@@ -333,7 +333,7 @@ struct MPSC_manager : public std::allocator_traits<Alloc>::template rebind_alloc
     global_node_count_.store(global_node_count_ + count, std::memory_order_release);
   }
 
-  DAKING_ALWAYS_INLINE thread_local_t* register_for(std::thread::id tid) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE thread_local_t* register_for(std::thread::id tid) {
     /* Already locked */
     if (!global_thread_local_recycler_.empty()) {
       global_thread_local_manager_[tid] = std::move(global_thread_local_recycler_.back());
@@ -344,15 +344,15 @@ struct MPSC_manager : public std::allocator_traits<Alloc>::template rebind_alloc
     return global_thread_local_manager_[tid].get();
   }
 
-  DAKING_ALWAYS_INLINE void unregister_for(std::thread::id tid) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void unregister_for(std::thread::id tid) {
     /* Already locked */
     global_thread_local_recycler_.push_back(std::move(global_thread_local_manager_[tid]));
     global_thread_local_manager_.erase(tid);
   }
 
-  DAKING_ALWAYS_INLINE size_type node_count() noexcept { return global_node_count_.load(std::memory_order_acquire); }
+  EX_ACTOR_DAKING_ALWAYS_INLINE size_type node_count() noexcept { return global_node_count_.load(std::memory_order_acquire); }
 
-  DAKING_ALWAYS_INLINE static MPSC_manager* create_global_manager(const Alloc& alloc) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE static MPSC_manager* create_global_manager(const Alloc& alloc) {
     static MPSC_manager global_manager(alloc);
     return &global_manager;
   }
@@ -445,25 +445,25 @@ class MPSC_queue {
   MPSC_queue& operator=(MPSC_queue&&) = delete;
 
   template <typename... Args>
-  DAKING_ALWAYS_INLINE void emplace(Args&&... args) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void emplace(Args&&... args) {
     node_t* new_node = _allocate();
     altraits_node_t::construct(_get_global_manager(), std::addressof(new_node->value_), std::forward<Args>(args)...);
 
     node_t* old_head = head_.exchange(new_node, std::memory_order_acq_rel);
     old_head->next_.store(new_node, std::memory_order_release);
-#if DAKING_HAS_CXX20_OR_ABOVE
+#if EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
     old_head->next_.notify_one();
 #endif
   }
 
-  DAKING_ALWAYS_INLINE void enqueue(const_reference value) { emplace(value); }
+  EX_ACTOR_DAKING_ALWAYS_INLINE void enqueue(const_reference value) { emplace(value); }
 
-  DAKING_ALWAYS_INLINE void enqueue(value_type&& value) { emplace(std::move(value)); }
+  EX_ACTOR_DAKING_ALWAYS_INLINE void enqueue(value_type&& value) { emplace(std::move(value)); }
 
-  DAKING_ALWAYS_INLINE void enqueue_bulk(const_reference value, size_type n) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void enqueue_bulk(const_reference value, size_type n) {
     // N times thread_local operation, One time CAS operation.
     // So it is more efficient than N times enqueue.
-    if (n == 0) DAKING_UNLIKELY {
+    if (n == 0) EX_ACTOR_DAKING_UNLIKELY {
         return;
       }
 
@@ -478,19 +478,19 @@ class MPSC_queue {
     }
     node_t* old_head = head_.exchange(prev_node, std::memory_order_acq_rel);
     old_head->next_.store(first_new_node, std::memory_order_release);
-#if DAKING_HAS_CXX20_OR_ABOVE
+#if EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
     old_head->next_.notify_one();
 #endif
   }
 
   template <typename InputIt>
-  DAKING_ALWAYS_INLINE void enqueue_bulk(InputIt it, size_type n) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void enqueue_bulk(InputIt it, size_type n) {
     // Enqueue n elements from input iterator.
     static_assert(std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<InputIt>::iterator_category>,
                   "Iterator must be at least input iterator.");
     static_assert(std::is_same_v<typename std::iterator_traits<InputIt>::value_type, value_type>,
                   "The value type of iterator must be same as MPSC_queue::value_type.");
-    if (n == 0) DAKING_UNLIKELY {
+    if (n == 0) EX_ACTOR_DAKING_UNLIKELY {
         return;
       }
 
@@ -507,7 +507,7 @@ class MPSC_queue {
     }
     node_t* old_head = head_.exchange(prev_node, std::memory_order_acq_rel);
     old_head->next_.store(first_new_node, std::memory_order_release);
-#if DAKING_HAS_CXX20_OR_ABOVE
+#if EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
     old_head->next_.notify_one();
 #endif
   }
@@ -516,17 +516,17 @@ class MPSC_queue {
             std::enable_if_t<std::is_base_of_v<std::forward_iterator_tag,
                                                typename std::iterator_traits<ForwardIt>::iterator_category>,
                              int> = 0>
-  DAKING_ALWAYS_INLINE void enqueue_bulk(ForwardIt begin, ForwardIt end) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void enqueue_bulk(ForwardIt begin, ForwardIt end) {
     enqueue_bulk(begin, (size_type)std::distance(begin, end));
   }
 
   template <typename T>
-  DAKING_ALWAYS_INLINE bool try_dequeue(T& value) noexcept(std::is_nothrow_assignable_v<T&, value_type&&> &&
+  EX_ACTOR_DAKING_ALWAYS_INLINE bool try_dequeue(T& value) noexcept(std::is_nothrow_assignable_v<T&, value_type&&> &&
                                                            std::is_nothrow_destructible_v<value_type>) {
     static_assert(std::is_assignable_v<T&, value_type&&>);
 
     node_t* next = tail_->next_.load(std::memory_order_acquire);
-    if (next) DAKING_LIKELY {
+    if (next) EX_ACTOR_DAKING_LIKELY {
         value = std::move(next->value_);
         altraits_node_t::destroy(_get_global_manager(), std::addressof(next->value_));
         _deallocate(std::exchange(tail_, next));
@@ -538,7 +538,7 @@ class MPSC_queue {
   }
 
   template <typename OutputIt>
-  DAKING_ALWAYS_INLINE size_type
+  EX_ACTOR_DAKING_ALWAYS_INLINE size_type
   try_dequeue_bulk(OutputIt it, size_type n) noexcept(std::is_nothrow_assignable_v<decltype(*it), value_type&&> &&
                                                       std::is_nothrow_destructible_v<value_type> && noexcept(++it)) {
     static_assert(
@@ -559,13 +559,13 @@ class MPSC_queue {
             std::enable_if_t<std::is_base_of_v<std::forward_iterator_tag,
                                                typename std::iterator_traits<ForwardIt>::iterator_category>,
                              int> = 0>
-  DAKING_ALWAYS_INLINE size_type try_dequeue_bulk(ForwardIt begin, ForwardIt end) noexcept(
+  EX_ACTOR_DAKING_ALWAYS_INLINE size_type try_dequeue_bulk(ForwardIt begin, ForwardIt end) noexcept(
       std::is_nothrow_assignable_v<decltype(*begin), value_type&&> && std::is_nothrow_destructible_v<value_type> &&
       noexcept(++begin)) {
     return try_dequeue_bulk(begin, (size_type)std::distance(begin, end));
   }
 
-#if DAKING_HAS_CXX20_OR_ABOVE
+#if EX_ACTOR_DAKING_HAS_CXX20_OR_ABOVE
   template <typename T>
   void dequeue(T& result) noexcept(std::is_nothrow_assignable_v<T&, value_type&&> &&
                                    std::is_nothrow_destructible_v<value_type>) {
@@ -603,41 +603,41 @@ class MPSC_queue {
             std::enable_if_t<std::is_base_of_v<std::forward_iterator_tag,
                                                typename std::iterator_traits<ForwardIt>::iterator_category>,
                              int> = 0>
-  DAKING_ALWAYS_INLINE void dequeue_bulk(ForwardIt begin, ForwardIt end) noexcept(
+  EX_ACTOR_DAKING_ALWAYS_INLINE void dequeue_bulk(ForwardIt begin, ForwardIt end) noexcept(
       std::is_nothrow_assignable_v<decltype(*begin), value_type&&> && std::is_nothrow_destructible_v<value_type> &&
       noexcept(++begin)) {
     dequeue_bulk(begin, (size_type)std::distance(begin, end));
   }
 #endif
 
-  DAKING_ALWAYS_INLINE bool empty() const noexcept { return tail_->next_.load(std::memory_order_acquire) == nullptr; }
+  EX_ACTOR_DAKING_ALWAYS_INLINE bool empty() const noexcept { return tail_->next_.load(std::memory_order_acquire) == nullptr; }
 
-  DAKING_ALWAYS_INLINE static size_type global_node_size_apprx() noexcept {
+  EX_ACTOR_DAKING_ALWAYS_INLINE static size_type global_node_size_apprx() noexcept {
     return _is_global_manager_alive() ? _get_global_manager().node_count() : 0;
   }
 
-  DAKING_ALWAYS_INLINE static bool reserve_global_chunk(size_type chunk_count) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE static bool reserve_global_chunk(size_type chunk_count) {
     return _is_global_manager_alive() ? _reserve_global_external(chunk_count) : false;
   }
 
  private:
-  DAKING_ALWAYS_INLINE static manager_t& _get_global_manager() noexcept { return *global_manager_instance_; }
+  EX_ACTOR_DAKING_ALWAYS_INLINE static manager_t& _get_global_manager() noexcept { return *global_manager_instance_; }
 
-  DAKING_ALWAYS_INLINE static bool _is_global_manager_alive() noexcept {
+  EX_ACTOR_DAKING_ALWAYS_INLINE static bool _is_global_manager_alive() noexcept {
     std::atomic_thread_fence(std::memory_order_acquire);
     return global_manager_instance_ != nullptr;
   }
 
-  DAKING_ALWAYS_INLINE thread_hook_t& _get_thread_hook() {
+  EX_ACTOR_DAKING_ALWAYS_INLINE thread_hook_t& _get_thread_hook() {
     static thread_local thread_hook_t thread_hook;
     return thread_hook;
   }
 
-  DAKING_ALWAYS_INLINE node_t*& _get_thread_local_node_list() noexcept { return _get_thread_hook().node_list(); }
+  EX_ACTOR_DAKING_ALWAYS_INLINE node_t*& _get_thread_local_node_list() noexcept { return _get_thread_hook().node_list(); }
 
-  DAKING_ALWAYS_INLINE size_type& _get_thread_local_node_size() noexcept { return _get_thread_hook().node_size(); }
+  EX_ACTOR_DAKING_ALWAYS_INLINE size_type& _get_thread_local_node_size() noexcept { return _get_thread_hook().node_size(); }
 
-  DAKING_ALWAYS_INLINE void _initial(const Alloc& alloc) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void _initial(const Alloc& alloc) {
     {
       std::lock_guard<std::mutex> guard(global_mutex_);
       global_manager_instance_ = manager_t::create_global_manager(alloc);  // single instance
@@ -648,36 +648,36 @@ class MPSC_queue {
     head_.store(dummy, std::memory_order_release);
   }
 
-  DAKING_ALWAYS_INLINE node_t* _allocate() {
+  EX_ACTOR_DAKING_ALWAYS_INLINE node_t* _allocate() {
     node_t*& thread_local_node_list = _get_thread_local_node_list();
     size_type& thread_local_node_size = _get_thread_local_node_size();
-    if (thread_local_node_size == 0) DAKING_UNLIKELY {
+    if (thread_local_node_size == 0) EX_ACTOR_DAKING_UNLIKELY {
         while (!global_chunk_stack_.try_pop(thread_local_node_list)) {
           _reserve_global_internal();
         }
         thread_local_node_size = thread_local_capacity;
       }
     thread_local_node_size--;
-    DAKING_TSAN_ANNOTATE_ACQUIRE(thread_local_node_list);
-    DAKING_TSAN_ANNOTATE_ACQUIRE(thread_local_node_list->next_);
+    EX_ACTOR_DAKING_TSAN_ANNOTATE_ACQUIRE(thread_local_node_list);
+    EX_ACTOR_DAKING_TSAN_ANNOTATE_ACQUIRE(thread_local_node_list->next_);
     node_t* res = std::exchange(thread_local_node_list, thread_local_node_list->next_.load(std::memory_order_relaxed));
     res->next_.store(nullptr, std::memory_order_relaxed);
     return res;
   }
 
-  DAKING_ALWAYS_INLINE void _deallocate(node_t* node) noexcept {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void _deallocate(node_t* node) noexcept {
     node_t*& thread_local_node_list = _get_thread_local_node_list();
     node->next_.store(thread_local_node_list, std::memory_order_relaxed);
     thread_local_node_list = node;
-    DAKING_TSAN_ANNOTATE_RELEASE(node);
-    if (++_get_thread_local_node_size() >= thread_local_capacity) DAKING_UNLIKELY {
+    EX_ACTOR_DAKING_TSAN_ANNOTATE_RELEASE(node);
+    if (++_get_thread_local_node_size() >= thread_local_capacity) EX_ACTOR_DAKING_UNLIKELY {
         global_chunk_stack_.push(thread_local_node_list);
         thread_local_node_list = nullptr;
         _get_thread_local_node_size() = 0;
       }
   }
 
-  DAKING_ALWAYS_INLINE static bool _reserve_global_external(size_type chunk_count) {
+  EX_ACTOR_DAKING_ALWAYS_INLINE static bool _reserve_global_external(size_type chunk_count) {
     manager_t& manager = _get_global_manager();
     size_type global_node_count = manager.node_count();
     if (global_node_count / thread_local_capacity >= chunk_count) {
@@ -694,7 +694,7 @@ class MPSC_queue {
     return true;
   }
 
-  DAKING_ALWAYS_INLINE static void _reserve_global_internal() {
+  EX_ACTOR_DAKING_ALWAYS_INLINE static void _reserve_global_internal() {
     std::lock_guard<std::mutex> lock(global_mutex_);
     if (global_chunk_stack_.top_.load(std::memory_order_acquire).node_) {
       // if anyone have already allocate chunks, I return.
@@ -704,7 +704,7 @@ class MPSC_queue {
     _get_global_manager().reserve(std::max(thread_local_capacity, _get_global_manager().node_count()));
   }
 
-  DAKING_ALWAYS_INLINE void _free_global() {
+  EX_ACTOR_DAKING_ALWAYS_INLINE void _free_global() {
     /* Already locked */
     global_chunk_stack_.reset();
     if (_is_global_manager_alive()) {
@@ -726,4 +726,4 @@ class MPSC_queue {
 };
 }  // namespace ex_actor::embedded_3rd::daking
 
-#endif  // !DAKING_MPSC_QUEUE_HPP
+#endif  // !EX_ACTOR_DAKING_MPSC_QUEUE_HPP

--- a/include/ex_actor/3rd_lib/moody_camel_queue/blockingconcurrentqueue.h
+++ b/include/ex_actor/3rd_lib/moody_camel_queue/blockingconcurrentqueue.h
@@ -61,7 +61,7 @@ class BlockingConcurrentQueue {
     assert(reinterpret_cast<ConcurrentQueue*>((BlockingConcurrentQueue*)1) == &((BlockingConcurrentQueue*)1)->inner &&
            "BlockingConcurrentQueue must have ConcurrentQueue as its first member");
     if (!sema) {
-      MOODYCAMEL_THROW(std::bad_alloc());
+      EX_ACTOR_MOODYCAMEL_THROW(std::bad_alloc());
     }
   }
 
@@ -72,13 +72,13 @@ class BlockingConcurrentQueue {
     assert(reinterpret_cast<ConcurrentQueue*>((BlockingConcurrentQueue*)1) == &((BlockingConcurrentQueue*)1)->inner &&
            "BlockingConcurrentQueue must have ConcurrentQueue as its first member");
     if (!sema) {
-      MOODYCAMEL_THROW(std::bad_alloc());
+      EX_ACTOR_MOODYCAMEL_THROW(std::bad_alloc());
     }
   }
 
   // Disable copying and copy assignment
-  BlockingConcurrentQueue(BlockingConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
-  BlockingConcurrentQueue& operator=(BlockingConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
+  BlockingConcurrentQueue(BlockingConcurrentQueue const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  BlockingConcurrentQueue& operator=(BlockingConcurrentQueue const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
   // Moving is supported, but note that it is *not* a thread-safe operation.
   // Nobody can use the queue while it's being moved, and the memory effects
@@ -86,10 +86,10 @@ class BlockingConcurrentQueue {
   // Note: When a queue is moved, its tokens are still valid but can only be
   // used with the destination queue (i.e. semantically they are moved along
   // with the queue itself).
-  BlockingConcurrentQueue(BlockingConcurrentQueue&& other) MOODYCAMEL_NOEXCEPT : inner(std::move(other.inner)),
+  BlockingConcurrentQueue(BlockingConcurrentQueue&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT : inner(std::move(other.inner)),
                                                                                  sema(std::move(other.sema)) {}
 
-  inline BlockingConcurrentQueue& operator=(BlockingConcurrentQueue&& other) MOODYCAMEL_NOEXCEPT {
+  inline BlockingConcurrentQueue& operator=(BlockingConcurrentQueue&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
     return swap_internal(other);
   }
 
@@ -98,7 +98,7 @@ class BlockingConcurrentQueue {
   // the tokens that were created for one queue must be used with
   // only the swapped queue (i.e. the tokens are tied to the
   // queue's movable state, not the object itself).
-  inline void swap(BlockingConcurrentQueue& other) MOODYCAMEL_NOEXCEPT { swap_internal(other); }
+  inline void swap(BlockingConcurrentQueue& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT { swap_internal(other); }
 
  private:
   BlockingConcurrentQueue& swap_internal(BlockingConcurrentQueue& other) {
@@ -531,7 +531,7 @@ class BlockingConcurrentQueue {
 };
 
 template <typename T, typename Traits>
-inline void swap(BlockingConcurrentQueue<T, Traits>& a, BlockingConcurrentQueue<T, Traits>& b) MOODYCAMEL_NOEXCEPT {
+inline void swap(BlockingConcurrentQueue<T, Traits>& a, BlockingConcurrentQueue<T, Traits>& b) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
   a.swap(b);
 }
 

--- a/include/ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h
+++ b/include/ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h
@@ -34,8 +34,8 @@
 #pragma push_macro("BLOCK_SIZE")
 #undef BLOCK_SIZE
 
-#ifdef MOODYCAMEL_ALIGNAS
-#undef MOODYCAMEL_ALIGNAS
+#ifdef EX_ACTOR_MOODYCAMEL_ALIGNAS
+#undef EX_ACTOR_MOODYCAMEL_ALIGNAS
 #endif
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER)
@@ -124,7 +124,7 @@ static inline thread_id_t thread_id() { return static_cast<thread_id_t>(::GetCur
 }  // namespace details
 }  // namespace ex_actor::embedded_3rd::moodycamel
 #elif defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) || (defined(__APPLE__) && TARGET_OS_IPHONE) || \
-    defined(__MVS__) || defined(MOODYCAMEL_NO_THREAD_LOCAL)
+    defined(__MVS__) || defined(EX_ACTOR_MOODYCAMEL_NO_THREAD_LOCAL)
 namespace ex_actor::embedded_3rd::moodycamel {
 namespace details {
 static_assert(sizeof(std::thread::id) == 4 || sizeof(std::thread::id) == 8,
@@ -134,7 +134,7 @@ typedef std::thread::id thread_id_t;
 static const thread_id_t invalid_thread_id;  // Default ctor creates invalid ID
 
 // Note we don't define an invalid_thread_id2 since std::thread::id doesn't have one; it's
-// only used if MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED is defined anyway, which it won't
+// only used if EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED is defined anyway, which it won't
 // be.
 static inline thread_id_t thread_id() { return std::this_thread::get_id(); }
 
@@ -173,12 +173,12 @@ struct thread_id_converter<thread_id_t> {
 // In order to get a numeric thread ID in a platform-independent way, we use a thread-local
 // static variable's address as a thread identifier :-)
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
-#define MOODYCAMEL_THREADLOCAL __thread
+#define EX_ACTOR_MOODYCAMEL_THREADLOCAL __thread
 #elif defined(_MSC_VER)
-#define MOODYCAMEL_THREADLOCAL __declspec(thread)
+#define EX_ACTOR_MOODYCAMEL_THREADLOCAL __declspec(thread)
 #else
 // Assume C++11 compliant compiler
-#define MOODYCAMEL_THREADLOCAL thread_local
+#define EX_ACTOR_MOODYCAMEL_THREADLOCAL thread_local
 #endif
 namespace ex_actor::embedded_3rd::moodycamel {
 namespace details {
@@ -187,7 +187,7 @@ static const thread_id_t invalid_thread_id = 0;  // Address can't be nullptr
 static const thread_id_t invalid_thread_id2 =
     1;  // Member accesses off a null pointer are also generally invalid. Plus it's not aligned.
 inline thread_id_t thread_id() {
-  static MOODYCAMEL_THREADLOCAL int x;
+  static EX_ACTOR_MOODYCAMEL_THREADLOCAL int x;
   return reinterpret_cast<thread_id_t>(&x);
 }
 }
@@ -195,74 +195,74 @@ inline thread_id_t thread_id() {
 #endif
 
 // Constexpr if
-#ifndef MOODYCAMEL_CONSTEXPR_IF
+#ifndef EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF
 #if (defined(_MSC_VER) && defined(_HAS_CXX17) && _HAS_CXX17) || __cplusplus > 201402L
-#define MOODYCAMEL_CONSTEXPR_IF if constexpr
-#define MOODYCAMEL_MAYBE_UNUSED [[maybe_unused]]
+#define EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF if constexpr
+#define EX_ACTOR_MOODYCAMEL_MAYBE_UNUSED [[maybe_unused]]
 #else
-#define MOODYCAMEL_CONSTEXPR_IF if
-#define MOODYCAMEL_MAYBE_UNUSED
+#define EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF if
+#define EX_ACTOR_MOODYCAMEL_MAYBE_UNUSED
 #endif
 #endif
 
 // Exceptions
-#ifndef MOODYCAMEL_EXCEPTIONS_ENABLED
+#ifndef EX_ACTOR_MOODYCAMEL_EXCEPTIONS_ENABLED
 #if (defined(_MSC_VER) && defined(_CPPUNWIND)) || (defined(__GNUC__) && defined(__EXCEPTIONS)) || \
     (!defined(_MSC_VER) && !defined(__GNUC__))
-#define MOODYCAMEL_EXCEPTIONS_ENABLED
+#define EX_ACTOR_MOODYCAMEL_EXCEPTIONS_ENABLED
 #endif
 #endif
-#ifdef MOODYCAMEL_EXCEPTIONS_ENABLED
-#define MOODYCAMEL_TRY try
-#define MOODYCAMEL_CATCH(...) catch (__VA_ARGS__)
-#define MOODYCAMEL_RETHROW throw
-#define MOODYCAMEL_THROW(expr) throw(expr)
+#ifdef EX_ACTOR_MOODYCAMEL_EXCEPTIONS_ENABLED
+#define EX_ACTOR_MOODYCAMEL_TRY try
+#define EX_ACTOR_MOODYCAMEL_CATCH(...) catch (__VA_ARGS__)
+#define EX_ACTOR_MOODYCAMEL_RETHROW throw
+#define EX_ACTOR_MOODYCAMEL_THROW(expr) throw(expr)
 #else
-#define MOODYCAMEL_TRY MOODYCAMEL_CONSTEXPR_IF(true)
-#define MOODYCAMEL_CATCH(...) else MOODYCAMEL_CONSTEXPR_IF(false)
-#define MOODYCAMEL_RETHROW
-#define MOODYCAMEL_THROW(expr)
+#define EX_ACTOR_MOODYCAMEL_TRY EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(true)
+#define EX_ACTOR_MOODYCAMEL_CATCH(...) else EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(false)
+#define EX_ACTOR_MOODYCAMEL_RETHROW
+#define EX_ACTOR_MOODYCAMEL_THROW(expr)
 #endif
 
-#ifndef MOODYCAMEL_NOEXCEPT
-#if !defined(MOODYCAMEL_EXCEPTIONS_ENABLED)
-#define MOODYCAMEL_NOEXCEPT
-#define MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr) true
-#define MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr) true
+#ifndef EX_ACTOR_MOODYCAMEL_NOEXCEPT
+#if !defined(EX_ACTOR_MOODYCAMEL_EXCEPTIONS_ENABLED)
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr) true
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr) true
 #elif defined(_MSC_VER) && defined(_NOEXCEPT) && _MSC_VER < 1800
 // VS2012's std::is_nothrow_[move_]constructible is broken and returns true when it shouldn't :-(
 // We have to assume *all* non-trivial constructors may throw on VS2012!
-#define MOODYCAMEL_NOEXCEPT _NOEXCEPT
-#define MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr)                                  \
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT _NOEXCEPT
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr)                                  \
   (std::is_rvalue_reference<valueType>::value && std::is_move_constructible<type>::value \
        ? std::is_trivially_move_constructible<type>::value                               \
        : std::is_trivially_copy_constructible<type>::value)
-#define MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr)                                                    \
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr)                                                    \
   ((std::is_rvalue_reference<valueType>::value && std::is_move_assignable<type>::value                       \
         ? std::is_trivially_move_assignable<type>::value || std::is_nothrow_move_assignable<type>::value     \
         : std::is_trivially_copy_assignable<type>::value || std::is_nothrow_copy_assignable<type>::value) && \
-   MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr))
+   EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr))
 #elif defined(_MSC_VER) && defined(_NOEXCEPT) && _MSC_VER < 1900
-#define MOODYCAMEL_NOEXCEPT _NOEXCEPT
-#define MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr)                                                       \
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT _NOEXCEPT
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr)                                                       \
   (std::is_rvalue_reference<valueType>::value && std::is_move_constructible<type>::value                      \
        ? std::is_trivially_move_constructible<type>::value || std::is_nothrow_move_constructible<type>::value \
        : std::is_trivially_copy_constructible<type>::value || std::is_nothrow_copy_constructible<type>::value)
-#define MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr)                                                    \
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr)                                                    \
   ((std::is_rvalue_reference<valueType>::value && std::is_move_assignable<type>::value                       \
         ? std::is_trivially_move_assignable<type>::value || std::is_nothrow_move_assignable<type>::value     \
         : std::is_trivially_copy_assignable<type>::value || std::is_nothrow_copy_assignable<type>::value) && \
-   MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr))
+   EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr))
 #else
-#define MOODYCAMEL_NOEXCEPT noexcept
-#define MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr) noexcept(expr)
-#define MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr) noexcept(expr)
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT noexcept
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(type, valueType, expr) noexcept(expr)
+#define EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(type, valueType, expr) noexcept(expr)
 #endif
 #endif
 
-#ifndef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifndef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 #ifdef MCDBGQ_USE_RELACY
-#define MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#define EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 #else
 // VS2013 doesn't support `thread_local`, and MinGW-w64 w/ POSIX threading has a crippling bug:
 // http://sourceforge.net/p/mingw-w64/bugs/445 g++ <=4.7 doesn't support thread_local either. Finally, iOS/ARM doesn't
@@ -273,7 +273,7 @@ inline thread_id_t thread_id() {
     (!defined(__APPLE__) || !TARGET_OS_IPHONE) && !defined(__arm__) && !defined(_M_ARM) && !defined(__aarch64__) && \
     !defined(__MVS__)
 // Assume `thread_local` is fully supported in all other C++11 compilers/platforms
-#define MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED  // tentatively enabled for now; years ago several users report having
+#define EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED  // tentatively enabled for now; years ago several users report having
                                                  // problems with it on
 #endif
 #endif
@@ -282,22 +282,22 @@ inline thread_id_t thread_id() {
 // VS2012 doesn't support deleted functions.
 // In this case, we declare the function normally but don't define it. A link error will be generated if the function is
 // called.
-#ifndef MOODYCAMEL_DELETE_FUNCTION
+#ifndef EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION
 #if defined(_MSC_VER) && _MSC_VER < 1800
-#define MOODYCAMEL_DELETE_FUNCTION
+#define EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION
 #else
-#define MOODYCAMEL_DELETE_FUNCTION = delete
+#define EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION = delete
 #endif
 #endif
 
 namespace ex_actor::embedded_3rd::moodycamel {
 namespace details {
-#ifndef MOODYCAMEL_ALIGNAS
+#ifndef EX_ACTOR_MOODYCAMEL_ALIGNAS
 // VS2013 doesn't support alignas or alignof, and align() requires a constant literal
 #if defined(_MSC_VER) && _MSC_VER <= 1800
-#define MOODYCAMEL_ALIGNAS(alignment) __declspec(align(alignment))
-#define MOODYCAMEL_ALIGNOF(obj) __alignof(obj)
-#define MOODYCAMEL_ALIGNED_TYPE_LIKE(T, obj) typename details::Vs2013Aligned<std::alignment_of<obj>::value, T>::type
+#define EX_ACTOR_MOODYCAMEL_ALIGNAS(alignment) __declspec(align(alignment))
+#define EX_ACTOR_MOODYCAMEL_ALIGNOF(obj) __alignof(obj)
+#define EX_ACTOR_MOODYCAMEL_ALIGNED_TYPE_LIKE(T, obj) typename details::Vs2013Aligned<std::alignment_of<obj>::value, T>::type
 template <int Align, typename T>
 struct Vs2013Aligned {};  // default, unsupported alignment
 template <typename T>
@@ -341,9 +341,9 @@ template <typename T>
 struct identity {
   typedef T type;
 };
-#define MOODYCAMEL_ALIGNAS(alignment) alignas(alignment)
-#define MOODYCAMEL_ALIGNOF(obj) alignof(obj)
-#define MOODYCAMEL_ALIGNED_TYPE_LIKE(T, obj) alignas(alignof(obj)) typename details::identity<T>::type
+#define EX_ACTOR_MOODYCAMEL_ALIGNAS(alignment) alignas(alignment)
+#define EX_ACTOR_MOODYCAMEL_ALIGNOF(obj) alignof(obj)
+#define EX_ACTOR_MOODYCAMEL_ALIGNED_TYPE_LIKE(T, obj) alignas(alignof(obj)) typename details::identity<T>::type
 #endif
 #endif
 }  // namespace details
@@ -352,11 +352,11 @@ struct identity {
 // TSAN can false report races in lock-free code.  To enable TSAN to be used from projects that use this one,
 // we can apply per-function compile-time suppression.
 // See https://clang.llvm.org/docs/ThreadSanitizer.html#has-feature-thread-sanitizer
-#define MOODYCAMEL_NO_TSAN
+#define EX_ACTOR_MOODYCAMEL_NO_TSAN
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
-#undef MOODYCAMEL_NO_TSAN
-#define MOODYCAMEL_NO_TSAN __attribute__((no_sanitize("thread")))
+#undef EX_ACTOR_MOODYCAMEL_NO_TSAN
+#define EX_ACTOR_MOODYCAMEL_NO_TSAN __attribute__((no_sanitize("thread")))
 #endif  // TSAN
 #endif  // TSAN
 
@@ -373,7 +373,7 @@ static inline bool(unlikely)(bool x) { return x; }
 }  // namespace details
 }  // namespace ex_actor::embedded_3rd::moodycamel
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 #include "internal/concurrentqueue_internal_debug.h"
 #endif
 
@@ -619,7 +619,7 @@ struct nomove_if<false> {
 };
 
 template <typename It>
-static inline auto deref_noexcept(It& it) MOODYCAMEL_NOEXCEPT->decltype(*it) {
+static inline auto deref_noexcept(It& it) EX_ACTOR_MOODYCAMEL_NOEXCEPT->decltype(*it) {
   return *it;
 }
 
@@ -631,7 +631,7 @@ template <typename T>
 struct is_trivially_destructible : std::has_trivial_destructor<T> {};
 #endif
 
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 #ifdef MCDBGQ_USE_RELACY
 typedef RelacyThreadExitListener ThreadExitListener;
 typedef RelacyThreadExitNotifier ThreadExitNotifier;
@@ -676,14 +676,14 @@ class ThreadExitNotifier {
 
  private:
   ThreadExitNotifier() : tail(nullptr) {}
-  ThreadExitNotifier(ThreadExitNotifier const&) MOODYCAMEL_DELETE_FUNCTION;
-  ThreadExitNotifier& operator=(ThreadExitNotifier const&) MOODYCAMEL_DELETE_FUNCTION;
+  ThreadExitNotifier(ThreadExitNotifier const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  ThreadExitNotifier& operator=(ThreadExitNotifier const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
   ~ThreadExitNotifier() {
     // This thread is about to exit, let everyone know!
     assert(this == &instance() &&
            "If this assert fails, you likely have a buggy compiler! Change the preprocessor conditions such that "
-           "MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED is no longer defined.");
+           "EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED is no longer defined.");
     std::lock_guard<std::mutex> guard(mutex());
     for (auto ptr = tail; ptr != nullptr; ptr = ptr->next) {
       ptr->chain = nullptr;
@@ -752,19 +752,19 @@ struct ProducerToken {
   template <typename T, typename Traits>
   explicit ProducerToken(BlockingConcurrentQueue<T, Traits>& queue);
 
-  ProducerToken(ProducerToken&& other) MOODYCAMEL_NOEXCEPT : producer(other.producer) {
+  ProducerToken(ProducerToken&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT : producer(other.producer) {
     other.producer = nullptr;
     if (producer != nullptr) {
       producer->token = this;
     }
   }
 
-  inline ProducerToken& operator=(ProducerToken&& other) MOODYCAMEL_NOEXCEPT {
+  inline ProducerToken& operator=(ProducerToken&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
     swap(other);
     return *this;
   }
 
-  void swap(ProducerToken& other) MOODYCAMEL_NOEXCEPT {
+  void swap(ProducerToken& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
     std::swap(producer, other.producer);
     if (producer != nullptr) {
       producer->token = this;
@@ -792,8 +792,8 @@ struct ProducerToken {
   }
 
   // Disable copying and assignment
-  ProducerToken(ProducerToken const&) MOODYCAMEL_DELETE_FUNCTION;
-  ProducerToken& operator=(ProducerToken const&) MOODYCAMEL_DELETE_FUNCTION;
+  ProducerToken(ProducerToken const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  ProducerToken& operator=(ProducerToken const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
  private:
   template <typename T, typename Traits>
@@ -811,18 +811,18 @@ struct ConsumerToken {
   template <typename T, typename Traits>
   explicit ConsumerToken(BlockingConcurrentQueue<T, Traits>& q);
 
-  ConsumerToken(ConsumerToken&& other) MOODYCAMEL_NOEXCEPT : initialOffset(other.initialOffset),
+  ConsumerToken(ConsumerToken&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT : initialOffset(other.initialOffset),
                                                              lastKnownGlobalOffset(other.lastKnownGlobalOffset),
                                                              itemsConsumedFromCurrent(other.itemsConsumedFromCurrent),
                                                              currentProducer(other.currentProducer),
                                                              desiredProducer(other.desiredProducer) {}
 
-  inline ConsumerToken& operator=(ConsumerToken&& other) MOODYCAMEL_NOEXCEPT {
+  inline ConsumerToken& operator=(ConsumerToken&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
     swap(other);
     return *this;
   }
 
-  void swap(ConsumerToken& other) MOODYCAMEL_NOEXCEPT {
+  void swap(ConsumerToken& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
     std::swap(initialOffset, other.initialOffset);
     std::swap(lastKnownGlobalOffset, other.lastKnownGlobalOffset);
     std::swap(itemsConsumedFromCurrent, other.itemsConsumedFromCurrent);
@@ -831,8 +831,8 @@ struct ConsumerToken {
   }
 
   // Disable copying and assignment
-  ConsumerToken(ConsumerToken const&) MOODYCAMEL_DELETE_FUNCTION;
-  ConsumerToken& operator=(ConsumerToken const&) MOODYCAMEL_DELETE_FUNCTION;
+  ConsumerToken(ConsumerToken const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  ConsumerToken& operator=(ConsumerToken const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
  private:
   template <typename T, typename Traits>
@@ -852,7 +852,7 @@ struct ConsumerToken {
 // http://stackoverflow.com/questions/4492062/why-does-a-c-friend-class-need-a-forward-declaration-only-in-other-namespaces
 template <typename T, typename Traits>
 inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
-                 typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b) MOODYCAMEL_NOEXCEPT;
+                 typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b) EX_ACTOR_MOODYCAMEL_NOEXCEPT;
 
 template <typename T, typename Traits = ConcurrentQueueDefaultTraits>
 class ConcurrentQueue {
@@ -926,7 +926,7 @@ class ConcurrentQueue {
     populate_initial_implicit_producer_hash();
     populate_initial_block_list(capacity / BLOCK_SIZE + ((capacity & (BLOCK_SIZE - 1)) == 0 ? 0 : 1));
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
     // Track all the producers using a fully-resolved typed list for
     // each kind; this makes it possible to debug them starting from
     // the root queue object (otherwise wacky casts are needed that
@@ -951,7 +951,7 @@ class ConcurrentQueue {
                     2 * (maxExplicitProducers + maxImplicitProducers);
     populate_initial_block_list(blocks);
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
     explicitProducers.store(nullptr, std::memory_order_relaxed);
     implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
@@ -973,7 +973,7 @@ class ConcurrentQueue {
     }
 
     // Destroy implicit producer hash tables
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE != 0) {
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE != 0) {
       auto hash = implicitProducerHash.load(std::memory_order_relaxed);
       while (hash != nullptr) {
         auto prev = hash->prev;
@@ -1003,8 +1003,8 @@ class ConcurrentQueue {
   }
 
   // Disable copying and copy assignment
-  ConcurrentQueue(ConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
-  ConcurrentQueue& operator=(ConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
+  ConcurrentQueue(ConcurrentQueue const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  ConcurrentQueue& operator=(ConcurrentQueue const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
   // Moving is supported, but note that it is *not* a thread-safe operation.
   // Nobody can use the queue while it's being moved, and the memory effects
@@ -1012,7 +1012,7 @@ class ConcurrentQueue {
   // Note: When a queue is moved, its tokens are still valid but can only be
   // used with the destination queue (i.e. semantically they are moved along
   // with the queue itself).
-  ConcurrentQueue(ConcurrentQueue&& other) MOODYCAMEL_NOEXCEPT
+  ConcurrentQueue(ConcurrentQueue&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT
       : producerListTail(other.producerListTail.load(std::memory_order_relaxed)),
         producerCount(other.producerCount.load(std::memory_order_relaxed)),
         initialBlockPoolIndex(other.initialBlockPoolIndex.load(std::memory_order_relaxed)),
@@ -1031,7 +1031,7 @@ class ConcurrentQueue {
     other.nextExplicitConsumerId.store(0, std::memory_order_relaxed);
     other.globalExplicitConsumerOffset.store(0, std::memory_order_relaxed);
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
     explicitProducers.store(other.explicitProducers.load(std::memory_order_relaxed), std::memory_order_relaxed);
     other.explicitProducers.store(nullptr, std::memory_order_relaxed);
     implicitProducers.store(other.implicitProducers.load(std::memory_order_relaxed), std::memory_order_relaxed);
@@ -1045,14 +1045,14 @@ class ConcurrentQueue {
     reown_producers();
   }
 
-  inline ConcurrentQueue& operator=(ConcurrentQueue&& other) MOODYCAMEL_NOEXCEPT { return swap_internal(other); }
+  inline ConcurrentQueue& operator=(ConcurrentQueue&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT { return swap_internal(other); }
 
   // Swaps this queue's state with the other's. Not thread-safe.
   // Swapping two queues does not invalidate their tokens, however
   // the tokens that were created for one queue must be used with
   // only the swapped queue (i.e. the tokens are tied to the
   // queue's movable state, not the object itself).
-  inline void swap(ConcurrentQueue& other) MOODYCAMEL_NOEXCEPT { swap_internal(other); }
+  inline void swap(ConcurrentQueue& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT { swap_internal(other); }
 
  private:
   ConcurrentQueue& swap_internal(ConcurrentQueue& other) {
@@ -1074,7 +1074,7 @@ class ConcurrentQueue {
     reown_producers();
     other.reown_producers();
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
     details::swap_relaxed(explicitProducers, other.explicitProducers);
     details::swap_relaxed(implicitProducers, other.implicitProducers);
 #endif
@@ -1089,7 +1089,7 @@ class ConcurrentQueue {
   // or Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
   // Thread-safe.
   inline bool enqueue(T const& item) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
     else return inner_enqueue<CanAlloc>(item);
   }
 
@@ -1099,7 +1099,7 @@ class ConcurrentQueue {
   // or Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
   // Thread-safe.
   inline bool enqueue(T&& item) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
     else return inner_enqueue<CanAlloc>(std::move(item));
   }
 
@@ -1125,7 +1125,7 @@ class ConcurrentQueue {
   // Thread-safe.
   template <typename It>
   bool enqueue_bulk(It itemFirst, size_t count) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
     else return inner_enqueue_bulk<CanAlloc>(itemFirst, count);
   }
 
@@ -1146,7 +1146,7 @@ class ConcurrentQueue {
   // is 0).
   // Thread-safe.
   inline bool try_enqueue(T const& item) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
     else return inner_enqueue<CannotAlloc>(item);
   }
 
@@ -1156,7 +1156,7 @@ class ConcurrentQueue {
   // disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE is 0).
   // Thread-safe.
   inline bool try_enqueue(T&& item) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
     else return inner_enqueue<CannotAlloc>(std::move(item));
   }
 
@@ -1183,7 +1183,7 @@ class ConcurrentQueue {
   // Thread-safe.
   template <typename It>
   bool try_enqueue_bulk(It itemFirst, size_t count) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
     else return inner_enqueue_bulk<CannotAlloc>(itemFirst, count);
   }
 
@@ -1522,8 +1522,8 @@ class ConcurrentQueue {
     }
     void swap(FreeList& other) { details::swap_relaxed(freeListHead, other.freeListHead); }
 
-    FreeList(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
-    FreeList& operator=(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
+    FreeList(FreeList const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+    FreeList& operator=(FreeList const&) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
     inline void add(N* node) {
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
@@ -1636,7 +1636,7 @@ class ConcurrentQueue {
 
     template <InnerQueueContext context>
     inline bool is_empty() const {
-      MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
         // Check flags
         for (size_t i = 0; i < BLOCK_SIZE; ++i) {
           if (!emptyFlags[i].load(std::memory_order_relaxed)) {
@@ -1661,8 +1661,8 @@ class ConcurrentQueue {
 
     // Returns true if the block is now empty (does not apply in explicit context)
     template <InnerQueueContext context>
-    inline bool set_empty(MOODYCAMEL_MAYBE_UNUSED index_t i) {
-      MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+    inline bool set_empty(EX_ACTOR_MOODYCAMEL_MAYBE_UNUSED index_t i) {
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
         // Set flag
         assert(!emptyFlags[BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(BLOCK_SIZE - 1))].load(
             std::memory_order_relaxed));
@@ -1681,8 +1681,8 @@ class ConcurrentQueue {
     // Sets multiple contiguous item statuses to 'empty' (assumes no wrapping and count > 0).
     // Returns true if the block is now empty (does not apply in explicit context).
     template <InnerQueueContext context>
-    inline bool set_many_empty(MOODYCAMEL_MAYBE_UNUSED index_t i, size_t count) {
-      MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+    inline bool set_many_empty(EX_ACTOR_MOODYCAMEL_MAYBE_UNUSED index_t i, size_t count) {
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
         // Set flags
         std::atomic_thread_fence(std::memory_order_release);
         i = BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(BLOCK_SIZE - 1)) - count + 1;
@@ -1702,7 +1702,7 @@ class ConcurrentQueue {
 
     template <InnerQueueContext context>
     inline void set_all_empty() {
-      MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
         // Set all flags
         for (size_t i = 0; i != BLOCK_SIZE; ++i) {
           emptyFlags[i].store(true, std::memory_order_relaxed);
@@ -1716,7 +1716,7 @@ class ConcurrentQueue {
 
     template <InnerQueueContext context>
     inline void reset_empty() {
-      MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
         // Reset flags
         for (size_t i = 0; i != BLOCK_SIZE; ++i) {
           emptyFlags[i].store(false, std::memory_order_relaxed);
@@ -1728,11 +1728,11 @@ class ConcurrentQueue {
       }
     }
 
-    inline T* operator[](index_t idx) MOODYCAMEL_NOEXCEPT {
+    inline T* operator[](index_t idx) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
       return static_cast<T*>(static_cast<void*>(elements)) +
              static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1));
     }
-    inline T const* operator[](index_t idx) const MOODYCAMEL_NOEXCEPT {
+    inline T const* operator[](index_t idx) const EX_ACTOR_MOODYCAMEL_NOEXCEPT {
       return static_cast<T const*>(static_cast<void const*>(elements)) +
              static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1));
     }
@@ -1740,7 +1740,7 @@ class ConcurrentQueue {
    private:
     static_assert(std::alignment_of<T>::value <= sizeof(T),
                   "The queue does not support types with an alignment greater than their size at this time");
-    MOODYCAMEL_ALIGNED_TYPE_LIKE(char[sizeof(T) * BLOCK_SIZE], T) elements;
+    EX_ACTOR_MOODYCAMEL_ALIGNED_TYPE_LIKE(char[sizeof(T) * BLOCK_SIZE], T) elements;
 
    public:
     Block* next;
@@ -1958,7 +1958,7 @@ class ConcurrentQueue {
             // to allocate a new index. Note pr_blockIndexRaw can only be nullptr if
             // the initial allocation failed in the constructor.
 
-            MOODYCAMEL_CONSTEXPR_IF(allocMode == CannotAlloc) { return false; }
+            EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(allocMode == CannotAlloc) { return false; }
             else if (!new_block_index(pr_blockIndexSlotsUsed)) {
               return false;
             }
@@ -1983,17 +1983,17 @@ class ConcurrentQueue {
           ++pr_blockIndexSlotsUsed;
         }
 
-        MOODYCAMEL_CONSTEXPR_IF(
-            !MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(
+            !EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
           // The constructor may throw. We want the element not to appear in the queue in
           // that case (without corrupting the queue):
-          MOODYCAMEL_TRY { new ((*this->tailBlock)[currentTailIndex]) T(std::forward<U>(element)); }
-          MOODYCAMEL_CATCH(...) {
+          EX_ACTOR_MOODYCAMEL_TRY { new ((*this->tailBlock)[currentTailIndex]) T(std::forward<U>(element)); }
+          EX_ACTOR_MOODYCAMEL_CATCH(...) {
             // Revert change to the current block, but leave the new block available
             // for next time
             pr_blockIndexSlotsUsed = originalBlockIndexSlotsUsed;
             this->tailBlock = startBlock == nullptr ? this->tailBlock : startBlock;
-            MOODYCAMEL_RETHROW;
+            EX_ACTOR_MOODYCAMEL_RETHROW;
           }
         }
         else {
@@ -2008,8 +2008,8 @@ class ConcurrentQueue {
         blockIndex.load(std::memory_order_relaxed)->front.store(pr_blockIndexFront, std::memory_order_release);
         pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
 
-        MOODYCAMEL_CONSTEXPR_IF(
-            !MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(
+            !EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
           this->tailIndex.store(newTailIndex, std::memory_order_release);
           return true;
         }
@@ -2092,7 +2092,7 @@ class ConcurrentQueue {
 
           // Dequeue
           auto& el = *((*block)[index]);
-          if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
+          if (!EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
             // Make sure the element is still fully dequeued and destroyed even if the assignment
             // throws
             struct Guard {
@@ -2125,7 +2125,7 @@ class ConcurrentQueue {
     }
 
     template <AllocationMode allocMode, typename It>
-    bool MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count) {
+    bool EX_ACTOR_MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count) {
       // First, we need to make sure we have enough room to enqueue all of the elements;
       // this means pre-allocating blocks and putting them in the block index (but only if
       // all the allocations succeeded).
@@ -2167,7 +2167,7 @@ class ConcurrentQueue {
                       (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value &&
                        (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head));
           if (pr_blockIndexRaw == nullptr || pr_blockIndexSlotsUsed == pr_blockIndexSize || full) {
-            MOODYCAMEL_CONSTEXPR_IF(allocMode == CannotAlloc) {
+            EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(allocMode == CannotAlloc) {
               // Failed to allocate, undo changes (but keep injected blocks)
               pr_blockIndexFront = originalBlockIndexFront;
               pr_blockIndexSlotsUsed = originalBlockIndexSlotsUsed;
@@ -2229,7 +2229,7 @@ class ConcurrentQueue {
           block = block->next;
         }
 
-        MOODYCAMEL_CONSTEXPR_IF(MOODYCAMEL_NOEXCEPT_CTOR(
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(
             T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
           blockIndex.load(std::memory_order_relaxed)
               ->front.store((pr_blockIndexFront - 1) & (pr_blockIndexSize - 1), std::memory_order_release);
@@ -2252,14 +2252,14 @@ class ConcurrentQueue {
         if (details::circular_less_than<index_t>(newTailIndex, stopIndex)) {
           stopIndex = newTailIndex;
         }
-        MOODYCAMEL_CONSTEXPR_IF(MOODYCAMEL_NOEXCEPT_CTOR(
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(
             T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
           while (currentTailIndex != stopIndex) {
             new ((*this->tailBlock)[currentTailIndex++]) T(*itemFirst++);
           }
         }
         else {
-          MOODYCAMEL_TRY {
+          EX_ACTOR_MOODYCAMEL_TRY {
             while (currentTailIndex != stopIndex) {
               // Must use copy constructor even if move constructor is available
               // because we may have to revert if there's an exception.
@@ -2269,14 +2269,14 @@ class ConcurrentQueue {
               // cctor will not compile, even if they are in an if branch that will never
               // be executed
               new ((*this->tailBlock)[currentTailIndex])
-                  T(details::nomove_if<!MOODYCAMEL_NOEXCEPT_CTOR(
+                  T(details::nomove_if<!EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(
                         T, decltype(*itemFirst),
                         new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))>::eval(*itemFirst));
               ++currentTailIndex;
               ++itemFirst;
             }
           }
-          MOODYCAMEL_CATCH(...) {
+          EX_ACTOR_MOODYCAMEL_CATCH(...) {
             // Oh dear, an exception's been thrown -- destroy the elements that
             // were enqueued so far and revert the entire bulk operation (we'll keep
             // any allocated blocks in our linked list for later, though).
@@ -2308,7 +2308,7 @@ class ConcurrentQueue {
                 block = block->next;
               }
             }
-            MOODYCAMEL_RETHROW;
+            EX_ACTOR_MOODYCAMEL_RETHROW;
           }
         }
 
@@ -2319,7 +2319,7 @@ class ConcurrentQueue {
         this->tailBlock = this->tailBlock->next;
       }
 
-      MOODYCAMEL_CONSTEXPR_IF(!MOODYCAMEL_NOEXCEPT_CTOR(
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(!EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(
           T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
         if (firstAllocatedBlock != nullptr)
           blockIndex.load(std::memory_order_relaxed)
@@ -2374,7 +2374,7 @@ class ConcurrentQueue {
                            ? firstIndex + static_cast<index_t>(actualCount)
                            : endIndex;
             auto block = localBlockIndex->entries[indexIndex].block;
-            if (MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&,
+            if (EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&,
                                            details::deref_noexcept(itemFirst) = std::move((*(*block)[index])))) {
               while (index != endIndex) {
                 auto& el = *((*block)[index]);
@@ -2383,7 +2383,7 @@ class ConcurrentQueue {
                 ++index;
               }
             } else {
-              MOODYCAMEL_TRY {
+              EX_ACTOR_MOODYCAMEL_TRY {
                 while (index != endIndex) {
                   auto& el = *((*block)[index]);
                   *itemFirst = std::move(el);
@@ -2392,7 +2392,7 @@ class ConcurrentQueue {
                   ++index;
                 }
               }
-              MOODYCAMEL_CATCH(...) {
+              EX_ACTOR_MOODYCAMEL_CATCH(...) {
                 // It's too late to revert the dequeue, but we can make sure that all
                 // the dequeued objects are properly destroyed and the block index
                 // (and empty count) are properly updated before we propagate the exception
@@ -2413,7 +2413,7 @@ class ConcurrentQueue {
                           : endIndex;
                 } while (index != firstIndex + actualCount);
 
-                MOODYCAMEL_RETHROW;
+                EX_ACTOR_MOODYCAMEL_RETHROW;
               }
             }
             block->ConcurrentQueue::Block::template set_many_empty<explicit_context>(
@@ -2495,7 +2495,7 @@ class ConcurrentQueue {
     BlockIndexEntry* pr_blockIndexEntries;
     void* pr_blockIndexRaw;
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
    public:
     ExplicitProducer* nextExplicitProducer;
 
@@ -2523,7 +2523,7 @@ class ConcurrentQueue {
       // contiguous blocks, and that only the first and last remaining blocks can be only partially
       // empty (all other remaining blocks must be completely full).
 
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
       // Unregister ourselves for thread termination notification
       if (!this->inactive.load(std::memory_order_relaxed)) {
         details::ThreadExitNotifier::unsubscribe(&threadExitListener);
@@ -2605,15 +2605,15 @@ class ConcurrentQueue {
 #endif
         newBlock->ConcurrentQueue::Block::template reset_empty<implicit_context>();
 
-        MOODYCAMEL_CONSTEXPR_IF(
-            !MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(
+            !EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
           // May throw, try to insert now before we publish the fact that we have this new block
-          MOODYCAMEL_TRY { new ((*newBlock)[currentTailIndex]) T(std::forward<U>(element)); }
-          MOODYCAMEL_CATCH(...) {
+          EX_ACTOR_MOODYCAMEL_TRY { new ((*newBlock)[currentTailIndex]) T(std::forward<U>(element)); }
+          EX_ACTOR_MOODYCAMEL_CATCH(...) {
             rewind_block_index_tail();
             idxEntry->value.store(nullptr, std::memory_order_relaxed);
             this->parent->add_block_to_free_list(newBlock);
-            MOODYCAMEL_RETHROW;
+            EX_ACTOR_MOODYCAMEL_RETHROW;
           }
         }
 
@@ -2622,8 +2622,8 @@ class ConcurrentQueue {
 
         this->tailBlock = newBlock;
 
-        MOODYCAMEL_CONSTEXPR_IF(
-            !MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(
+            !EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
           this->tailIndex.store(newTailIndex, std::memory_order_release);
           return true;
         }
@@ -2657,7 +2657,7 @@ class ConcurrentQueue {
           auto block = entry->value.load(std::memory_order_relaxed);
           auto& el = *((*block)[index]);
 
-          if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
+          if (!EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
             // Note: Acquiring the mutex with every dequeue instead of only when a block
             // is released is very sub-optimal, but it is, after all, purely debug code.
@@ -2803,24 +2803,24 @@ class ConcurrentQueue {
         if (details::circular_less_than<index_t>(newTailIndex, stopIndex)) {
           stopIndex = newTailIndex;
         }
-        MOODYCAMEL_CONSTEXPR_IF(MOODYCAMEL_NOEXCEPT_CTOR(
+        EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(
             T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
           while (currentTailIndex != stopIndex) {
             new ((*this->tailBlock)[currentTailIndex++]) T(*itemFirst++);
           }
         }
         else {
-          MOODYCAMEL_TRY {
+          EX_ACTOR_MOODYCAMEL_TRY {
             while (currentTailIndex != stopIndex) {
               new ((*this->tailBlock)[currentTailIndex])
-                  T(details::nomove_if<!MOODYCAMEL_NOEXCEPT_CTOR(
+                  T(details::nomove_if<!EX_ACTOR_MOODYCAMEL_NOEXCEPT_CTOR(
                         T, decltype(*itemFirst),
                         new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))>::eval(*itemFirst));
               ++currentTailIndex;
               ++itemFirst;
             }
           }
-          MOODYCAMEL_CATCH(...) {
+          EX_ACTOR_MOODYCAMEL_CATCH(...) {
             auto constructedStopIndex = currentTailIndex;
             auto lastBlockEnqueued = this->tailBlock;
 
@@ -2855,7 +2855,7 @@ class ConcurrentQueue {
             }
             this->parent->add_blocks_to_free_list(firstAllocatedBlock);
             this->tailBlock = startBlock;
-            MOODYCAMEL_RETHROW;
+            EX_ACTOR_MOODYCAMEL_RETHROW;
           }
         }
 
@@ -2909,7 +2909,7 @@ class ConcurrentQueue {
 
             auto entry = localBlockIndex->index[indexIndex];
             auto block = entry->value.load(std::memory_order_relaxed);
-            if (MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&,
+            if (EX_ACTOR_MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&,
                                            details::deref_noexcept(itemFirst) = std::move((*(*block)[index])))) {
               while (index != endIndex) {
                 auto& el = *((*block)[index]);
@@ -2918,7 +2918,7 @@ class ConcurrentQueue {
                 ++index;
               }
             } else {
-              MOODYCAMEL_TRY {
+              EX_ACTOR_MOODYCAMEL_TRY {
                 while (index != endIndex) {
                   auto& el = *((*block)[index]);
                   *itemFirst = std::move(el);
@@ -2927,7 +2927,7 @@ class ConcurrentQueue {
                   ++index;
                 }
               }
-              MOODYCAMEL_CATCH(...) {
+              EX_ACTOR_MOODYCAMEL_CATCH(...) {
                 do {
                   entry = localBlockIndex->index[indexIndex];
                   block = entry->value.load(std::memory_order_relaxed);
@@ -2953,7 +2953,7 @@ class ConcurrentQueue {
                           : endIndex;
                 } while (index != firstIndex + actualCount);
 
-                MOODYCAMEL_RETHROW;
+                EX_ACTOR_MOODYCAMEL_RETHROW;
               }
             }
             if (block->ConcurrentQueue::Block::template set_many_empty<implicit_context>(
@@ -3013,7 +3013,7 @@ class ConcurrentQueue {
       }
 
       // No room in the old block index, try to allocate another one!
-      MOODYCAMEL_CONSTEXPR_IF(allocMode == CannotAlloc) { return false; }
+      EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(allocMode == CannotAlloc) { return false; }
       else if (!new_block_index()) {
         return false;
       }
@@ -3109,14 +3109,14 @@ class ConcurrentQueue {
     size_t nextBlockIndexCapacity;
     std::atomic<BlockIndexHeader*> blockIndex;
 
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
    public:
     details::ThreadExitListener threadExitListener;
 
    private:
 #endif
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
    public:
     ImplicitProducer* nextImplicitProducer;
 
@@ -3195,7 +3195,7 @@ class ConcurrentQueue {
       return block;
     }
 
-    MOODYCAMEL_CONSTEXPR_IF(canAlloc == CanAlloc) { return create<Block>(); }
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(canAlloc == CanAlloc) { return create<Block>(); }
     else {
       return nullptr;
     }
@@ -3346,7 +3346,7 @@ class ConcurrentQueue {
     } while (!producerListTail.compare_exchange_weak(prevTail, producer, std::memory_order_release,
                                                      std::memory_order_relaxed));
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
     if (producer->isExplicit) {
       auto prevTailExplicit = explicitProducers.load(std::memory_order_relaxed);
       do {
@@ -3385,17 +3385,17 @@ class ConcurrentQueue {
 
     ImplicitProducerKVP() : value(nullptr) {}
 
-    ImplicitProducerKVP(ImplicitProducerKVP&& other) MOODYCAMEL_NOEXCEPT {
+    ImplicitProducerKVP(ImplicitProducerKVP&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
       key.store(other.key.load(std::memory_order_relaxed), std::memory_order_relaxed);
       value = other.value;
     }
 
-    inline ImplicitProducerKVP& operator=(ImplicitProducerKVP&& other) MOODYCAMEL_NOEXCEPT {
+    inline ImplicitProducerKVP& operator=(ImplicitProducerKVP&& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
       swap(other);
       return *this;
     }
 
-    inline void swap(ImplicitProducerKVP& other) MOODYCAMEL_NOEXCEPT {
+    inline void swap(ImplicitProducerKVP& other) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
       if (this != &other) {
         details::swap_relaxed(key, other.key);
         std::swap(value, other.value);
@@ -3405,7 +3405,7 @@ class ConcurrentQueue {
 
   template <typename XT, typename XTraits>
   friend void moodycamel::swap(typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&,
-                               typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&) MOODYCAMEL_NOEXCEPT;
+                               typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&) EX_ACTOR_MOODYCAMEL_NOEXCEPT;
 
   struct ImplicitProducerHash {
     size_t capacity;
@@ -3414,7 +3414,7 @@ class ConcurrentQueue {
   };
 
   inline void populate_initial_implicit_producer_hash() {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) { return; }
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) { return; }
     else {
       implicitProducerHashCount.store(0, std::memory_order_relaxed);
       auto hash = &initialImplicitProducerHash;
@@ -3429,7 +3429,7 @@ class ConcurrentQueue {
   }
 
   void swap_implicit_producer_hashes(ConcurrentQueue& other) {
-    MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) { return; }
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) { return; }
     else {
       // Swap (assumes our implicit producer hash is initialized)
       initialImplicitProducerHashEntries.swap(other.initialImplicitProducerHashEntries);
@@ -3502,7 +3502,7 @@ class ConcurrentQueue {
             while (true) {
               index &= mainHash->capacity - 1u;
               auto empty = details::invalid_thread_id;
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
               auto reusable = details::invalid_thread_id2;
               if (mainHash->entries[index].key.compare_exchange_strong(empty, id, std::memory_order_seq_cst,
                                                                        std::memory_order_relaxed) ||
@@ -3581,7 +3581,7 @@ class ConcurrentQueue {
           return nullptr;
         }
 
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
         producer->threadExitListener.callback = &ConcurrentQueue::implicit_producer_thread_exited_callback;
         producer->threadExitListener.userData = producer;
         details::ThreadExitNotifier::subscribe(&producer->threadExitListener);
@@ -3591,7 +3591,7 @@ class ConcurrentQueue {
         while (true) {
           index &= mainHash->capacity - 1u;
           auto empty = details::invalid_thread_id;
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
           auto reusable = details::invalid_thread_id2;
           if (mainHash->entries[index].key.compare_exchange_strong(reusable, id, std::memory_order_seq_cst,
                                                                    std::memory_order_relaxed)) {
@@ -3617,7 +3617,7 @@ class ConcurrentQueue {
     }
   }
 
-#ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
+#ifdef EX_ACTOR_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
   void implicit_producer_thread_exited(ImplicitProducer* producer) {
     // Remove from hash
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
@@ -3664,7 +3664,7 @@ class ConcurrentQueue {
 
   template <typename TAlign>
   static inline void* aligned_malloc(size_t size) {
-    MOODYCAMEL_CONSTEXPR_IF(std::alignment_of<TAlign>::value <= std::alignment_of<details::max_align_t>::value)
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(std::alignment_of<TAlign>::value <= std::alignment_of<details::max_align_t>::value)
     return (Traits::malloc)(size);
     else {
       size_t alignment = std::alignment_of<TAlign>::value;
@@ -3678,7 +3678,7 @@ class ConcurrentQueue {
 
   template <typename TAlign>
   static inline void aligned_free(void* ptr) {
-    MOODYCAMEL_CONSTEXPR_IF(std::alignment_of<TAlign>::value <= std::alignment_of<details::max_align_t>::value)
+    EX_ACTOR_MOODYCAMEL_CONSTEXPR_IF(std::alignment_of<TAlign>::value <= std::alignment_of<details::max_align_t>::value)
     return (Traits::free)(ptr);
     else(Traits::free)(ptr ? *(reinterpret_cast<void**>(ptr) - 1) : nullptr);
   }
@@ -3747,7 +3747,7 @@ class ConcurrentQueue {
   debug::DebugMutex implicitProdMutex;
 #endif
 
-#ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
+#ifdef EX_ACTOR_MOODYCAMEL_QUEUE_INTERNAL_DEBUG
   std::atomic<ExplicitProducer*> explicitProducers;
   std::atomic<ImplicitProducer*> implicitProducers;
 #endif
@@ -3784,17 +3784,17 @@ ConsumerToken::ConsumerToken(BlockingConcurrentQueue<T, Traits>& queue)
 }
 
 template <typename T, typename Traits>
-inline void swap(ConcurrentQueue<T, Traits>& a, ConcurrentQueue<T, Traits>& b) MOODYCAMEL_NOEXCEPT {
+inline void swap(ConcurrentQueue<T, Traits>& a, ConcurrentQueue<T, Traits>& b) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
   a.swap(b);
 }
 
-inline void swap(ProducerToken& a, ProducerToken& b) MOODYCAMEL_NOEXCEPT { a.swap(b); }
+inline void swap(ProducerToken& a, ProducerToken& b) EX_ACTOR_MOODYCAMEL_NOEXCEPT { a.swap(b); }
 
-inline void swap(ConsumerToken& a, ConsumerToken& b) MOODYCAMEL_NOEXCEPT { a.swap(b); }
+inline void swap(ConsumerToken& a, ConsumerToken& b) EX_ACTOR_MOODYCAMEL_NOEXCEPT { a.swap(b); }
 
 template <typename T, typename Traits>
 inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
-                 typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b) MOODYCAMEL_NOEXCEPT {
+                 typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b) EX_ACTOR_MOODYCAMEL_NOEXCEPT {
   a.swap(b);
 }
 
@@ -3811,6 +3811,6 @@ inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a,
 #pragma pop_macro("BLOCK_SIZE")
 
 // undef it in order not to pollute user's own moody_camel_queue.h
-#ifdef MOODYCAMEL_ALIGNAS
-#undef MOODYCAMEL_ALIGNAS
+#ifdef EX_ACTOR_MOODYCAMEL_ALIGNAS
+#undef EX_ACTOR_MOODYCAMEL_ALIGNAS
 #endif

--- a/include/ex_actor/3rd_lib/moody_camel_queue/lightweightsemaphore.h
+++ b/include/ex_actor/3rd_lib/moody_camel_queue/lightweightsemaphore.h
@@ -33,7 +33,7 @@ __declspec(dllimport) int __stdcall ReleaseSemaphore(void* hSemaphore, long lRel
 
 #if defined(__GLIBC_PREREQ) && defined(_GNU_SOURCE)
 #if __GLIBC_PREREQ(2, 30)
-#define MOODYCAMEL_LIGHTWEIGHTSEMAPHORE_MONOTONIC
+#define EX_ACTOR_MOODYCAMEL_LIGHTWEIGHTSEMAPHORE_MONOTONIC
 #endif
 #endif
 #endif
@@ -67,8 +67,8 @@ class Semaphore {
  private:
   void* m_hSema;
 
-  Semaphore(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
-  Semaphore& operator=(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
+  Semaphore(const Semaphore& other) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  Semaphore& operator=(const Semaphore& other) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
  public:
   Semaphore(int initialCount = 0) {
@@ -103,8 +103,8 @@ class Semaphore {
  private:
   semaphore_t m_sema;
 
-  Semaphore(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
-  Semaphore& operator=(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
+  Semaphore(const Semaphore& other) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  Semaphore& operator=(const Semaphore& other) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
  public:
   Semaphore(int initialCount = 0) {
@@ -151,8 +151,8 @@ class Semaphore {
  private:
   sem_t m_sema;
 
-  Semaphore(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
-  Semaphore& operator=(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
+  Semaphore(const Semaphore& other) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
+  Semaphore& operator=(const Semaphore& other) EX_ACTOR_MOODYCAMEL_DELETE_FUNCTION;
 
  public:
   Semaphore(int initialCount = 0) {
@@ -185,7 +185,7 @@ class Semaphore {
     struct timespec ts;
     const int usecs_in_1_sec = 1000000;
     const int nsecs_in_1_sec = 1000000000;
-#ifdef MOODYCAMEL_LIGHTWEIGHTSEMAPHORE_MONOTONIC
+#ifdef EX_ACTOR_MOODYCAMEL_LIGHTWEIGHTSEMAPHORE_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &ts);
 #else
     clock_gettime(CLOCK_REALTIME, &ts);
@@ -201,7 +201,7 @@ class Semaphore {
 
     int rc;
     do {
-#ifdef MOODYCAMEL_LIGHTWEIGHTSEMAPHORE_MONOTONIC
+#ifdef EX_ACTOR_MOODYCAMEL_LIGHTWEIGHTSEMAPHORE_MONOTONIC
       rc = sem_clockwait(&m_sema, CLOCK_MONOTONIC, &ts);
 #else
       rc = sem_timedwait(&m_sema, &ts);

--- a/include/ex_actor/internal/actor.h
+++ b/include/ex_actor/internal/actor.h
@@ -23,46 +23,12 @@
 #include <rfl/apply.hpp>
 #include <stdexec/execution.hpp>
 
+#include "ex_actor/3rd_lib/absl/functional/any_invocable.h"
 #include "ex_actor/internal/actor_config.h"
 #include "ex_actor/internal/container.h"
 #include "ex_actor/internal/reflect.h"
 #include "ex_actor/internal/scheduler.h"
 #include "ex_actor/internal/util.h"
-
-namespace ex_actor::internal {
-
-template <typename Sig>
-class MoveOnlyFunction;
-
-template <typename R, typename... Args>
-class MoveOnlyFunction<R(Args...)> {
-  struct Concept {
-    virtual ~Concept() = default;
-    virtual R Invoke(Args...) = 0;
-  };
-  template <typename F>
-  struct Model : Concept {
-    F fn;
-    explicit Model(F f) : fn(std::move(f)) {}
-    R Invoke(Args... args) override { return fn(std::forward<Args>(args)...); }
-  };
-  std::unique_ptr<Concept> impl_;
-
- public:
-  MoveOnlyFunction() = default;
-  template <typename F>
-    requires(!std::is_same_v<std::decay_t<F>, MoveOnlyFunction>)
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  MoveOnlyFunction(F&& f) : impl_(std::make_unique<Model<std::decay_t<F>>>(std::forward<F>(f))) {}
-  MoveOnlyFunction(MoveOnlyFunction&&) noexcept = default;
-  MoveOnlyFunction& operator=(MoveOnlyFunction&&) noexcept = default;
-  MoveOnlyFunction(const MoveOnlyFunction&) = delete;
-  MoveOnlyFunction& operator=(const MoveOnlyFunction&) = delete;
-  R operator()(Args... args) { return impl_->Invoke(std::forward<Args>(args)...); }
-  explicit operator bool() const { return impl_ != nullptr; }
-};
-
-}  // namespace ex_actor::internal
 
 namespace ex_actor {
 
@@ -104,7 +70,7 @@ class TypeErasedActor {
 class TypeErasedActorScheduler {
  public:
   virtual ~TypeErasedActorScheduler() = default;
-  virtual void Schedule(MoveOnlyFunction<void()> fn, const ActorConfig& config,
+  virtual void Schedule(::ex_actor::embedded_3rd::absl::AnyInvocable<void()> fn, const ActorConfig& config,
                         ex::simple_counting_scope::token scope_token) = 0;
   virtual std::unique_ptr<TypeErasedActorScheduler> Clone() const = 0;
 
@@ -115,7 +81,7 @@ template <ex::scheduler Scheduler>
 class AnyStdExecScheduler : public TypeErasedActorScheduler {
  public:
   explicit AnyStdExecScheduler(Scheduler scheduler) : scheduler_(std::move(scheduler)) {}
-  void Schedule(MoveOnlyFunction<void()> fn, const ActorConfig& config,
+  void Schedule(::ex_actor::embedded_3rd::absl::AnyInvocable<void()> fn, const ActorConfig& config,
                 ex::simple_counting_scope::token scope_token) override {
     auto sender = ex::schedule(scheduler_) | ex::write_env(ex::prop {ex_actor::get_priority, config.priority}) |
                   ex::write_env(ex::prop {ex_actor::get_scheduler_index, config.scheduler_index}) |

--- a/include/ex_actor/internal/actor.h
+++ b/include/ex_actor/internal/actor.h
@@ -239,7 +239,7 @@ class Actor : public TypeErasedActor {
     std::exception_ptr init_exception;
     ex::simple_counting_scope init_scope;
     scheduler_->Schedule(
-        [this, &init_exception, ...args = std::move(args)]() mutable {
+        [this, &init_exception, ... args = std::move(args)]() mutable {
           try {
             if constexpr (kCreateFn != nullptr) {
               using ReturnType = FnReturnType<kCreateFn>;

--- a/include/ex_actor/internal/actor.h
+++ b/include/ex_actor/internal/actor.h
@@ -29,6 +29,41 @@
 #include "ex_actor/internal/scheduler.h"
 #include "ex_actor/internal/util.h"
 
+namespace ex_actor::internal {
+
+template <typename Sig>
+class MoveOnlyFunction;
+
+template <typename R, typename... Args>
+class MoveOnlyFunction<R(Args...)> {
+  struct Concept {
+    virtual ~Concept() = default;
+    virtual R Invoke(Args...) = 0;
+  };
+  template <typename F>
+  struct Model : Concept {
+    F fn;
+    explicit Model(F f) : fn(std::move(f)) {}
+    R Invoke(Args... args) override { return fn(std::forward<Args>(args)...); }
+  };
+  std::unique_ptr<Concept> impl_;
+
+ public:
+  MoveOnlyFunction() = default;
+  template <typename F>
+    requires(!std::is_same_v<std::decay_t<F>, MoveOnlyFunction>)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  MoveOnlyFunction(F&& f) : impl_(std::make_unique<Model<std::decay_t<F>>>(std::forward<F>(f))) {}
+  MoveOnlyFunction(MoveOnlyFunction&&) noexcept = default;
+  MoveOnlyFunction& operator=(MoveOnlyFunction&&) noexcept = default;
+  MoveOnlyFunction(const MoveOnlyFunction&) = delete;
+  MoveOnlyFunction& operator=(const MoveOnlyFunction&) = delete;
+  R operator()(Args... args) { return impl_->Invoke(std::forward<Args>(args)...); }
+  explicit operator bool() const { return impl_ != nullptr; }
+};
+
+}  // namespace ex_actor::internal
+
 namespace ex_actor {
 
 // Passed to the optional user-defined hook `bool ExActorShouldActivate(MailboxPushEvent)`.
@@ -69,7 +104,8 @@ class TypeErasedActor {
 class TypeErasedActorScheduler {
  public:
   virtual ~TypeErasedActorScheduler() = default;
-  virtual void Schedule(TypeErasedActor* actor, ex::simple_counting_scope::token scope_token) = 0;
+  virtual void Schedule(MoveOnlyFunction<void()> fn, const ActorConfig& config,
+                        ex::simple_counting_scope::token scope_token) = 0;
   virtual std::unique_ptr<TypeErasedActorScheduler> Clone() const = 0;
 
   virtual const void* GetUnderlyingSchedulerPtr() const = 0;
@@ -79,11 +115,11 @@ template <ex::scheduler Scheduler>
 class AnyStdExecScheduler : public TypeErasedActorScheduler {
  public:
   explicit AnyStdExecScheduler(Scheduler scheduler) : scheduler_(std::move(scheduler)) {}
-  void Schedule(TypeErasedActor* actor, ex::simple_counting_scope::token scope_token) override {
-    const auto& actor_config = actor->GetActorConfig();
-    auto sender = ex::schedule(scheduler_) | ex::write_env(ex::prop {ex_actor::get_priority, actor_config.priority}) |
-                  ex::write_env(ex::prop {ex_actor::get_scheduler_index, actor_config.scheduler_index}) |
-                  ex::then([actor] { actor->PullMailboxAndRun(); });
+  void Schedule(MoveOnlyFunction<void()> fn, const ActorConfig& config,
+                ex::simple_counting_scope::token scope_token) override {
+    auto sender = ex::schedule(scheduler_) | ex::write_env(ex::prop {ex_actor::get_priority, config.priority}) |
+                  ex::write_env(ex::prop {ex_actor::get_scheduler_index, config.scheduler_index}) |
+                  ex::then([fn = std::move(fn)]() mutable { fn(); });
     ex::spawn(std::move(sender) | DiscardResult(), scope_token);
   }
 
@@ -227,36 +263,37 @@ class MailboxSet {
 template <class UserClass, auto kCreateFn = nullptr>
 class Actor : public TypeErasedActor {
  public:
-  template <typename... Args>
-  explicit Actor(std::unique_ptr<TypeErasedActorScheduler> scheduler, ActorConfig actor_config, Args... args)
+  explicit Actor(std::unique_ptr<TypeErasedActorScheduler> scheduler, ActorConfig actor_config)
       : TypeErasedActor(std::move(actor_config)),
         scheduler_(std::move(scheduler)),
-        mailbox_set_(actor_config_.mailbox_configs) {
-    if constexpr (kCreateFn != nullptr) {
-      using ReturnType = FnReturnType<kCreateFn>;
-      static_assert(
-          std::is_same_v<ReturnType, UserClass>,
-          "The return type of kCreateFn must match the Actor's UserClass template parameter to avoid slicing.");
-
-      // Use `new` directly so the prvalue returned by kCreateFn is used to
-      // initialize the heap object, benefiting from guaranteed copy elision
-      // (C++17 [dcl.init]/17.6.1) and not requiring UserClass to be movable.
-      user_class_instance_.reset(new UserClass(kCreateFn(std::move(args)...)));
-    } else {
-      user_class_instance_ = std::make_unique<UserClass>(std::move(args)...);
-    }
-    cached_user_class_instance_address_ = user_class_instance_.get();
-  }
+        mailbox_set_(actor_config_.mailbox_configs) {}
 
   template <typename... Args>
-  static std::unique_ptr<TypeErasedActor> CreateUseArgTuple(std::unique_ptr<TypeErasedActorScheduler> scheduler,
-                                                            ActorConfig actor_config, std::tuple<Args...> arg_tuple) {
-    return std::apply(
-        [scheduler = std::move(scheduler), actor_config = std::move(actor_config)](auto&&... args) mutable {
-          return std::make_unique<Actor<UserClass, kCreateFn>>(std::move(scheduler), std::move(actor_config),
-                                                               std::move(args)...);
+  ex::task<void> InitUserClassInstance(Args... args) {
+    std::exception_ptr init_exception;
+    ex::simple_counting_scope init_scope;
+    scheduler_->Schedule(
+        [this, &init_exception, ...args = std::move(args)]() mutable {
+          try {
+            if constexpr (kCreateFn != nullptr) {
+              using ReturnType = FnReturnType<kCreateFn>;
+              static_assert(
+                  std::is_same_v<ReturnType, UserClass>,
+                  "The return type of kCreateFn must match the Actor's UserClass template parameter to avoid slicing.");
+              user_class_instance_.reset(new UserClass(kCreateFn(std::move(args)...)));
+            } else {
+              user_class_instance_ = std::make_unique<UserClass>(std::move(args)...);
+            }
+            cached_user_class_instance_address_ = user_class_instance_.get();
+          } catch (...) {
+            init_exception = std::current_exception();
+          }
         },
-        std::move(arg_tuple));
+        actor_config_, init_scope.get_token());
+    co_await init_scope.join();
+    if (init_exception) {
+      std::rethrow_exception(init_exception);
+    }
   }
 
   ~Actor() override = default;
@@ -324,7 +361,7 @@ class Actor : public TypeErasedActor {
     if (!changed) {
       return;
     }
-    scheduler_->Schedule(this, async_scope_.get_token());
+    scheduler_->Schedule([this] { PullMailboxAndRun(); }, actor_config_, async_scope_.get_token());
   }
 
   void PullMailboxAndRun() override {

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -188,7 +188,9 @@ class ActorRegistryBackend {
     try {
       co_await actor_ptr->InitUserClassInstance(std::move(args)...);
     } catch (...) {
-      actor_name_to_id_.erase(name);
+      if (config.actor_name.has_value()) {
+        actor_name_to_id_.erase(*config.actor_name);
+      }
       throw;
     }
 

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -184,10 +184,15 @@ class ActorRegistryBackend {
       EXA_THROW_CHECK(!actor_name_to_id_.contains(name)) << "An actor with the same name already exists, name=" << name;
       actor_name_to_id_[name] = actor_id;
     }
+
+    try {
+      co_await actor_ptr->InitUserClassInstance(std::move(args)...);
+    } catch (...) {
+      actor_name_to_id_.erase(name);
+      throw;
+    }
+
     actor_id_to_actor_[actor_id] = std::move(actor);
-
-    co_await actor_ptr->InitUserClassInstance(std::move(args)...);
-
     auto handle = ActorRef<UserClass>(this_node_id_, node_id, actor_id, actor_ptr, broker_actor_ref_);
     NotifyExActorOnSpawned<UserClass>(actor_ptr, handle);
     // Workaround: see DeserializeActorRef comment.

--- a/include/ex_actor/internal/actor_registry.h
+++ b/include/ex_actor/internal/actor_registry.h
@@ -49,13 +49,13 @@ class ActorRegistryBackend {
    * @brief Spawn a local actor with config.
    */
   template <class UserClass, class... Args>
-  ActorRef<UserClass> SpawnWithClass(uint64_t node_id, ActorConfig config, Args... args) {
+  ex::task<ActorRef<UserClass>> SpawnWithClass(uint64_t node_id, ActorConfig config, Args... args) {
     if (node_id != this_node_id_) {
       EXA_THROW << "Spawn<UserClass> can only be used to create local actor, to create remote actor, use "
                    "Spawn<&CreateFn> to provide a fixed signature for remote actor creation. node_id="
                 << node_id << ", this_node_id=" << this_node_id_ << ", actor_type=" << typeid(UserClass).name();
     }
-    return SpawnLocal<UserClass>(node_id, std::move(config), std::move(args)...);
+    co_return co_await SpawnLocal<UserClass>(node_id, std::move(config), std::move(args)...);
   }
 
   /**
@@ -65,7 +65,7 @@ class ActorRegistryBackend {
   ex::task<ActorRef<FnReturnType<kCreateFn>>> SpawnWithCreateFn(uint64_t node_id, ActorConfig config, Args... args) {
     using UserClass = FnReturnType<kCreateFn>;
     if (node_id == this_node_id_) {
-      co_return SpawnLocal<UserClass, kCreateFn>(node_id, std::move(config), std::move(args)...);
+      co_return co_await SpawnLocal<UserClass, kCreateFn>(node_id, std::move(config), std::move(args)...);
     }
 
     EXA_THROW_CHECK(!broker_actor_ref_.IsEmpty()) << "Broker actor not set";
@@ -174,21 +174,25 @@ class ActorRegistryBackend {
   }
 
   template <class UserClass, auto kCreateFn = nullptr, class... Args>
-  ActorRef<UserClass> SpawnLocal(uint64_t node_id, ActorConfig config, Args... args) {
+  ex::task<ActorRef<UserClass>> SpawnLocal(uint64_t node_id, ActorConfig config, Args... args) {
     auto actor_id = GenerateRandomActorId();
-    auto actor =
-        std::make_unique<Actor<UserClass, kCreateFn>>(user_actor_scheduler_->Clone(), config, std::move(args)...);
-    auto handle = ActorRef<UserClass>(this_node_id_, node_id, actor_id, actor.get(), broker_actor_ref_);
-    NotifyExActorOnSpawned<UserClass>(actor.get(), handle);
+    auto actor = std::make_unique<Actor<UserClass, kCreateFn>>(user_actor_scheduler_->Clone(), config);
+    auto* actor_ptr = actor.get();
+
     if (config.actor_name.has_value()) {
       std::string& name = *config.actor_name;
       EXA_THROW_CHECK(!actor_name_to_id_.contains(name)) << "An actor with the same name already exists, name=" << name;
       actor_name_to_id_[name] = actor_id;
     }
     actor_id_to_actor_[actor_id] = std::move(actor);
+
+    co_await actor_ptr->InitUserClassInstance(std::move(args)...);
+
+    auto handle = ActorRef<UserClass>(this_node_id_, node_id, actor_id, actor_ptr, broker_actor_ref_);
+    NotifyExActorOnSpawned<UserClass>(actor_ptr, handle);
     // Workaround: see DeserializeActorRef comment.
     actor_id_to_serialized_ref_[actor_id] = Serialize(rfl::Reflector<ActorRef<UserClass>>::from(handle));
-    return handle;
+    co_return handle;
   }
 
   std::mt19937 random_num_generator_;
@@ -204,7 +208,7 @@ class ActorRegistryBackend {
   void InitRandomNumGenerator();
   uint64_t GenerateRandomActorId();
   ByteBuffer SerializeReply(const NetworkReply& reply);
-  void HandleActorCreationRequest(ActorCreationRequest msg, ByteBuffer& reply_out);
+  ex::task<ByteBuffer> HandleActorCreationRequest(ActorCreationRequest msg);
   ex::task<ByteBuffer> HandleActorMethodCallRequest(ActorMethodCallRequest msg);
   ex::task<ByteBuffer> HandleActorDestroyRequest(ActorDestroyRequest msg);
 };

--- a/include/ex_actor/internal/remote_handler_registry.h
+++ b/include/ex_actor/internal/remote_handler_registry.h
@@ -55,7 +55,8 @@ class RemoteActorRequestHandlerRegistry {
 
   using RemoteActorMethodCallHandler =
       std::function<ex::task<NetworkReply>(RemoteActorMethodCallHandlerContext context)>;
-  using RemoteActorCreationHandler = std::function<ex::task<ActorCreationResult>(RemoteActorCreationHandlerContext context)>;
+  using RemoteActorCreationHandler =
+      std::function<ex::task<ActorCreationResult>(RemoteActorCreationHandlerContext context)>;
 
   void RegisterRemoteActorMethodCallHandler(uint64_t handler_key, RemoteActorMethodCallHandler func) {
     EXA_THROW_CHECK(!remote_actor_method_call_handler_.contains(handler_key))
@@ -133,10 +134,9 @@ class RemoteFuncHandlerRegistrar {
         DeserializeFnArgs<kCreateFn>(context.serialized_args, context.actor_ref_serde_ctx);
 
     auto actor = std::make_unique<Actor<ActorClass, kCreateFn>>(std::move(context.scheduler),
-                                                                 std::move(creation_args.actor_config));
-    co_await std::apply(
-        [&actor](auto&&... args) { return actor->InitUserClassInstance(std::move(args)...); },
-        std::move(creation_args.args_tuple));
+                                                                std::move(creation_args.actor_config));
+    co_await std::apply([&actor](auto&&... args) { return actor->InitUserClassInstance(std::move(args)...); },
+                        std::move(creation_args.args_tuple));
 
     auto this_node_id = context.actor_ref_serde_ctx.this_node_id;
     auto actor_ref = ActorRef<ActorClass>(this_node_id, this_node_id, context.actor_id, actor.get(),

--- a/include/ex_actor/internal/remote_handler_registry.h
+++ b/include/ex_actor/internal/remote_handler_registry.h
@@ -55,7 +55,7 @@ class RemoteActorRequestHandlerRegistry {
 
   using RemoteActorMethodCallHandler =
       std::function<ex::task<NetworkReply>(RemoteActorMethodCallHandlerContext context)>;
-  using RemoteActorCreationHandler = std::function<ActorCreationResult(RemoteActorCreationHandlerContext context)>;
+  using RemoteActorCreationHandler = std::function<ex::task<ActorCreationResult>(RemoteActorCreationHandlerContext context)>;
 
   void RegisterRemoteActorMethodCallHandler(uint64_t handler_key, RemoteActorMethodCallHandler func) {
     EXA_THROW_CHECK(!remote_actor_method_call_handler_.contains(handler_key))
@@ -126,19 +126,24 @@ class RemoteFuncHandlerRegistrar {
 
  private:
   template <auto kCreateFn>
-  RemoteActorRequestHandlerRegistry::ActorCreationResult DeserializeAndCreateActor(
+  ex::task<RemoteActorRequestHandlerRegistry::ActorCreationResult> DeserializeAndCreateActor(
       RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext context) {
     using ActorClass = Signature<decltype(kCreateFn)>::ReturnType;
     ActorCreationArgs creation_args =
         DeserializeFnArgs<kCreateFn>(context.serialized_args, context.actor_ref_serde_ctx);
-    std::unique_ptr<TypeErasedActor> actor = Actor<ActorClass, kCreateFn>::CreateUseArgTuple(
-        std::move(context.scheduler), std::move(creation_args.actor_config), std::move(creation_args.args_tuple));
+
+    auto actor = std::make_unique<Actor<ActorClass, kCreateFn>>(std::move(context.scheduler),
+                                                                 std::move(creation_args.actor_config));
+    co_await std::apply(
+        [&actor](auto&&... args) { return actor->InitUserClassInstance(std::move(args)...); },
+        std::move(creation_args.args_tuple));
+
     auto this_node_id = context.actor_ref_serde_ctx.this_node_id;
     auto actor_ref = ActorRef<ActorClass>(this_node_id, this_node_id, context.actor_id, actor.get(),
                                           context.actor_ref_serde_ctx.broker_actor_ref);
     NotifyExActorOnSpawned<ActorClass>(actor.get(), actor_ref);
     auto actor_name = actor->GetActorConfig().actor_name;
-    return {
+    co_return RemoteActorRequestHandlerRegistry::ActorCreationResult {
         .actor = std::move(actor),
         .actor_name = std::move(actor_name),
         // Workaround: see ActorRegistryBackend::DeserializeActorRef comment.

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -218,8 +218,7 @@ ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeEras
                                 ? std::move(scheduler)
                                 : std::make_unique<AnyStdExecScheduler<WorkSharingThreadPool::Scheduler>>(
                                       default_work_sharing_thread_pool_.GetScheduler())),
-      backend_actor_(system_actor_scheduler_->Clone(), ActorConfig {}),
-      backend_actor_ref_() {
+      backend_actor_(system_actor_scheduler_->Clone(), ActorConfig {}) {
   ex::sync_wait(backend_actor_.InitUserClassInstance(user_actor_scheduler_->Clone(), this_node_id_, broker_actor_ref_));
   backend_actor_ref_ = BasicActorRef<ActorRegistryBackend>(/*actor_id=*/UINT64_MAX, &backend_actor_);
   log::Info("ActorRegistry created, node_id={:#x}", this_node_id_);

--- a/src/ex_actor/internal/actor_registry.cc
+++ b/src/ex_actor/internal/actor_registry.cc
@@ -66,9 +66,7 @@ ex::task<ByteBuffer> ActorRegistryBackend::HandleNetworkRequest(ByteBuffer reque
   auto request = Deserialize<NetworkRequest>(request_buffer);
 
   if (auto* msg = std::get_if<ActorCreationRequest>(&request.variant)) {
-    ByteBuffer reply_out;
-    HandleActorCreationRequest(std::move(*msg), reply_out);
-    co_return reply_out;
+    co_return co_await HandleActorCreationRequest(std::move(*msg));
   }
 
   if (auto* msg = std::get_if<ActorMethodCallRequest>(&request.variant)) {
@@ -108,7 +106,7 @@ uint64_t ActorRegistryBackend::GenerateRandomActorId() {
 
 ByteBuffer ActorRegistryBackend::SerializeReply(const NetworkReply& reply) { return Serialize(reply); }
 
-void ActorRegistryBackend::HandleActorCreationRequest(ActorCreationRequest msg, ByteBuffer& reply_out) {
+ex::task<ByteBuffer> ActorRegistryBackend::HandleActorCreationRequest(ActorCreationRequest msg) {
   try {
     auto handler = RemoteActorRequestHandlerRegistry::GetInstance().GetRemoteActorCreationHandler(msg.handler_key);
     ActorRefSerdeContext info {.this_node_id = this_node_id_,
@@ -120,11 +118,12 @@ void ActorRegistryBackend::HandleActorCreationRequest(ActorCreationRequest msg, 
                                },
                                .broker_actor_ref = broker_actor_ref_};
     uint64_t actor_id = GenerateRandomActorId();
-    auto result = handler(RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext {
+    RemoteActorRequestHandlerRegistry::RemoteActorCreationHandlerContext context {
         .serialized_args = std::move(msg.serialized_args),
         .scheduler = user_actor_scheduler_->Clone(),
         .actor_ref_serde_ctx = info,
-        .actor_id = actor_id});
+        .actor_id = actor_id};
+    auto result = co_await handler(std::move(context));
     if (result.actor_name.has_value()) {
       EXA_THROW_CHECK(!actor_name_to_id_.contains(result.actor_name.value()))
           << "An actor with the same name already exists, name=" << result.actor_name.value();
@@ -132,11 +131,11 @@ void ActorRegistryBackend::HandleActorCreationRequest(ActorCreationRequest msg, 
     }
     actor_id_to_actor_[actor_id] = std::move(result.actor);
     actor_id_to_serialized_ref_[actor_id] = result.serialized_actor_ref;
-    reply_out = SerializeReply(NetworkReply {
+    co_return SerializeReply(NetworkReply {
         ActorCreationReply {.success = true, .serialized_actor_ref = std::move(result.serialized_actor_ref)}});
   } catch (std::exception& error) {
     auto error_msg = fmt_lib::format("Exception type: {}, what(): {}", typeid(error).name(), error.what());
-    reply_out = SerializeReply(NetworkReply {ActorCreationReply {.success = false, .error = std::move(error_msg)}});
+    co_return SerializeReply(NetworkReply {ActorCreationReply {.success = false, .error = std::move(error_msg)}});
   }
 }
 
@@ -219,9 +218,10 @@ ActorRegistry::ActorRegistry(uint32_t thread_pool_size, std::unique_ptr<TypeEras
                                 ? std::move(scheduler)
                                 : std::make_unique<AnyStdExecScheduler<WorkSharingThreadPool::Scheduler>>(
                                       default_work_sharing_thread_pool_.GetScheduler())),
-      backend_actor_(system_actor_scheduler_->Clone(), ActorConfig {}, user_actor_scheduler_->Clone(), this_node_id_,
-                     broker_actor_ref_),
-      backend_actor_ref_(/*actor_id=*/UINT64_MAX, &backend_actor_) {
+      backend_actor_(system_actor_scheduler_->Clone(), ActorConfig {}),
+      backend_actor_ref_() {
+  ex::sync_wait(backend_actor_.InitUserClassInstance(user_actor_scheduler_->Clone(), this_node_id_, broker_actor_ref_));
+  backend_actor_ref_ = BasicActorRef<ActorRegistryBackend>(/*actor_id=*/UINT64_MAX, &backend_actor_);
   log::Info("ActorRegistry created, node_id={:#x}", this_node_id_);
 }
 
@@ -230,8 +230,8 @@ ex::task<void> ActorRegistry::StartOrJoinCluster(const ClusterConfig& cluster_co
   EXA_THROW_CHECK(broker_actor_ref_.IsEmpty()) << "Already in distributed mode.";
   EXA_THROW_CHECK(!cluster_config.listen_address.empty()) << "listen_address must not be empty";
 
-  broker_actor_ = std::make_unique<Actor<MessageBroker>>(system_actor_scheduler_->Clone(), ActorConfig {},
-                                                         this_node_id_, cluster_config);
+  broker_actor_ = std::make_unique<Actor<MessageBroker>>(system_actor_scheduler_->Clone(), ActorConfig {});
+  co_await broker_actor_->InitUserClassInstance(this_node_id_, cluster_config);
 
   broker_actor_ref_ = BasicActorRef<MessageBroker>(/*actor_id=*/UINT64_MAX, broker_actor_.get());
   NotifyExActorOnSpawned<MessageBroker>(broker_actor_.get(), broker_actor_ref_);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ ex_actor_test(network_test TIMEOUT 15)
 ex_actor_test(skynet_test TIMEOUT 10)
 ex_actor_test(logging_test)
 ex_actor_test(global_registry_test)
+ex_actor_test(async_init_test)
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 # multi-process test

--- a/test/async_init_test.cc
+++ b/test/async_init_test.cc
@@ -1,5 +1,6 @@
 #include <atomic>
 #include <chrono>
+#include <stdexcept>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -48,6 +49,45 @@ struct SlowActor {
   }
   void Noop() {}
 };
+
+struct ThrowingActor {
+  explicit ThrowingActor() { throw std::runtime_error("ctor failed"); }
+  void Noop() {}
+};
+
+struct TrivialActor {
+  void Noop() {}
+};
+
+// Regression test for commit 4b95ee8: when a named actor's constructor throws
+// during InitUserClassInstance, the registry must roll back the name->id
+// mapping so the name can be reused.
+TEST(AsyncInitTest, NameRegistrationRolledBackWhenConstructorThrows) {
+  constexpr const char* kName = "rollback_name";
+  ex_actor::Init(/*thread_pool_size=*/1);
+  auto coroutine = [kName]() -> stdexec::task<void> {
+    bool threw = false;
+    try {
+      co_await ex_actor::Spawn<ThrowingActor>().WithConfig({.actor_name = kName});
+    } catch (const std::exception&) {
+      threw = true;
+    }
+    EXPECT_TRUE(threw);
+
+    // The name mapping should have been erased on failure.
+    auto looked_up = co_await ex_actor::GetActorRefByName<ThrowingActor>(kName);
+    EXPECT_FALSE(looked_up.has_value());
+
+    // The name is free again, so spawning a different actor with the same name
+    // must succeed instead of failing the duplicate-name check.
+    auto actor = co_await ex_actor::Spawn<TrivialActor>().WithConfig({.actor_name = kName});
+    EXPECT_FALSE(actor.IsEmpty());
+    auto looked_up_again = co_await ex_actor::GetActorRefByName<TrivialActor>(kName);
+    EXPECT_TRUE(looked_up_again.has_value());
+  };
+  ex::sync_wait(coroutine());
+  ex_actor::Shutdown();
+}
 
 TEST(AsyncInitTest, ConstructorsRunInParallel) {
   ex_actor::Init(/*thread_pool_size=*/4);

--- a/test/async_init_test.cc
+++ b/test/async_init_test.cc
@@ -1,0 +1,73 @@
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "ex_actor/api.h"
+
+namespace ex = ex_actor::ex;
+
+struct ConstructorThreadRecorder {
+  explicit ConstructorThreadRecorder(std::thread::id* out) { *out = std::this_thread::get_id(); }
+  void Noop() {}
+};
+
+TEST(AsyncInitTest, ConstructorRunsOnCorrectSchedulerWithEnv) {
+  ex_actor::WorkSharingThreadPool thread_pool1(1);
+  ex_actor::WorkSharingThreadPool thread_pool2(1);
+  ex_actor::SchedulerUnion scheduler_union(thread_pool1.GetScheduler(), thread_pool2.GetScheduler());
+
+  // Get the thread ID that runs on each pool.
+  auto get_tid = ex::schedule(scheduler_union.GetScheduler()) | ex::then([] { return std::this_thread::get_id(); });
+  auto [tid_pool1] = ex::sync_wait(get_tid | ex::write_env(ex::prop{ex_actor::get_scheduler_index, 0})).value();
+  auto [tid_pool2] = ex::sync_wait(get_tid | ex::write_env(ex::prop{ex_actor::get_scheduler_index, 1})).value();
+  ASSERT_NE(tid_pool1, tid_pool2);
+
+  ex_actor::Init(scheduler_union.GetScheduler());
+  auto coroutine = [&]() -> stdexec::task<void> {
+    std::thread::id ctor_thread;
+    auto actor = co_await ex_actor::Spawn<ConstructorThreadRecorder>(&ctor_thread)
+                     .WithConfig({.scheduler_index = 1});
+    // Constructor should have run on thread pool 2, not thread pool 1.
+    EXPECT_EQ(ctor_thread, tid_pool2);
+    EXPECT_NE(ctor_thread, tid_pool1);
+  };
+  ex::sync_wait(coroutine());
+  ex_actor::Shutdown();
+}
+
+struct SlowActor {
+  explicit SlowActor(std::atomic_int* concurrent_count, std::atomic_int* max_concurrent) {
+    int cur = concurrent_count->fetch_add(1, std::memory_order_relaxed) + 1;
+    int prev_max = max_concurrent->load(std::memory_order_relaxed);
+    while (cur > prev_max && !max_concurrent->compare_exchange_weak(prev_max, cur)) {
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    concurrent_count->fetch_sub(1, std::memory_order_relaxed);
+  }
+  void Noop() {}
+};
+
+TEST(AsyncInitTest, ConstructorsRunInParallel) {
+  ex_actor::Init(/*thread_pool_size=*/4);
+  auto coroutine = []() -> stdexec::task<void> {
+    std::atomic_int concurrent_count = 0;
+    std::atomic_int max_concurrent = 0;
+
+    stdexec::simple_counting_scope scope;
+    constexpr int kNumActors = 4;
+
+    for (int i = 0; i < kNumActors; ++i) {
+      stdexec::spawn(
+          ex_actor::Spawn<SlowActor>(&concurrent_count, &max_concurrent) | ex_actor::DiscardResult(),
+          scope.get_token());
+    }
+    co_await scope.join();
+
+    // If constructors ran in parallel, max_concurrent should be > 1.
+    EXPECT_GT(max_concurrent.load(), 1);
+  };
+  ex::sync_wait(coroutine());
+  ex_actor::Shutdown();
+}

--- a/test/async_init_test.cc
+++ b/test/async_init_test.cc
@@ -67,7 +67,10 @@ TEST(AsyncInitTest, NameRegistrationRolledBackWhenConstructorThrows) {
   auto coroutine = [kName]() -> stdexec::task<void> {
     bool threw = false;
     try {
-      co_await ex_actor::Spawn<ThrowingActor>().WithConfig({.actor_name = kName});
+      // GCC < 13 double-frees a temporary ActorConfig (heap-allocated actor_name) used directly
+      // in a co_await expression, so bind it to a named variable first. See actor_config.h.
+      ex_actor::ActorConfig config {.actor_name = kName};
+      co_await ex_actor::Spawn<ThrowingActor>().WithConfig(config);
     } catch (const std::exception&) {
       threw = true;
     }
@@ -79,7 +82,8 @@ TEST(AsyncInitTest, NameRegistrationRolledBackWhenConstructorThrows) {
 
     // The name is free again, so spawning a different actor with the same name
     // must succeed instead of failing the duplicate-name check.
-    auto actor = co_await ex_actor::Spawn<TrivialActor>().WithConfig({.actor_name = kName});
+    ex_actor::ActorConfig config {.actor_name = kName};
+    auto actor = co_await ex_actor::Spawn<TrivialActor>().WithConfig(config);
     EXPECT_FALSE(actor.IsEmpty());
     auto looked_up_again = co_await ex_actor::GetActorRefByName<TrivialActor>(kName);
     EXPECT_TRUE(looked_up_again.has_value());

--- a/test/async_init_test.cc
+++ b/test/async_init_test.cc
@@ -21,15 +21,14 @@ TEST(AsyncInitTest, ConstructorRunsOnCorrectSchedulerWithEnv) {
 
   // Get the thread ID that runs on each pool.
   auto get_tid = ex::schedule(scheduler_union.GetScheduler()) | ex::then([] { return std::this_thread::get_id(); });
-  auto [tid_pool1] = ex::sync_wait(get_tid | ex::write_env(ex::prop{ex_actor::get_scheduler_index, 0})).value();
-  auto [tid_pool2] = ex::sync_wait(get_tid | ex::write_env(ex::prop{ex_actor::get_scheduler_index, 1})).value();
+  auto [tid_pool1] = ex::sync_wait(get_tid | ex::write_env(ex::prop {ex_actor::get_scheduler_index, 0})).value();
+  auto [tid_pool2] = ex::sync_wait(get_tid | ex::write_env(ex::prop {ex_actor::get_scheduler_index, 1})).value();
   ASSERT_NE(tid_pool1, tid_pool2);
 
   ex_actor::Init(scheduler_union.GetScheduler());
   auto coroutine = [&]() -> stdexec::task<void> {
     std::thread::id ctor_thread;
-    auto actor = co_await ex_actor::Spawn<ConstructorThreadRecorder>(&ctor_thread)
-                     .WithConfig({.scheduler_index = 1});
+    auto actor = co_await ex_actor::Spawn<ConstructorThreadRecorder>(&ctor_thread).WithConfig({.scheduler_index = 1});
     // Constructor should have run on thread pool 2, not thread pool 1.
     EXPECT_EQ(ctor_thread, tid_pool2);
     EXPECT_NE(ctor_thread, tid_pool1);
@@ -99,9 +98,8 @@ TEST(AsyncInitTest, ConstructorsRunInParallel) {
     constexpr int kNumActors = 4;
 
     for (int i = 0; i < kNumActors; ++i) {
-      stdexec::spawn(
-          ex_actor::Spawn<SlowActor>(&concurrent_count, &max_concurrent) | ex_actor::DiscardResult(),
-          scope.get_token());
+      stdexec::spawn(ex_actor::Spawn<SlowActor>(&concurrent_count, &max_concurrent) | ex_actor::DiscardResult(),
+                     scope.get_token());
     }
     co_await scope.join();
 


### PR DESCRIPTION
Refactors actor construction so that the user's class constructor runs on the actor's assigned scheduler thread rather than the ActorRegistry's thread. so that:

1. actor construction can run in parallel
2. actor's constructor will horner envs, closes https://github.com/ex-actor/ex-actor/issues/266