### PR TITLE
[feat] implement `WeakPriorityThreadPool`

### DIFF
--- a/include/ex_actor/internal/container.h
+++ b/include/ex_actor/internal/container.h
@@ -338,8 +338,6 @@ class BucketedPriorityQueue {
         return value;
       }
     }
-    // Semaphore was signaled but scan found nothing (the push might not be visible immediately).
-    sema_.signal();
     return std::nullopt;
   }
 

--- a/include/ex_actor/internal/container.h
+++ b/include/ex_actor/internal/container.h
@@ -319,8 +319,7 @@ class UnboundedBlockingQueue {
 template <class T>
 class BucketedPriorityQueue {
  public:
-  explicit BucketedPriorityQueue(uint32_t max_priorities)
-      : max_priorities_(max_priorities), buckets_(max_priorities) {}
+  explicit BucketedPriorityQueue(uint32_t max_priorities) : max_priorities_(max_priorities), buckets_(max_priorities) {}
 
   void Push(T value, uint32_t priority) {
     EXA_THROW_CHECK(priority < max_priorities_)

--- a/include/ex_actor/internal/container.h
+++ b/include/ex_actor/internal/container.h
@@ -338,6 +338,10 @@ class BucketedPriorityQueue {
         return value;
       }
     }
+    // ConcurrentQueue::try_dequeue uses size_approx() (relaxed loads) as a heuristic and
+    // can return false even when an item exists. Re-signal to preserve the permit so a
+    // subsequent Pop attempt will find the item.
+    sema_.signal();
     return std::nullopt;
   }
 

--- a/include/ex_actor/internal/container.h
+++ b/include/ex_actor/internal/container.h
@@ -26,12 +26,11 @@
 #include <optional>
 #include <queue>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
 #include <utility>
 
 #include "ex_actor/3rd_lib/daking/MPSC_queue.h"
 #include "ex_actor/3rd_lib/moody_camel_queue/blockingconcurrentqueue.h"
+#include "ex_actor/internal/alias.h"  // IWYU pragma: keep
 #include "ex_actor/internal/logging.h"
 
 namespace ex_actor::internal {
@@ -314,81 +313,41 @@ class UnboundedBlockingQueue {
   ex_actor::embedded_3rd::moodycamel::BlockingConcurrentQueue<T> queue_;
 };
 
-template <class K, class V>
-class LockGuardedMap {
- public:
-  bool Insert(const K& key, V value) {
-    std::lock_guard lock(mutex_);
-    auto [iter, inserted] = map_.try_emplace(key, std::move(value));
-    return inserted;
-  }
-
-  V& At(const K& key) {
-    std::lock_guard lock(mutex_);
-    auto iter = map_.find(key);
-    EXA_THROW_CHECK(iter != map_.end()) << "Key not found: " << key;
-    return iter->second;
-  }
-
-  const V& At(const K& key) const {
-    std::lock_guard lock(mutex_);
-    auto iter = map_.find(key);
-    EXA_THROW_CHECK(iter != map_.end()) << "Key not found: " << key;
-    return iter->second;
-  }
-
-  void Erase(const K& key) {
-    std::lock_guard lock(mutex_);
-    map_.erase(key);
-  }
-
-  bool Contains(const K& key) const {
-    std::lock_guard lock(mutex_);
-    return map_.contains(key);
-  }
-
-  void Clear() {
-    std::lock_guard lock(mutex_);
-    map_.clear();
-  }
-
-  std::unordered_map<K, V>& GetMap() { return map_; }
-  std::mutex& GetMutex() const { return mutex_; }
-
- private:
-  std::unordered_map<K, V> map_;
-  mutable std::mutex mutex_;
-};
-
+// Lock-free bucketed priority queue. One ConcurrentQueue per priority level eliminates
+// contention on Push entirely. Pop uses a LightweightSemaphore (spin-then-futex) for
+// blocking — no mutex involved.
 template <class T>
-class LockGuardedSet {
+class BucketedPriorityQueue {
  public:
-  bool Insert(T value) {
-    std::lock_guard lock(mutex_);
-    auto [iter, inserted] = set_.emplace(std::move(value));
-    return inserted;
+  explicit BucketedPriorityQueue(uint32_t max_priorities)
+      : max_priorities_(max_priorities), buckets_(max_priorities) {}
+
+  void Push(T value, uint32_t priority) {
+    EXA_THROW_CHECK(priority < max_priorities_)
+        << fmt_lib::format("priority={} is out of range, max={}", priority, max_priorities_);
+    buckets_[priority].enqueue(std::move(value));
+    sema_.signal();
   }
 
-  void Erase(const T& value) {
-    std::lock_guard lock(mutex_);
-    set_.erase(value);
+  std::optional<T> Pop(uint64_t timeout_ms) {
+    if (!sema_.wait(static_cast<int64_t>(timeout_ms) * 1000)) {
+      return std::nullopt;
+    }
+    T value;
+    for (auto& bucket : buckets_) {
+      if (bucket.try_dequeue(value)) {
+        return value;
+      }
+    }
+    // Semaphore was signaled but scan found nothing (the push might not be visible immediately).
+    sema_.signal();
+    return std::nullopt;
   }
-
-  bool Empty() {
-    std::lock_guard lock(mutex_);
-    return set_.empty();
-  }
-
-  bool Contains(const T& value) {
-    std::lock_guard lock(mutex_);
-    return set_.contains(value);
-  }
-
-  std::mutex& GetMutex() const { return mutex_; }
 
  private:
-  std::unordered_set<T> set_;
-  mutable std::mutex mutex_;
+  uint32_t max_priorities_;
+  std::vector<ex_actor::embedded_3rd::moodycamel::ConcurrentQueue<T>> buckets_;
+  ex_actor::embedded_3rd::moodycamel::LightweightSemaphore sema_;
 };
 
 }  // namespace ex_actor::internal

--- a/include/ex_actor/internal/scheduler/all.h
+++ b/include/ex_actor/internal/scheduler/all.h
@@ -18,6 +18,7 @@
 #include "ex_actor/internal/scheduler/core_pinned_thread_pool.h"
 #include "ex_actor/internal/scheduler/priority_thread_pool.h"
 #include "ex_actor/internal/scheduler/scheduler_union.h"
+#include "ex_actor/internal/scheduler/weak_priority_thread_pool.h"
 #include "ex_actor/internal/scheduler/work_sharing_thread_pool.h"
 #include "ex_actor/internal/scheduler/work_stealing_thread_pool.h"
 // IWYU pragma: end_exports

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -31,8 +31,7 @@ class WeakPriorityThreadPool {
  public:
   using TypeErasedOperation = internal::TypeErasedOperation;
 
-  explicit WeakPriorityThreadPool(size_t thread_count, uint32_t max_priority,
-                                   bool start_workers_immediately = true);
+  explicit WeakPriorityThreadPool(size_t thread_count, uint32_t max_priority, bool start_workers_immediately = true);
 
   void StartWorkers();
 

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -1,0 +1,68 @@
+// Copyright 2026 The ex_actor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <thread>
+
+#include "ex_actor/internal/actor_config.h"
+#include "ex_actor/internal/container.h"
+#include "ex_actor/internal/scheduler/shared/scheduler_operation.h"
+#include "ex_actor/internal/scheduler/shared/scheduler_sender.h"
+
+namespace ex_actor {
+
+// Lock-free priority thread pool with thread-local slot optimization. Priority ordering is
+// weak: operations re-enqueued by the currently-executing task bypass the shared queue and
+// run inline, which may violate strict priority order in exchange for reduced contention.
+class WeakPriorityThreadPool {
+ public:
+  using TypeErasedOperation = internal::TypeErasedOperation;
+
+  explicit WeakPriorityThreadPool(size_t thread_count, uint32_t max_priority,
+                                   bool start_workers_immediately = true);
+
+  void StartWorkers();
+
+  template <ex::receiver R>
+  struct Operation : internal::SchedulerOperationBase<WeakPriorityThreadPool, R> {
+    using Base = internal::SchedulerOperationBase<WeakPriorityThreadPool, R>;
+    using Base::Base;
+
+    void start() noexcept {
+      auto env = ex::get_env(this->receiver);
+      uint32_t priority = ex_actor::get_priority(env);
+      this->thread_pool->EnqueueOperation(this, priority);
+    }
+  };
+
+  using Sender = internal::SchedulerSender<WeakPriorityThreadPool>;
+  using Scheduler = internal::SchedulerHandle<WeakPriorityThreadPool>;
+
+  Scheduler GetScheduler() noexcept { return Scheduler {.thread_pool = this}; }
+
+  void EnqueueOperation(TypeErasedOperation* operation, uint32_t priority = 0);
+
+ private:
+  size_t thread_count_;
+  internal::BucketedPriorityQueue<TypeErasedOperation*> queue_;
+  std::vector<std::jthread> workers_;
+  inline static thread_local TypeErasedOperation* local_slot_ = nullptr;
+  inline static thread_local WeakPriorityThreadPool* owning_pool_ = nullptr;
+
+  void WorkerThreadLoop(const std::stop_token& stop_token);
+};
+
+}  // namespace ex_actor

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -1,0 +1,64 @@
+// Copyright 2026 The ex_actor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ex_actor/internal/scheduler/weak_priority_thread_pool.h"
+
+#include "ex_actor/internal/platform.h"
+
+namespace ex_actor {
+
+WeakPriorityThreadPool::WeakPriorityThreadPool(size_t thread_count, uint32_t max_priority,
+                                               bool start_workers_immediately)
+    : thread_count_(thread_count), queue_(max_priority) {
+  if (thread_count > 0 && start_workers_immediately) {
+    StartWorkers();
+  }
+}
+
+void WeakPriorityThreadPool::StartWorkers() {
+  for (size_t i = 0; i < thread_count_; ++i) {
+    workers_.emplace_back([this](const std::stop_token& stop_token) { WorkerThreadLoop(stop_token); });
+  }
+}
+
+void WeakPriorityThreadPool::EnqueueOperation(TypeErasedOperation* operation, uint32_t priority) {
+  if (owning_pool_ == this && local_slot_ == nullptr) {
+    local_slot_ = operation;
+    return;
+  }
+  queue_.Push(operation, priority);
+}
+
+void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token) {
+  internal::SetThreadName("weak_pri_worker");
+  owning_pool_ = this;
+  while (!stop_token.stop_requested()) {
+    auto optional_operation = queue_.Pop(/*timeout_ms=*/10);
+    if (!optional_operation) {
+      continue;
+    }
+    optional_operation.value()->Execute();
+    // Drain the local slot: priority ordering is "weak" here — local slot items execute
+    // inline without re-entering the shared priority queue, trading strict ordering for
+    // reduced contention.
+    while (local_slot_ != nullptr) {
+      auto* operation = local_slot_;
+      local_slot_ = nullptr;
+      operation->Execute();
+    }
+  }
+  owning_pool_ = nullptr;
+}
+
+}  // namespace ex_actor

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -164,6 +164,62 @@ TEST(SchedulerTest, CorePinnedThreadPoolTest) {
   ex_actor::Shutdown();
 }
 
+TEST(SchedulerTest, WeakPriorityThreadPoolPriorityOrderTest) {
+  ex_actor::WeakPriorityThreadPool thread_pool(1, /*max_priority=*/8, /*start_workers_immediately=*/false);
+  auto scheduler = thread_pool.GetScheduler();
+  std::atomic_int count = 0;
+  auto sender1 = ex::schedule(scheduler) | ex::then([&count]() {
+                   EXPECT_EQ(count, 0);
+                   count++;
+                 }) |
+                 ex::write_env(ex::prop {ex_actor::get_priority, 1});
+  auto sender2 = ex::schedule(scheduler) | ex::then([&count]() {
+                   EXPECT_EQ(count, 2);
+                   count++;
+                 }) |
+                 ex::write_env(ex::prop {ex_actor::get_priority, 3});
+  auto sender3 = ex::schedule(scheduler) | ex::then([&count]() {
+                   EXPECT_EQ(count, 1);
+                   count++;
+                 }) |
+                 ex::write_env(ex::prop {ex_actor::get_priority, 2});
+  stdexec::simple_counting_scope scope;
+  stdexec::spawn(sender1 | ex_actor::DiscardResult(), scope.get_token());
+  stdexec::spawn(sender2 | ex_actor::DiscardResult(), scope.get_token());
+  stdexec::spawn(sender3 | ex_actor::DiscardResult(), scope.get_token());
+  thread_pool.StartWorkers();
+  ex::sync_wait(scope.join());
+  ASSERT_EQ(count, 3);
+}
+
+TEST(SchedulerTest, WeakPriorityThreadPoolStoppableTest) {
+  ex_actor::WeakPriorityThreadPool thread_pool(1, /*max_priority=*/4);
+  auto scheduler = thread_pool.GetScheduler();
+  auto task = ex::schedule(scheduler) | ex::then([]() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); });
+  stdexec::counting_scope scope;
+  for (int i = 0; i < 100000; ++i) {
+    stdexec::spawn(task | ex::write_env(ex::prop {ex_actor::get_priority, static_cast<uint32_t>(i % 4)}) |
+                       ex_actor::DiscardResult(),
+                   scope.get_token());
+  }
+  scope.request_stop();
+  ex::sync_wait(scope.join());
+}
+
+TEST(SchedulerTest, WeakPriorityThreadPoolLocalSlotTest) {
+  // Verify the thread-local slot works: an operation that re-enqueues to the same pool
+  // should complete without deadlock.
+  ex_actor::WeakPriorityThreadPool thread_pool(1, /*max_priority=*/4);
+  auto scheduler = thread_pool.GetScheduler();
+  auto sender = ex::schedule(scheduler) | ex::then([]() { return 1; }) |
+                ex::write_env(ex::prop {ex_actor::get_priority, 0}) | ex::let_value([&](int val) {
+                  return ex::schedule(scheduler) | ex::then([val]() { return val + 1; }) |
+                         ex::write_env(ex::prop {ex_actor::get_priority, 0});
+                });
+  auto [result] = ex::sync_wait(sender).value();
+  ASSERT_EQ(result, 2);
+}
+
 TEST(SchedulerTest, SchedulerUnionWithCorePinnedThreadPoolTest) {
   ex_actor::WorkSharingThreadPool ws_pool(1);
   ex_actor::CorePinnedThreadPool cp_pool(2);


### PR DESCRIPTION
## Summary
- Add `WeakPriorityThreadPool`: a lock-free priority scheduler with thread-local slot optimization. Uses `BucketedPriorityQueue` for priority ordering and bypasses the shared queue for inline re-enqueued operations (weak priority semantics).
- Make `BucketedPriorityQueue` accept a runtime `max_priorities` constructor argument.
- Add tests covering priority ordering, stoppability, and local slot behavior.

## Test plan
- [x] `WeakPriorityThreadPoolPriorityOrderTest` — verifies operations dequeue in priority order
- [x] `WeakPriorityThreadPoolStoppableTest` — verifies graceful shutdown with 100k pending tasks
- [x] `WeakPriorityThreadPoolLocalSlotTest` — verifies re-enqueue from within an executing operation uses the local slot without deadlock
