### PR TITLE
[fix] change default priority to 0 for safer default

### DIFF
--- a/include/ex_actor/internal/actor_config.h
+++ b/include/ex_actor/internal/actor_config.h
@@ -58,7 +58,7 @@ struct ActorConfig {
   // used in SchedulerUnion
   size_t scheduler_index = 0;
   // used in PriorityThreadPool
-  uint32_t priority = UINT32_MAX;
+  uint32_t priority = 0;
   // used in CorePinnedThreadPool
   size_t core_index = 0;
 };
@@ -68,7 +68,7 @@ struct get_priority_t {
     if constexpr (requires { prop.query(get_priority_t {}); }) {
       return prop.query(get_priority_t {});
     } else {
-      return UINT32_MAX;
+      return 0;
     }
   }
   constexpr auto query(ex::forwarding_query_t) const noexcept -> bool { return true; }


### PR DESCRIPTION
## Summary
- Change default `priority` in `ActorConfig` and `get_priority_t` from `UINT32_MAX` to `0`.
- `UINT32_MAX` can exceed the `max_priority` limit specified in `WeakPriorityThreadPool`, causing out-of-bounds access.
- `0` (highest priority) is a safer default that stays within bounds for any pool configuration.

## Test plan
- [ ] Existing tests pass with the new default
- [ ] Verify actors without explicit priority work correctly in `WeakPriorityThreadPool`