### PR TITLE
[refactor] Extract shared scheduler operation and sender into reusable headers

### DIFF
--- a/include/ex_actor/internal/scheduler/core_pinned_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/core_pinned_thread_pool.h
@@ -15,22 +15,19 @@
 #pragma once
 
 #include <thread>
-#include <utility>
 
 #include "ex_actor/internal/actor_config.h"
 #include "ex_actor/internal/container.h"
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/platform.h"
-#include "ex_actor/internal/scheduler/stoppable_scheduler_completion_signatures.h"
+#include "ex_actor/internal/scheduler/scheduler_operation.h"
+#include "ex_actor/internal/scheduler/scheduler_sender.h"
 
 namespace ex_actor {
 
 class CorePinnedThreadPool {
  public:
-  struct TypeErasedOperation {
-    virtual ~TypeErasedOperation() = default;
-    virtual void Execute() = 0;
-  };
+  using TypeErasedOperation = internal::TypeErasedOperation;
 
   explicit CorePinnedThreadPool(size_t thread_count) : thread_count_(thread_count), queues_(thread_count) {
     EXA_THROW_CHECK(thread_count > 0) << "Thread count must be greater than 0";
@@ -40,63 +37,19 @@ class CorePinnedThreadPool {
   }
 
   template <ex::receiver R>
-  struct Operation : TypeErasedOperation {
-    Operation(R receiver, CorePinnedThreadPool* thread_pool)
-        : receiver(std::move(receiver)), thread_pool(thread_pool) {}
-
-    R receiver;
-    CorePinnedThreadPool* thread_pool;
-
-    void Execute() override {
-      auto env = ex::get_env(receiver);
-      auto stoken = ex::get_stop_token(env);
-      if constexpr (ex::unstoppable_token<decltype(stoken)>) {
-        receiver.set_value();
-      } else {
-        if (stoken.stop_requested()) {
-          receiver.set_stopped();
-        } else {
-          receiver.set_value();
-        }
-      }
-    }
+  struct Operation : internal::SchedulerOperationBase<CorePinnedThreadPool, R> {
+    using Base = internal::SchedulerOperationBase<CorePinnedThreadPool, R>;
+    using Base::Base;
 
     void start() noexcept {
-      auto env = ex::get_env(receiver);
+      auto env = ex::get_env(this->receiver);
       size_t core_index = ex_actor::get_core_index(env);
-      thread_pool->EnqueueOperation(this, core_index);
+      this->thread_pool->EnqueueOperation(this, core_index);
     }
   };
 
-  struct Scheduler;
-
-  struct Sender : ex::sender_t, internal::StoppableSchedulerCompletionSignatures {
-    using internal::StoppableSchedulerCompletionSignatures::get_completion_signatures;
-    CorePinnedThreadPool* thread_pool;
-
-    struct Env {
-      CorePinnedThreadPool* thread_pool;
-      template <class CPO>
-      auto query(ex::get_completion_scheduler_t<CPO>) const noexcept -> Scheduler {
-        return {.thread_pool = thread_pool};
-      }
-    };
-
-    auto get_env() const noexcept -> Env { return Env {.thread_pool = thread_pool}; }
-
-    template <ex::receiver R>
-    Operation<R> connect(R receiver) {
-      return {std::move(receiver), thread_pool};
-    }
-  };
-
-  struct Scheduler : ex::scheduler_t {
-    CorePinnedThreadPool* thread_pool;
-    Sender schedule() const noexcept { return {.thread_pool = thread_pool}; }
-    friend bool operator==(const Scheduler& lhs, const Scheduler& rhs) noexcept {
-      return lhs.thread_pool == rhs.thread_pool;
-    }
-  };
+  using Sender = internal::SchedulerSender<CorePinnedThreadPool>;
+  using Scheduler = internal::SchedulerHandle<CorePinnedThreadPool>;
 
   Scheduler GetScheduler() noexcept { return Scheduler {.thread_pool = this}; }
 

--- a/include/ex_actor/internal/scheduler/priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/priority_thread_pool.h
@@ -16,17 +16,19 @@
 
 #include <cstdint>
 #include <thread>
-#include <utility>
 
 #include "ex_actor/internal/actor_config.h"
 #include "ex_actor/internal/container.h"
 #include "ex_actor/internal/platform.h"
-#include "ex_actor/internal/scheduler/stoppable_scheduler_completion_signatures.h"
+#include "ex_actor/internal/scheduler/scheduler_operation.h"
+#include "ex_actor/internal/scheduler/scheduler_sender.h"
 
 namespace ex_actor {
 
 class PriorityThreadPool {
  public:
+  using TypeErasedOperation = internal::TypeErasedOperation;
+
   explicit PriorityThreadPool(size_t thread_count, bool start_workers_immediately = true)
       : thread_count_(thread_count) {
     if (thread_count > 0 && start_workers_immediately) {
@@ -40,64 +42,20 @@ class PriorityThreadPool {
     }
   }
 
-  struct TypeErasedOperation {
-    virtual ~TypeErasedOperation() = default;
-    virtual void Execute() = 0;
-  };
-
   template <ex::receiver R>
-  struct Operation : TypeErasedOperation {
-    Operation(R receiver, PriorityThreadPool* thread_pool) : receiver(std::move(receiver)), thread_pool(thread_pool) {}
-    R receiver;
-    PriorityThreadPool* thread_pool;
-    void Execute() override {
-      auto env = ex::get_env(receiver);
-      auto stoken = ex::get_stop_token(env);
-      if constexpr (ex::unstoppable_token<decltype(stoken)>) {
-        receiver.set_value();
-      } else {
-        if (stoken.stop_requested()) {
-          receiver.set_stopped();
-        } else {
-          receiver.set_value();
-        }
-      }
-    }
+  struct Operation : internal::SchedulerOperationBase<PriorityThreadPool, R> {
+    using Base = internal::SchedulerOperationBase<PriorityThreadPool, R>;
+    using Base::Base;
 
     void start() noexcept {
-      auto env = ex::get_env(receiver);
+      auto env = ex::get_env(this->receiver);
       uint32_t priority = ex_actor::get_priority(env);
-      thread_pool->EnqueueOperation(this, priority);
+      this->thread_pool->EnqueueOperation(this, priority);
     }
   };
 
-  struct Scheduler;
-
-  struct Sender : ex::sender_t, internal::StoppableSchedulerCompletionSignatures {
-    using internal::StoppableSchedulerCompletionSignatures::get_completion_signatures;
-    PriorityThreadPool* thread_pool;
-
-    struct Env {
-      PriorityThreadPool* thread_pool;
-      template <class CPO>
-      auto query(ex::get_completion_scheduler_t<CPO>) const noexcept -> Scheduler {
-        return {.thread_pool = thread_pool};
-      }
-    };
-    auto get_env() const noexcept -> Env { return Env {.thread_pool = thread_pool}; }
-    template <ex::receiver R>
-    Operation<R> connect(R receiver) {
-      return {std::move(receiver), thread_pool};
-    }
-  };
-
-  struct Scheduler : ex::scheduler_t {
-    PriorityThreadPool* thread_pool;
-    Sender schedule() const noexcept { return {.thread_pool = thread_pool}; }
-    friend bool operator==(const Scheduler& lhs, const Scheduler& rhs) noexcept {
-      return lhs.thread_pool == rhs.thread_pool;
-    }
-  };
+  using Sender = internal::SchedulerSender<PriorityThreadPool>;
+  using Scheduler = internal::SchedulerHandle<PriorityThreadPool>;
 
   Scheduler GetScheduler() noexcept { return Scheduler {.thread_pool = this}; }
 

--- a/include/ex_actor/internal/scheduler/scheduler_operation.h
+++ b/include/ex_actor/internal/scheduler/scheduler_operation.h
@@ -1,0 +1,54 @@
+// Copyright 2026 The ex_actor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <utility>
+
+#include "ex_actor/internal/alias.h"  // IWYU pragma: keep
+
+namespace ex_actor::internal {
+
+struct TypeErasedOperation {
+  virtual ~TypeErasedOperation() = default;
+  virtual void Execute() = 0;
+};
+
+// Base class for scheduler operations. Implements the common Execute() logic
+// (stop-token check + set_value/set_stopped). Each pool defines a derived
+// Operation that adds its own start() dispatching to the pool's queue.
+template <typename Pool, ex::receiver R>
+struct SchedulerOperationBase : TypeErasedOperation {
+  SchedulerOperationBase(R receiver, Pool* thread_pool)
+      : receiver(std::move(receiver)), thread_pool(thread_pool) {}
+
+  R receiver;
+  Pool* thread_pool;
+
+  void Execute() override {
+    auto env = ex::get_env(receiver);
+    auto stoken = ex::get_stop_token(env);
+    if constexpr (ex::unstoppable_token<decltype(stoken)>) {
+      receiver.set_value();
+    } else {
+      if (stoken.stop_requested()) {
+        receiver.set_stopped();
+      } else {
+        receiver.set_value();
+      }
+    }
+  }
+};
+
+}  // namespace ex_actor::internal

--- a/include/ex_actor/internal/scheduler/scheduler_operation.h
+++ b/include/ex_actor/internal/scheduler/scheduler_operation.h
@@ -30,8 +30,7 @@ struct TypeErasedOperation {
 // Operation that adds its own start() dispatching to the pool's queue.
 template <typename Pool, ex::receiver R>
 struct SchedulerOperationBase : TypeErasedOperation {
-  SchedulerOperationBase(R receiver, Pool* thread_pool)
-      : receiver(std::move(receiver)), thread_pool(thread_pool) {}
+  SchedulerOperationBase(R receiver, Pool* thread_pool) : receiver(std::move(receiver)), thread_pool(thread_pool) {}
 
   R receiver;
   Pool* thread_pool;
@@ -40,12 +39,12 @@ struct SchedulerOperationBase : TypeErasedOperation {
     auto env = ex::get_env(receiver);
     auto stoken = ex::get_stop_token(env);
     if constexpr (ex::unstoppable_token<decltype(stoken)>) {
-      receiver.set_value();
+      ex::set_value(std::move(receiver));
     } else {
       if (stoken.stop_requested()) {
-        receiver.set_stopped();
+        ex::set_stopped(std::move(receiver));
       } else {
-        receiver.set_value();
+        ex::set_value(std::move(receiver));
       }
     }
   }

--- a/include/ex_actor/internal/scheduler/scheduler_sender.h
+++ b/include/ex_actor/internal/scheduler/scheduler_sender.h
@@ -40,7 +40,7 @@ struct SchedulerSender : ex::sender_t, StoppableSchedulerCompletionSignatures {
   auto get_env() const noexcept -> Env { return Env {.thread_pool = thread_pool}; }
 
   template <ex::receiver R>
-  typename Pool::template Operation<R> connect(R receiver) {
+  typename Pool::template Operation<R> connect(R receiver) const {
     return {std::move(receiver), thread_pool};
   }
 };

--- a/include/ex_actor/internal/scheduler/scheduler_sender.h
+++ b/include/ex_actor/internal/scheduler/scheduler_sender.h
@@ -1,0 +1,57 @@
+// Copyright 2026 The ex_actor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <utility>
+
+#include "ex_actor/internal/alias.h"  // IWYU pragma: keep
+#include "ex_actor/internal/scheduler/stoppable_scheduler_completion_signatures.h"
+
+namespace ex_actor::internal {
+
+template <typename Pool>
+struct SchedulerHandle;
+
+template <typename Pool>
+struct SchedulerSender : ex::sender_t, StoppableSchedulerCompletionSignatures {
+  using StoppableSchedulerCompletionSignatures::get_completion_signatures;
+  Pool* thread_pool;
+
+  struct Env {
+    Pool* thread_pool;
+    template <class CPO>
+    auto query(ex::get_completion_scheduler_t<CPO>) const noexcept -> SchedulerHandle<Pool> {
+      return {.thread_pool = thread_pool};
+    }
+  };
+
+  auto get_env() const noexcept -> Env { return Env {.thread_pool = thread_pool}; }
+
+  template <ex::receiver R>
+  typename Pool::template Operation<R> connect(R receiver) {
+    return {std::move(receiver), thread_pool};
+  }
+};
+
+template <typename Pool>
+struct SchedulerHandle : ex::scheduler_t {
+  Pool* thread_pool;
+  SchedulerSender<Pool> schedule() const noexcept { return {.thread_pool = thread_pool}; }
+  friend bool operator==(const SchedulerHandle& lhs, const SchedulerHandle& rhs) noexcept {
+    return lhs.thread_pool == rhs.thread_pool;
+  }
+};
+
+}  // namespace ex_actor::internal

--- a/include/ex_actor/internal/scheduler/work_sharing_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/work_sharing_thread_pool.h
@@ -15,17 +15,19 @@
 #pragma once
 
 #include <thread>
-#include <utility>
 
 #include "ex_actor/internal/alias.h"  // IWYU pragma: keep
 #include "ex_actor/internal/container.h"
 #include "ex_actor/internal/platform.h"
-#include "ex_actor/internal/scheduler/stoppable_scheduler_completion_signatures.h"
+#include "ex_actor/internal/scheduler/scheduler_operation.h"
+#include "ex_actor/internal/scheduler/scheduler_sender.h"
 
 namespace ex_actor {
 
 class WorkSharingThreadPool {
  public:
+  using TypeErasedOperation = internal::TypeErasedOperation;
+
   explicit WorkSharingThreadPool(size_t thread_count, bool start_workers_immediately = true)
       : thread_count_(thread_count) {
     if (thread_count > 0 && start_workers_immediately) {
@@ -39,61 +41,16 @@ class WorkSharingThreadPool {
     }
   }
 
-  struct TypeErasedOperation {
-    virtual ~TypeErasedOperation() = default;
-    virtual void Execute() = 0;
-  };
-
   template <ex::receiver R>
-  struct Operation : TypeErasedOperation {
-    Operation(R receiver, WorkSharingThreadPool* thread_pool)
-        : receiver(std::move(receiver)), thread_pool(thread_pool) {}
-    R receiver;
-    WorkSharingThreadPool* thread_pool;
-    void Execute() override {
-      auto env = ex::get_env(receiver);
-      auto stoken = ex::get_stop_token(env);
-      if constexpr (ex::unstoppable_token<decltype(stoken)>) {
-        receiver.set_value();
-      } else {
-        if (stoken.stop_requested()) {
-          receiver.set_stopped();
-        } else {
-          receiver.set_value();
-        }
-      }
-    }
+  struct Operation : internal::SchedulerOperationBase<WorkSharingThreadPool, R> {
+    using Base = internal::SchedulerOperationBase<WorkSharingThreadPool, R>;
+    using Base::Base;
 
-    void start() noexcept { thread_pool->EnqueueOperation(this); }
+    void start() noexcept { this->thread_pool->EnqueueOperation(this); }
   };
 
-  struct Scheduler;
-
-  struct Sender : ex::sender_t, internal::StoppableSchedulerCompletionSignatures {
-    using internal::StoppableSchedulerCompletionSignatures::get_completion_signatures;
-    WorkSharingThreadPool* thread_pool;
-
-    struct Env {
-      WorkSharingThreadPool* thread_pool;
-      template <class CPO>
-      auto query(ex::get_completion_scheduler_t<CPO>) const noexcept -> Scheduler {
-        return {.thread_pool = thread_pool};
-      }
-    };
-    auto get_env() const noexcept -> Env { return Env {.thread_pool = thread_pool}; }
-    template <ex::receiver R>
-    Operation<R> connect(R receiver) {
-      return {std::move(receiver), thread_pool};
-    }
-  };
-
-  struct Scheduler : ex::scheduler_t {
-    WorkSharingThreadPool* thread_pool;
-    Sender schedule() const noexcept { return {.thread_pool = thread_pool}; }
-    friend bool operator==(const Scheduler& lhs, const Scheduler& rhs) noexcept {
-      return lhs.thread_pool == rhs.thread_pool;
-    }
-  };
+  using Sender = internal::SchedulerSender<WorkSharingThreadPool>;
+  using Scheduler = internal::SchedulerHandle<WorkSharingThreadPool>;
 
   Scheduler GetScheduler() noexcept { return Scheduler {.thread_pool = this}; }
 


### PR DESCRIPTION
## Summary

- Extracted duplicated scheduling infrastructure (~40 lines per pool) into two reusable headers:
  - `scheduler_operation.h`: `TypeErasedOperation` + `SchedulerOperationBase<Pool, R>` with the shared `Execute()` logic
  - `scheduler_sender.h`: `SchedulerSender<Pool>` + `SchedulerHandle<Pool>` templates for the sender/scheduler boilerplate
- Each pool now only defines a thin `Operation` struct with its pool-specific `start()` method and type-aliases `Sender`/`Scheduler` to the shared templates

## Test plan

- [x] Full build passes (`cmake --build . --config Release`)
- [x] All 23 tests pass (`ctest -C Release --output-on-failure`)
- [x] Code formatted with `scripts/format.py`