### PR TITLE
[opt] Redesign WeakPriorityThreadPool based on power-of-two-choices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,16 @@
-refer README.md and docs/contents for how to use this framework(ignore files listed in .gitignore, which might be stale)
+# Understanding This Project
 
-refer "How to build from source" part in CONTRIBUTING.md for how to build&test.
+- Refer README.md and docs/contents for how to use this framework(ignore files listed in .gitignore, which might be stale)
+- Refer "How to build from source" part in CONTRIBUTING.md for how to build&test.
 
-when refactoring, do not remove original comments unless they are stale.
+# Editing Guidelines
+
+- When editing code, try best to keep original comments unless they are stale.
 
 # Debugging
 
-- when debugging tests, do not simplify the test code unless you are very confident the test is not correct.
-- prefer adding logs to gather more information before thinking too much.
+- When debugging tests, do not simplify the test code unless you are very confident the test is not correct.
+- Prefer adding logs to gather more information before thinking too much.
 
 # Code Style
 
@@ -20,6 +23,7 @@ Based on Google Style Guide, with the following additions:
 - Don't use placeholder `_` in struct binding. Always use meaningful variable names even it's not used.
 - In maps, when you can't get the key/value meaning from the variable name, add comments like `map</*key_meaning*/KeyType, /*value_meaning*/ValueType/>` for better readability. No "=" sign.
 
-# Pull Request & Commit Message
+# Pull Request Description & Commit Message
 
 - Make the description short and concise so reviewer can quickly understand the changes. don't exceed 50 words. Make the structure compact, no big titles, so it can be directly used as squash merge's commit message.
+

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -38,7 +38,7 @@ class WeakPriorityThreadPool {
   using TypeErasedOperation = internal::TypeErasedOperation;
 
   explicit WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues = 0,
-                                   bool start_workers_immediately = true);
+                                  bool start_workers_immediately = true);
 
   void StartWorkers();
 

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <deque>
 #include <map>
@@ -30,7 +31,7 @@
 namespace ex_actor {
 
 /// A sharded thread pool with best-effort (non-strict) priority, using "power of two choices":
-///   - Push: randomly select one sub-queue
+///   - Push: randomly pick 2 sub-queues, enqueue to the less loaded one
 ///   - Pop: randomly pick 2 sub-queues, peek their tops, take the higher-priority item
 class WeakPriorityThreadPool {
  public:
@@ -61,6 +62,7 @@ class WeakPriorityThreadPool {
   struct alignas(128) SubQueue {
     std::mutex lock;
     std::map<uint32_t, std::deque<TypeErasedOperation*>> queue;
+    std::atomic<size_t> size {0};
   };
 
   size_t thread_count_;

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -29,10 +29,11 @@
 
 namespace ex_actor {
 
-/// A high-performance sharded priority thread pool using "power of two choices":
-///   1. maintains 4 * cpu_core_num lock-guarded priority sub-queues
-///   2. push: randomly selects a sub-queue
-///   3. pop: randomly selects 2 sub-queues, peeks their tops, takes the higher priority one
+/// A sharded priority thread pool using "power of two choices" load balancing:
+///   - Each sub-queue holds all priority levels via std::map<priority, std::deque<op*>>
+///   - Push: randomly select one sub-queue
+///   - Pop: randomly pick 2 sub-queues, peek their tops, take the higher-priority item
+///   - Thread-local slot keeps the highest-priority successor for depth-first DAG execution
 class WeakPriorityThreadPool {
  public:
   using TypeErasedOperation = internal::TypeErasedOperation;

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -15,6 +15,9 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
+#include <map>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -26,15 +29,16 @@
 
 namespace ex_actor {
 
-/// A high-performance lock-free priority thread pool, but with the following constraints:
-///   1. priority level is limited, must be specified at construction time
-///   2. priority is only a hint, not a strict guarantee
+/// A high-performance sharded priority thread pool using "power of two choices":
+///   1. maintains 4 * cpu_core_num lock-guarded priority sub-queues
+///   2. push: randomly selects a sub-queue
+///   3. pop: randomly selects 2 sub-queues, peeks their tops, takes the higher priority one
 class WeakPriorityThreadPool {
  public:
   using TypeErasedOperation = internal::TypeErasedOperation;
 
-  explicit WeakPriorityThreadPool(size_t thread_count, uint32_t priority_upper_bound,
-                                  bool start_workers_immediately = true);
+  explicit WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues = 0,
+                                   bool start_workers_immediately = true);
 
   void StartWorkers();
 
@@ -58,11 +62,19 @@ class WeakPriorityThreadPool {
   void EnqueueOperation(TypeErasedOperation* operation, uint32_t priority = 0);
 
  private:
+  struct alignas(128) SubQueue {
+    std::mutex lock;
+    std::map<uint32_t, std::deque<TypeErasedOperation*>> queue;
+  };
+
   size_t thread_count_;
-  uint32_t priority_upper_bound_;
-  std::vector<embedded_3rd::moodycamel::ConcurrentQueue<TypeErasedOperation*>> queues_;
+  size_t num_sub_queues_;
+  std::vector<SubQueue> sub_queues_;
   embedded_3rd::moodycamel::LightweightSemaphore sema_;
   std::vector<std::jthread> workers_;
+  inline static thread_local TypeErasedOperation* local_slot_ = nullptr;
+  inline static thread_local uint32_t local_slot_priority_ = 0;
+  inline static thread_local WeakPriorityThreadPool* owning_pool_ = nullptr;
 
   struct LocalSlot {
     TypeErasedOperation* op;

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 
+#include "ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h"
 #include "ex_actor/3rd_lib/moody_camel_queue/lightweightsemaphore.h"
 #include "ex_actor/internal/actor_config.h"
 #include "ex_actor/internal/scheduler/shared/scheduler_operation.h"

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -21,7 +21,7 @@
 #include <thread>
 #include <vector>
 
-#include "ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h"
+#include "ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h"  // IWYU pragma: keep
 #include "ex_actor/3rd_lib/moody_camel_queue/lightweightsemaphore.h"
 #include "ex_actor/internal/actor_config.h"
 #include "ex_actor/internal/scheduler/shared/scheduler_operation.h"

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -21,7 +21,6 @@
 #include <thread>
 #include <vector>
 
-#include "ex_actor/3rd_lib/moody_camel_queue/concurrentqueue.h"
 #include "ex_actor/3rd_lib/moody_camel_queue/lightweightsemaphore.h"
 #include "ex_actor/internal/actor_config.h"
 #include "ex_actor/internal/scheduler/shared/scheduler_operation.h"
@@ -36,10 +35,7 @@ class WeakPriorityThreadPool {
  public:
   using TypeErasedOperation = internal::TypeErasedOperation;
 
-  explicit WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues = 0,
-                                  bool start_workers_immediately = true);
-
-  void StartWorkers();
+  explicit WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues = 0);
 
   template <ex::receiver R>
   struct Operation : internal::SchedulerOperationBase<WeakPriorityThreadPool, R> {

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -29,11 +29,9 @@
 
 namespace ex_actor {
 
-/// A sharded priority thread pool using "power of two choices" load balancing:
-///   - Each sub-queue holds all priority levels via std::map<priority, std::deque<op*>>
+/// A sharded thread pool with best-effort (non-strict) priority, using "power of two choices":
 ///   - Push: randomly select one sub-queue
 ///   - Pop: randomly pick 2 sub-queues, peek their tops, take the higher-priority item
-///   - Thread-local slot: bypass the queue for the highest-priority successor task
 class WeakPriorityThreadPool {
  public:
   using TypeErasedOperation = internal::TypeErasedOperation;

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -76,13 +76,6 @@ class WeakPriorityThreadPool {
   inline static thread_local uint32_t local_slot_priority_ = 0;
   inline static thread_local WeakPriorityThreadPool* owning_pool_ = nullptr;
 
-  struct LocalSlot {
-    TypeErasedOperation* op;
-    uint32_t priority;
-  };
-  inline static thread_local LocalSlot local_slot_ = {.op = nullptr, .priority = 0};
-  inline static thread_local WeakPriorityThreadPool* owning_pool_ = nullptr;
-
   void WorkerThreadLoop(const std::stop_token& stop_token);
 };
 

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -33,7 +33,7 @@ namespace ex_actor {
 ///   - Each sub-queue holds all priority levels via std::map<priority, std::deque<op*>>
 ///   - Push: randomly select one sub-queue
 ///   - Pop: randomly pick 2 sub-queues, peek their tops, take the higher-priority item
-///   - Thread-local slot keeps the highest-priority successor for depth-first DAG execution
+///   - Thread-local slot: bypass the queue for the highest-priority successor task
 class WeakPriorityThreadPool {
  public:
   using TypeErasedOperation = internal::TypeErasedOperation;

--- a/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
+++ b/include/ex_actor/internal/scheduler/weak_priority_thread_pool.h
@@ -75,6 +75,7 @@ class WeakPriorityThreadPool {
   inline static thread_local WeakPriorityThreadPool* owning_pool_ = nullptr;
 
   void WorkerThreadLoop(const std::stop_token& stop_token);
+  TypeErasedOperation* TryDequeueOperation();
 };
 
 }  // namespace ex_actor

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -70,6 +70,47 @@ void WeakPriorityThreadPool::EnqueueOperation(TypeErasedOperation* operation, ui
   sema_.signal();
 }
 
+WeakPriorityThreadPool::TypeErasedOperation* WeakPriorityThreadPool::TryDequeueOperation() {
+  size_t idx_a = tl_rng() % num_sub_queues_;
+  size_t idx_b = tl_rng() % num_sub_queues_;
+  if (idx_a == idx_b) {
+    idx_b = (idx_b + 1) % num_sub_queues_;
+  }
+
+  bool maybe_has_a = sub_queues_[idx_a].size.load(std::memory_order_relaxed) > 0;
+  bool maybe_has_b = sub_queues_[idx_b].size.load(std::memory_order_relaxed) > 0;
+  if (!maybe_has_a && !maybe_has_b) {
+    return nullptr;
+  }
+
+  auto pop_one = [](SubQueue& sq) -> TypeErasedOperation* {
+    auto it = sq.queue.begin();
+    auto& fifo = it->second;
+    TypeErasedOperation* op = fifo.front();
+    fifo.pop_front();
+    if (fifo.empty()) {
+      sq.queue.erase(it);
+    }
+    sq.size.fetch_sub(1, std::memory_order_relaxed);
+    return op;
+  };
+
+  std::scoped_lock guard(sub_queues_[idx_a].lock, sub_queues_[idx_b].lock);
+
+  bool has_a = !sub_queues_[idx_a].queue.empty();
+  bool has_b = !sub_queues_[idx_b].queue.empty();
+  if (has_a && has_b) {
+    uint32_t pri_a = sub_queues_[idx_a].queue.begin()->first;
+    uint32_t pri_b = sub_queues_[idx_b].queue.begin()->first;
+    return pop_one(pri_a <= pri_b ? sub_queues_[idx_a] : sub_queues_[idx_b]);
+  } else if (has_a) {
+    return pop_one(sub_queues_[idx_a]);
+  } else if (has_b) {
+    return pop_one(sub_queues_[idx_b]);
+  }
+  return nullptr;
+}
+
 void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token) {
   internal::SetThreadName("weak_pri_worker");
   owning_pool_ = this;
@@ -79,49 +120,9 @@ void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token)
       continue;
     }
 
-    auto pop_one = [](SubQueue& sq) -> TypeErasedOperation* {
-      auto it = sq.queue.begin();
-      auto& fifo = it->second;
-      TypeErasedOperation* op = fifo.front();
-      fifo.pop_front();
-      if (fifo.empty()) {
-        sq.queue.erase(it);
-      }
-      sq.size.fetch_sub(1, std::memory_order_relaxed);
-      return op;
-    };
-
-    auto peek_priority = [](SubQueue& sq) -> uint32_t { return sq.queue.begin()->first; };
-
     TypeErasedOperation* operation = nullptr;
     while (operation == nullptr) {
-      size_t idx_a = tl_rng() % num_sub_queues_;
-      size_t idx_b = tl_rng() % num_sub_queues_;
-      if (idx_a == idx_b) {
-        idx_b = (idx_b + 1) % num_sub_queues_;
-      }
-
-      bool maybe_has_a = sub_queues_[idx_a].size.load(std::memory_order_relaxed) > 0;
-      bool maybe_has_b = sub_queues_[idx_b].size.load(std::memory_order_relaxed) > 0;
-      if (!maybe_has_a && !maybe_has_b) {
-        continue;
-      }
-
-      std::scoped_lock guard(sub_queues_[idx_a].lock, sub_queues_[idx_b].lock);
-
-      bool has_a = !sub_queues_[idx_a].queue.empty();
-      bool has_b = !sub_queues_[idx_b].queue.empty();
-      if (has_a && has_b) {
-        if (peek_priority(sub_queues_[idx_a]) <= peek_priority(sub_queues_[idx_b])) {
-          operation = pop_one(sub_queues_[idx_a]);
-        } else {
-          operation = pop_one(sub_queues_[idx_b]);
-        }
-      } else if (has_a) {
-        operation = pop_one(sub_queues_[idx_a]);
-      } else if (has_b) {
-        operation = pop_one(sub_queues_[idx_b]);
-      }
+      operation = TryDequeueOperation();
     }
 
     operation->Execute();

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -14,15 +14,25 @@
 
 #include "ex_actor/internal/scheduler/weak_priority_thread_pool.h"
 
+#include <algorithm>
+#include <random>
+
 #include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/platform.h"
 
 namespace ex_actor {
 
-WeakPriorityThreadPool::WeakPriorityThreadPool(size_t thread_count, uint32_t priority_upper_bound,
+namespace {
+
+thread_local std::minstd_rand tl_rng {std::random_device {}()};
+
+}  // namespace
+
+WeakPriorityThreadPool::WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues,
                                                bool start_workers_immediately)
-    : thread_count_(thread_count), priority_upper_bound_(priority_upper_bound), queues_(priority_upper_bound_) {
-  EXA_THROW_CHECK_GT(priority_upper_bound_, 0U);
+    : thread_count_(thread_count),
+      num_sub_queues_(std::max<size_t>(2, num_sub_queues == 0 ? thread_count / 2 : num_sub_queues)),
+      sub_queues_(num_sub_queues_) {
   if (thread_count > 0 && start_workers_immediately) {
     StartWorkers();
   }
@@ -35,49 +45,86 @@ void WeakPriorityThreadPool::StartWorkers() {
 }
 
 void WeakPriorityThreadPool::EnqueueOperation(TypeErasedOperation* operation, uint32_t priority) {
-  EXA_THROW_CHECK_LT(priority, priority_upper_bound_);
   if (owning_pool_ == this) {
-    if (local_slot_.op == nullptr) {
-      local_slot_ = {.op = operation, .priority = priority};
+    if (local_slot_ == nullptr) {
+      local_slot_ = operation;
+      local_slot_priority_ = priority;
       return;
     }
-    if (priority < local_slot_.priority) {
-      auto evicted = local_slot_;
-      local_slot_ = {.op = operation, .priority = priority};
-      operation = evicted.op;
-      priority = evicted.priority;
+    if (priority < local_slot_priority_) {
+      auto* evicted = local_slot_;
+      uint32_t evicted_priority = local_slot_priority_;
+      local_slot_ = operation;
+      local_slot_priority_ = priority;
+      operation = evicted;
+      priority = evicted_priority;
     }
   }
-  uint32_t queue_index = priority;
-  queues_[queue_index].enqueue(operation);
+  size_t idx = tl_rng() % num_sub_queues_;
+  {
+    auto& sq = sub_queues_[idx];
+    std::lock_guard guard(sq.lock);
+    sq.queue[priority].push_back(operation);
+  }
   sema_.signal();
 }
 
 void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token) {
   internal::SetThreadName("weak_pri_worker");
   owning_pool_ = this;
+
   while (!stop_token.stop_requested()) {
     if (!sema_.wait(static_cast<int64_t>(10) * 1000)) {
       continue;
     }
+
+    auto pop_one = [](SubQueue& sq) -> TypeErasedOperation* {
+      auto it = sq.queue.begin();
+      auto& fifo = it->second;
+      TypeErasedOperation* op = fifo.front();
+      fifo.pop_front();
+      if (fifo.empty()) {
+        sq.queue.erase(it);
+      }
+      return op;
+    };
+
+    auto peek_priority = [](SubQueue& sq) -> uint32_t {
+      return sq.queue.begin()->first;
+    };
+
     TypeErasedOperation* operation = nullptr;
-    for (auto& queue : queues_) {
-      if (queue.try_dequeue(operation)) {
-        break;
+    while (operation == nullptr) {
+      size_t idx_a = tl_rng() % num_sub_queues_;
+      size_t idx_b = tl_rng() % num_sub_queues_;
+      if (idx_a == idx_b) {
+        idx_b = (idx_b + 1) % num_sub_queues_;
+      }
+
+      std::scoped_lock guard(sub_queues_[idx_a].lock, sub_queues_[idx_b].lock);
+
+      bool has_a = !sub_queues_[idx_a].queue.empty();
+      bool has_b = !sub_queues_[idx_b].queue.empty();
+      if (has_a && has_b) {
+        if (peek_priority(sub_queues_[idx_a]) <= peek_priority(sub_queues_[idx_b])) {
+          operation = pop_one(sub_queues_[idx_a]);
+        } else {
+          operation = pop_one(sub_queues_[idx_b]);
+        }
+      } else if (has_a) {
+        operation = pop_one(sub_queues_[idx_a]);
+      } else if (has_b) {
+        operation = pop_one(sub_queues_[idx_b]);
       }
     }
-    // ConcurrentQueue::try_dequeue uses size_approx() (relaxed loads) as a heuristic and
-    // can return false even when an item exists. Re-signal to preserve the permit so a
-    // subsequent Pop attempt will find the item.
-    if (operation == nullptr) {
-      sema_.signal();
-      continue;
-    }
+
     operation->Execute();
-    while (local_slot_.op != nullptr) {
-      operation = local_slot_.op;
-      local_slot_.op = nullptr;
-      operation->Execute();
+    // Immediately execute any task that was placed in the local slot
+    // during Execute() (successor task from the same DAG chain).
+    while (local_slot_ != nullptr) {
+      auto* op = local_slot_;
+      local_slot_ = nullptr;
+      op->Execute();
     }
   }
   owning_pool_ = nullptr;

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -52,11 +52,20 @@ void WeakPriorityThreadPool::EnqueueOperation(TypeErasedOperation* operation, ui
       priority = evicted_priority;
     }
   }
-  size_t idx = tl_rng() % num_sub_queues_;
+  size_t idx_a = tl_rng() % num_sub_queues_;
+  size_t idx_b = tl_rng() % num_sub_queues_;
+  if (idx_a == idx_b) {
+    idx_b = (idx_b + 1) % num_sub_queues_;
+  }
+  size_t idx =
+      sub_queues_[idx_a].size.load(std::memory_order_relaxed) <= sub_queues_[idx_b].size.load(std::memory_order_relaxed)
+          ? idx_a
+          : idx_b;
   {
     auto& sq = sub_queues_[idx];
     std::lock_guard guard(sq.lock);
     sq.queue[priority].push_back(operation);
+    sq.size.fetch_add(1, std::memory_order_relaxed);
   }
   sema_.signal();
 }
@@ -78,6 +87,7 @@ void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token)
       if (fifo.empty()) {
         sq.queue.erase(it);
       }
+      sq.size.fetch_sub(1, std::memory_order_relaxed);
       return op;
     };
 
@@ -89,6 +99,12 @@ void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token)
       size_t idx_b = tl_rng() % num_sub_queues_;
       if (idx_a == idx_b) {
         idx_b = (idx_b + 1) % num_sub_queues_;
+      }
+
+      bool maybe_has_a = sub_queues_[idx_a].size.load(std::memory_order_relaxed) > 0;
+      bool maybe_has_b = sub_queues_[idx_b].size.load(std::memory_order_relaxed) > 0;
+      if (!maybe_has_a && !maybe_has_b) {
+        continue;
       }
 
       std::scoped_lock guard(sub_queues_[idx_a].lock, sub_queues_[idx_b].lock);

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -89,9 +89,7 @@ void WeakPriorityThreadPool::WorkerThreadLoop(const std::stop_token& stop_token)
       return op;
     };
 
-    auto peek_priority = [](SubQueue& sq) -> uint32_t {
-      return sq.queue.begin()->first;
-    };
+    auto peek_priority = [](SubQueue& sq) -> uint32_t { return sq.queue.begin()->first; };
 
     TypeErasedOperation* operation = nullptr;
     while (operation == nullptr) {

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -103,9 +103,11 @@ WeakPriorityThreadPool::TypeErasedOperation* WeakPriorityThreadPool::TryDequeueO
     uint32_t pri_a = sub_queues_[idx_a].queue.begin()->first;
     uint32_t pri_b = sub_queues_[idx_b].queue.begin()->first;
     return pop_one(pri_a <= pri_b ? sub_queues_[idx_a] : sub_queues_[idx_b]);
-  } else if (has_a) {
+  }
+  if (has_a) {
     return pop_one(sub_queues_[idx_a]);
-  } else if (has_b) {
+  }
+  if (has_b) {
     return pop_one(sub_queues_[idx_b]);
   }
   return nullptr;

--- a/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
+++ b/src/ex_actor/internal/scheduler/weak_priority_thread_pool.cc
@@ -17,7 +17,6 @@
 #include <algorithm>
 #include <random>
 
-#include "ex_actor/internal/logging.h"
 #include "ex_actor/internal/platform.h"
 
 namespace ex_actor {
@@ -28,17 +27,10 @@ thread_local std::minstd_rand tl_rng {std::random_device {}()};
 
 }  // namespace
 
-WeakPriorityThreadPool::WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues,
-                                               bool start_workers_immediately)
+WeakPriorityThreadPool::WeakPriorityThreadPool(size_t thread_count, size_t num_sub_queues)
     : thread_count_(thread_count),
       num_sub_queues_(std::max<size_t>(2, num_sub_queues == 0 ? thread_count / 2 : num_sub_queues)),
       sub_queues_(num_sub_queues_) {
-  if (thread_count > 0 && start_workers_immediately) {
-    StartWorkers();
-  }
-}
-
-void WeakPriorityThreadPool::StartWorkers() {
   for (size_t i = 0; i < thread_count_; ++i) {
     workers_.emplace_back([this](const std::stop_token& stop_token) { WorkerThreadLoop(stop_token); });
   }

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -165,33 +165,6 @@ TEST(SchedulerTest, CorePinnedThreadPoolTest) {
   ex_actor::Shutdown();
 }
 
-TEST(SchedulerTest, WeakPriorityThreadPoolPriorityOrderTest) {
-  ex_actor::WeakPriorityThreadPool thread_pool(1, /*start_workers_immediately=*/false);
-  auto scheduler = thread_pool.GetScheduler();
-  std::atomic_int count = 0;
-  auto sender1 = ex::schedule(scheduler) | ex::then([&count]() {
-                   EXPECT_EQ(count, 0);
-                   count++;
-                 }) |
-                 ex::write_env(ex::prop {ex_actor::get_priority, 1});
-  auto sender2 = ex::schedule(scheduler) | ex::then([&count]() {
-                   EXPECT_EQ(count, 2);
-                   count++;
-                 }) |
-                 ex::write_env(ex::prop {ex_actor::get_priority, 3});
-  auto sender3 = ex::schedule(scheduler) | ex::then([&count]() {
-                   EXPECT_EQ(count, 1);
-                   count++;
-                 }) |
-                 ex::write_env(ex::prop {ex_actor::get_priority, 2});
-  stdexec::simple_counting_scope scope;
-  stdexec::spawn(sender1 | ex_actor::DiscardResult(), scope.get_token());
-  stdexec::spawn(sender2 | ex_actor::DiscardResult(), scope.get_token());
-  stdexec::spawn(sender3 | ex_actor::DiscardResult(), scope.get_token());
-  thread_pool.StartWorkers();
-  ex::sync_wait(scope.join());
-  ASSERT_EQ(count, 3);
-}
 
 TEST(SchedulerTest, WeakPriorityThreadPoolStoppableTest) {
   ex_actor::WeakPriorityThreadPool thread_pool(1);

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -166,7 +166,7 @@ TEST(SchedulerTest, CorePinnedThreadPoolTest) {
 }
 
 TEST(SchedulerTest, WeakPriorityThreadPoolPriorityOrderTest) {
-  ex_actor::WeakPriorityThreadPool thread_pool(1, /*priority_upper_bound=*/8, /*start_workers_immediately=*/false);
+  ex_actor::WeakPriorityThreadPool thread_pool(1, /*start_workers_immediately=*/false);
   auto scheduler = thread_pool.GetScheduler();
   std::atomic_int count = 0;
   auto sender1 = ex::schedule(scheduler) | ex::then([&count]() {
@@ -194,7 +194,7 @@ TEST(SchedulerTest, WeakPriorityThreadPoolPriorityOrderTest) {
 }
 
 TEST(SchedulerTest, WeakPriorityThreadPoolStoppableTest) {
-  ex_actor::WeakPriorityThreadPool thread_pool(1, /*priority_upper_bound=*/4);
+  ex_actor::WeakPriorityThreadPool thread_pool(1);
   auto scheduler = thread_pool.GetScheduler();
   auto task = ex::schedule(scheduler) | ex::then([]() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); });
   stdexec::counting_scope scope;
@@ -210,7 +210,7 @@ TEST(SchedulerTest, WeakPriorityThreadPoolStoppableTest) {
 TEST(SchedulerTest, WeakPriorityThreadPoolLocalSlotTest) {
   // Verify the thread-local slot works: an operation that re-enqueues to the same pool
   // should complete without deadlock.
-  ex_actor::WeakPriorityThreadPool thread_pool(1, /*priority_upper_bound=*/4);
+  ex_actor::WeakPriorityThreadPool thread_pool(1);
   auto scheduler = thread_pool.GetScheduler();
   auto sender = ex::schedule(scheduler) | ex::then([]() { return 1; }) |
                 ex::write_env(ex::prop {ex_actor::get_priority, 0}) | ex::let_value([&](int val) {
@@ -222,7 +222,7 @@ TEST(SchedulerTest, WeakPriorityThreadPoolLocalSlotTest) {
 }
 
 TEST(SchedulerTest, WeakPriorityThreadPoolLocalSlotEvictionTest) {
-  ex_actor::WeakPriorityThreadPool thread_pool(1, /*priority_upper_bound=*/4);
+  ex_actor::WeakPriorityThreadPool thread_pool(1);
   auto scheduler = thread_pool.GetScheduler();
   std::vector<int> execution_order;
   stdexec::simple_counting_scope scope;

--- a/test/scheduler_test.cc
+++ b/test/scheduler_test.cc
@@ -165,7 +165,6 @@ TEST(SchedulerTest, CorePinnedThreadPoolTest) {
   ex_actor::Shutdown();
 }
 
-
 TEST(SchedulerTest, WeakPriorityThreadPoolStoppableTest) {
   ex_actor::WeakPriorityThreadPool thread_pool(1);
   auto scheduler = thread_pool.GetScheduler();


### PR DESCRIPTION
Replace per-priority-level ConcurrentQueue array with randomly-sharded sub-queues and power-of-two-choices pop.

- Push: randomly pick 2 sub-queues, enqueue to the less loaded one
- Pop: randomly pick 2 sub-queues, peek tops, take the higher-priority item (was: linear scan across all priority levels)
